### PR TITLE
Set up unicorn

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem "bootsnap"
 gem "gds-sso"
 gem "govuk_app_config"
 gem "pg"
-gem "puma"
 
 group :development, :test do
   gem "awesome_print"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -329,7 +329,6 @@ DEPENDENCIES
   pg
   pry-byebug
   pry-rails
-  puma
   rails (= 6.1.3)
   rspec-rails
   rubocop-govuk

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec unicorn -c ./config/unicorn.rb -p ${PORT:-3000}

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,0 +1,2 @@
+require "govuk_app_config/govuk_unicorn"
+GovukUnicorn.configure(self)


### PR DESCRIPTION
Our deployment and monitoring scripts assume that we use unicorn, not
puma.  This is a shame, as the default Rails server has been puma for
years, but fixing this would be a nontrivial change to a
rarely-touched part of the GOV.UK stack.

---

[Trello card](https://trello.com/c/ZeAKl2SM/651-set-up-a-new-app)