### PR TITLE
Implement authentication endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "rails", "6.1.3"
 gem "bootsnap"
 gem "gds-sso"
 gem "govuk_app_config"
+gem "openid_connect"
 gem "pg"
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :development do
 end
 
 group :test do
+  gem "climate_control"
   gem "simplecov"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,8 +62,11 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    aes_key_wrap (1.1.0)
     ast (2.4.2)
+    attr_required (1.0.1)
     awesome_print (1.9.2)
+    bindata (2.4.8)
     bootsnap (1.7.2)
       msgpack (~> 1.0)
     brakeman (4.10.1)
@@ -124,8 +127,13 @@ GEM
       webdrivers (>= 4)
     hashdiff (1.0.1)
     hashie (4.1.0)
+    httpclient (2.8.3)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
+    json-jwt (1.13.0)
+      activesupport (>= 4.2)
+      aes_key_wrap
+      bindata
     jwt (2.2.2)
     kgio (2.11.3)
     listen (3.4.1)
@@ -169,6 +177,16 @@ GEM
     omniauth-oauth2 (1.3.1)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
+    openid_connect (1.2.0)
+      activemodel
+      attr_required (>= 1.0.0)
+      json-jwt (>= 1.5.0)
+      rack-oauth2 (>= 1.6.1)
+      swd (>= 1.0.0)
+      tzinfo
+      validate_email
+      validate_url
+      webfinger (>= 1.0.1)
     parallel (1.20.1)
     parser (3.0.0.0)
       ast (~> 2.4.1)
@@ -187,6 +205,12 @@ GEM
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
+    rack-oauth2 (1.16.0)
+      activesupport
+      attr_required
+      httpclient
+      json-jwt (>= 1.11.0)
+      rack (>= 2.1.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.1.3)
@@ -289,6 +313,10 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     statsd-ruby (1.5.0)
+    swd (1.2.0)
+      activesupport (>= 3)
+      attr_required (>= 0.0.5)
+      httpclient (>= 2.4)
     thor (1.1.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -297,6 +325,12 @@ GEM
       kgio (~> 2.6)
       raindrops (~> 0.7)
     uniform_notifier (1.14.1)
+    validate_email (0.1.6)
+      activemodel (>= 3.0)
+      mail (>= 2.2.5)
+    validate_url (1.0.13)
+      activemodel (>= 3.0.0)
+      public_suffix
     warden (1.2.9)
       rack (>= 2.0.9)
     warden-oauth2 (0.0.1)
@@ -305,6 +339,9 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (>= 3.0, < 4.0)
+    webfinger (1.1.0)
+      activesupport
+      httpclient (>= 2.4)
     webmock (3.12.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -328,6 +365,7 @@ DEPENDENCIES
   govuk_app_config
   govuk_test
   listen
+  openid_connect
   pg
   pry-byebug
   pry-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    climate_control (1.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
     crack (0.4.5)
@@ -360,6 +361,7 @@ DEPENDENCIES
   awesome_print
   bootsnap
   bullet
+  climate_control
   factory_bot_rails
   gds-sso
   govuk_app_config

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,10 @@ class ApplicationController < ActionController::API
 
   before_action :authorise
 
+  def to_account_session(access_token, refresh_token)
+    "#{Base64.urlsafe_encode64(access_token)}.#{Base64.urlsafe_encode64(refresh_token)}"
+  end
+
 protected
 
   def authorise

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -1,5 +1,7 @@
 class AuthenticationController < ApplicationController
   def sign_in
+    AuthRequest.expired.delete_all
+
     auth_request = AuthRequest.create!(
       oauth_state: params.fetch(:state_id, SecureRandom.hex(16)),
       oidc_nonce: SecureRandom.hex(16),
@@ -25,7 +27,7 @@ class AuthenticationController < ApplicationController
 
     redirect_path = auth_request.redirect_path
 
-    auth_request.delete!
+    auth_request.delete
 
     render json: {
       govuk_account_session: to_account_session(oauth_response[:access_token], oauth_response[:refresh_token]),

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -1,7 +1,40 @@
 class AuthenticationController < ApplicationController
-  def sign_in; end
+  def sign_in
+    auth_request = AuthRequest.create!(
+      oauth_state: params.fetch(:state_id, SecureRandom.hex(16)),
+      oidc_nonce: SecureRandom.hex(16),
+      redirect_path: params[:redirect_path],
+    )
 
-  def callback; end
+    render json: {
+      auth_uri: OidcClient.new.auth_uri(auth_request),
+      state: auth_request.to_oauth_state,
+    }
+  end
+
+  def callback
+    auth_request = AuthRequest.from_oauth_state(params.fetch(:state))
+    head :unauthorized and return unless auth_request
+
+    client = OidcClient.new
+    tokens = client.callback(auth_request, params.fetch(:code))
+    oauth_response = client.get_ephemeral_state(
+      access_token: tokens[:access_token],
+      refresh_token: tokens[:refresh_token],
+    )
+
+    redirect_path = auth_request.redirect_path
+
+    auth_request.delete!
+
+    render json: {
+      govuk_account_session: to_account_session(oauth_response[:access_token], oauth_response[:refresh_token]),
+      redirect_path: redirect_path,
+      ga_client_id: oauth_response[:result]["_ga"],
+    }
+  rescue OidcClient::OAuthFailure
+    head :unauthorized
+  end
 
   def create_state; end
 end

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -36,5 +36,21 @@ class AuthenticationController < ApplicationController
     head :unauthorized
   end
 
-  def create_state; end
+  def create_state
+    payload = {
+      attributes: params[:attributes].permit!.to_h,
+    }.compact
+
+    client = OidcClient.new
+    tokens = client.tokens!
+    oauth_response = client.submit_jwt(
+      jwt: JWT.encode(payload, nil, "none"),
+      access_token: tokens[:access_token],
+      refresh_token: tokens[:refresh_token],
+    )
+
+    render json: {
+      state_id: oauth_response[:result]["id"],
+    }
+  end
 end

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -1,0 +1,7 @@
+class AuthenticationController < ApplicationController
+  def sign_in; end
+
+  def callback; end
+
+  def create_state; end
+end

--- a/app/lib/oidc_client.rb
+++ b/app/lib/oidc_client.rb
@@ -1,0 +1,129 @@
+require "openid_connect"
+
+class OidcClient
+  class OAuthFailure < RuntimeError; end
+
+  DEFAULT_SCOPES = %i[transition_checker openid].freeze
+
+  attr_reader :client_id,
+              :provider_uri
+
+  delegate :authorization_endpoint,
+           :token_endpoint,
+           :userinfo_endpoint,
+           :end_session_endpoint,
+           to: :discover
+
+  def initialize(provider_uri: nil, client_id: nil, secret: nil)
+    @provider_uri = provider_uri || Plek.find("account-manager")
+    @client_id = client_id || ENV.fetch("GOVUK_ACCOUNT_OAUTH_CLIENT_ID")
+    @secret = secret || ENV.fetch("GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET")
+  end
+
+  def auth_uri(auth_request)
+    client.authorization_uri(
+      scope: DEFAULT_SCOPES,
+      state: auth_request.to_oauth_state,
+      nonce: auth_request.oidc_nonce,
+    )
+  end
+
+  def callback(auth_request, code)
+    client.authorization_code = code
+
+    tokens!(oidc_nonce: auth_request.oidc_nonce)
+  end
+
+  def tokens!(oidc_nonce: nil)
+    access_token = client.access_token!
+    response = access_token.token_response
+
+    if oidc_nonce
+      id_token = OpenIDConnect::ResponseObject::IdToken.decode access_token.id_token, discover.jwks
+      id_token.verify! client_id: client_id, issuer: discover.issuer, nonce: oidc_nonce
+    end
+
+    {
+      access_token: response[:access_token],
+      refresh_token: response[:refresh_token],
+      id_token: id_token,
+    }.compact
+  rescue Rack::OAuth2::Client::Error
+    raise OAuthFailure
+  end
+
+  def get_ephemeral_state(access_token:, refresh_token:)
+    response = oauth_request(
+      access_token: access_token,
+      refresh_token: refresh_token,
+      method: :get,
+      uri: ephemeral_state_uri,
+    )
+
+    begin
+      response.merge(result: JSON.parse(response[:result].body))
+    rescue JSON::ParserError
+      response.merge(result: {})
+    end
+  end
+
+protected
+
+  OK_STATUSES = [200, 204, 404, 410].freeze
+
+  def oauth_request(access_token:, refresh_token:, method:, uri:, arg: nil)
+    access_token_str = access_token
+    refresh_token_str = refresh_token
+
+    args = [uri, arg].compact
+
+    response = Rack::OAuth2::AccessToken::Bearer.new(access_token: access_token_str).public_send(method, *args)
+
+    unless OK_STATUSES.include? response.status
+      raise OAuthFailure unless refresh_token
+
+      client.refresh_token = refresh_token
+      access_token = client.access_token!
+
+      response = access_token.public_send(method, *args)
+      raise OAuthFailure unless OK_STATUSES.include? response.status
+
+      access_token_str = access_token.token_response[:access_token]
+      refresh_token_str = access_token.token_response[:refresh_token]
+    end
+
+    {
+      access_token: access_token_str,
+      refresh_token: refresh_token_str,
+      result: response,
+    }
+  rescue AttrRequired::AttrMissing, Rack::OAuth2::Client::Error, URI::InvalidURIError
+    raise OAuthFailure
+  end
+
+  def redirect_uri
+    host = Rails.env.production? ? ENV["GOVUK_WEBSITE_ROOT"] : Plek.find("finder-frontend")
+    host + "/transition-check/login/callback"
+  end
+
+  def ephemeral_state_uri
+    URI.parse(provider_uri).tap do |u|
+      u.path = "/api/v1/ephemeral-state"
+    end
+  end
+
+  def client
+    @client ||= OpenIDConnect::Client.new(
+      identifier: client_id,
+      secret: @secret,
+      redirect_uri: redirect_uri,
+      authorization_endpoint: authorization_endpoint,
+      token_endpoint: token_endpoint,
+      userinfo_endpoint: userinfo_endpoint,
+    )
+  end
+
+  def discover
+    @discover ||= OpenIDConnect::Discovery::Provider::Config.discover! provider_uri
+  end
+end

--- a/app/lib/oidc_client.rb
+++ b/app/lib/oidc_client.rb
@@ -67,6 +67,23 @@ class OidcClient
     end
   end
 
+  def submit_jwt(jwt:, access_token:, refresh_token: nil)
+    response = oauth_request(
+      access_token: access_token,
+      refresh_token: refresh_token,
+      method: :post,
+      uri: jwt_uri,
+      arg: { jwt: jwt },
+    )
+
+    body = response[:result].body
+    if body.empty?
+      raise OAuthFailure
+    else
+      response.merge(result: JSON.parse(body))
+    end
+  end
+
 protected
 
   OK_STATUSES = [200, 204, 404, 410].freeze
@@ -109,6 +126,12 @@ protected
   def ephemeral_state_uri
     URI.parse(provider_uri).tap do |u|
       u.path = "/api/v1/ephemeral-state"
+    end
+  end
+
+  def jwt_uri
+    URI.parse(provider_uri).tap do |u|
+      u.path = "/api/v1/jwt"
     end
   end
 

--- a/app/models/auth_request.rb
+++ b/app/models/auth_request.rb
@@ -1,2 +1,14 @@
 class AuthRequest < ApplicationRecord
+  # This has to be something which the account manager can use to retrieve a JWT, if there is one:
+  # https://github.com/alphagov/govuk-account-manager-prototype/blob/6a68e02055fe3c70083b3899b474b10cc944ffa5/config/initializers/doorkeeper.rb#L14
+  def to_oauth_state
+    "#{oauth_state}:#{id}"
+  end
+
+  def self.from_oauth_state(state)
+    bits = state.split(":")
+    return nil unless bits.length == 2
+
+    find_by(id: bits[1], oauth_state: bits[0])
+  end
 end

--- a/app/models/auth_request.rb
+++ b/app/models/auth_request.rb
@@ -1,0 +1,2 @@
+class AuthRequest < ApplicationRecord
+end

--- a/app/models/auth_request.rb
+++ b/app/models/auth_request.rb
@@ -2,6 +2,8 @@ class AuthRequest < ApplicationRecord
   EXPIRATION_AGE = 2.hours
   scope :expired, -> { where("created_at < ?", EXPIRATION_AGE.ago) }
 
+  validate :redirect_path_is_safe
+
   # This has to be something which the account manager can use to retrieve a JWT, if there is one:
   # https://github.com/alphagov/govuk-account-manager-prototype/blob/6a68e02055fe3c70083b3899b474b10cc944ffa5/config/initializers/doorkeeper.rb#L14
   def to_oauth_state
@@ -13,5 +15,20 @@ class AuthRequest < ApplicationRecord
     return nil unless bits.length == 2
 
     find_by(id: bits[1], oauth_state: bits[0])
+  end
+
+  def redirect_path_is_safe
+    return if redirect_path.nil?
+    return if redirect_path.empty?
+
+    if redirect_path&.starts_with? "//"
+      errors.add(:redirect_path, "can't be protocol-relative")
+      return
+    end
+
+    return if redirect_path.starts_with? "/"
+    return if redirect_path.starts_with?("http://") && Rails.env.development?
+
+    errors.add(:redirect_path, "can't be absolute")
   end
 end

--- a/app/models/auth_request.rb
+++ b/app/models/auth_request.rb
@@ -1,4 +1,7 @@
 class AuthRequest < ApplicationRecord
+  EXPIRATION_AGE = 2.hours
+  scope :expired, -> { where("created_at < ?", EXPIRATION_AGE.ago) }
+
   # This has to be something which the account manager can use to retrieve a JWT, if there is one:
   # https://github.com/alphagov/govuk-account-manager-prototype/blob/6a68e02055fe3c70083b3899b474b10cc944ffa5/config/initializers/doorkeeper.rb#L14
   def to_oauth_state

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -65,3 +65,34 @@ Rails.application.configure do
   # Allow requests for all domains, e.g. <app>.dev.gov.uk
   config.hosts.clear
 end
+
+# make discovery work over HTTP
+module OpenIDConnect
+  module Discovery
+    module Provider
+      class Config
+        class Resource
+          def initialize(uri)
+            @host = uri.host
+            @port = uri.port unless [80, 443].include?(uri.port)
+            @path = File.join uri.path, ".well-known/openid-configuration"
+            @scheme = uri.scheme
+            attr_missing!
+          end
+
+          def endpoint
+            SWD.url_builder = case @scheme
+                              when "http"
+                                URI::HTTP
+                              else
+                                URI::HTTPS
+                              end
+            SWD.url_builder.build [nil, host, port, path, nil, nil]
+          rescue URI::Error => e
+            raise SWD::Exception, e.message
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,12 @@ Rails.application.routes.draw do
   get "/healthcheck", to: GovukHealthcheck.rack_response(
     GovukHealthcheck::ActiveRecord,
   )
+
+  scope :api do
+    scope :oauth2 do
+      get "/sign-in", to: "authentication#sign_in"
+      post "/callback", to: "authentication#callback"
+      post "/state", to: "authentication#create_state"
+    end
+  end
 end

--- a/db/migrate/20210310134450_create_auth_requests.rb
+++ b/db/migrate/20210310134450_create_auth_requests.rb
@@ -1,0 +1,11 @@
+class CreateAuthRequests < ActiveRecord::Migration[6.1]
+  def change
+    create_table :auth_requests do |t|
+      t.string :oauth_state, null: false
+      t.string :oidc_nonce,  null: false
+      t.string :redirect_path
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,6 +15,14 @@ ActiveRecord::Schema.define(version: 2021_03_10_153334) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "auth_requests", force: :cascade do |t|
+    t.string "oauth_state", null: false
+    t.string "oidc_nonce", null: false
+    t.string "redirect_path"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "name"
     t.string "email"

--- a/spec/lib/oidc_client_spec.rb
+++ b/spec/lib/oidc_client_spec.rb
@@ -1,0 +1,93 @@
+RSpec.describe OidcClient do
+  subject(:client) { described_class.new }
+
+  before { stub_oidc_discovery }
+
+  describe "tokens!" do
+    before do
+      access_token = Rack::OAuth2::AccessToken.new(
+        access_token: "access-token",
+        refresh_token: "refresh-token",
+        token_type: "test",
+      )
+
+      @client_stub = stub_oidc_client(client)
+      # rubocop:disable RSpec/InstanceVariable
+      allow(@client_stub).to receive(:access_token!).and_return(access_token)
+      # rubocop:enable RSpec/InstanceVariable
+    end
+
+    it "doesn't fetch an ID token by default" do
+      expect(client.tokens!).to eq({ access_token: "access-token", refresh_token: "refresh-token" })
+    end
+
+    it "fetches an ID token if a nonce is provided" do
+      # the OAuth2::AccessToken type doesn't implement #id_token, so we get a NoMethodError
+      expect { client.tokens!(oidc_nonce: "nonce") }.to raise_error(NoMethodError)
+    end
+
+    it "converts a Rack::OAuth2 error into an OAuthFailure" do
+      # rubocop:disable RSpec/InstanceVariable
+      allow(@client_stub).to receive(:access_token!).and_raise(Rack::OAuth2::Client::Error.new(401, { error: "error", error_description: "description" }))
+      # rubocop:enable RSpec/InstanceVariable
+
+      expect { client.tokens! }.to raise_error(OidcClient::OAuthFailure)
+    end
+  end
+
+  describe "get_ephemeral_state" do
+    it "returns {} if there is no JSON" do
+      stub_request(:get, Plek.find("account-manager") + "/api/v1/ephemeral-state").to_return(body: "")
+
+      expect(client.get_ephemeral_state(access_token: "access-token", refresh_token: "refresh-token")).to eq({ access_token: "access-token", refresh_token: "refresh-token", result: {} })
+    end
+  end
+
+  describe "submit_jwt" do
+    it "raises an error if there is no JSON" do
+      stub_request(:post, Plek.find("account-manager") + "/api/v1/jwt").to_return(body: "")
+
+      expect { client.submit_jwt(jwt: "foo", access_token: "access-token", refresh_token: "refresh-token") }.to raise_error(OidcClient::OAuthFailure)
+    end
+  end
+
+  describe "the access token has expired" do
+    before do
+      stub = stub_oidc_client(client)
+      allow_token_refresh(stub)
+
+      @stub_fail = stub_request(:post, Plek.find("account-manager") + "/api/v1/jwt")
+        .with(headers: { Authorization: "Bearer access-token" })
+        .to_return(status: 401)
+    end
+
+    it "refreshes the token and retries" do
+      stub_success = stub_request(:post, Plek.find("account-manager") + "/api/v1/jwt")
+        .with(headers: { Authorization: "Bearer new-access-token" })
+        .to_return(status: 200, body: { id: "foo" }.to_json)
+
+      client.submit_jwt(jwt: "", access_token: "access-token", refresh_token: "refresh-token")
+
+      # rubocop:disable RSpec/InstanceVariable
+      expect(@stub_fail).to have_been_made
+      # rubocop:enable RSpec/InstanceVariable
+      expect(stub_success).to have_been_made
+    end
+
+    context "but there is no refresh token" do
+      it "fails" do
+        expect { client.submit_jwt(jwt: "", access_token: "access-token", refresh_token: nil) }.to raise_error(OidcClient::OAuthFailure)
+      end
+    end
+
+    context "but the refreshed access token fails" do
+      it "fails" do
+        stub_request(:post, Plek.find("account-manager") + "/api/v1/jwt")
+          .with(headers: { Authorization: "Bearer new-access-token" })
+          .to_return(status: 401)
+
+        expect { client.submit_jwt(jwt: "", access_token: "access-token", refresh_token: "refresh-token") }.to raise_error(OidcClient::OAuthFailure)
+      end
+    end
+  end
+end

--- a/spec/models/auth_request_spec.rb
+++ b/spec/models/auth_request_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe AuthRequest do
     request1 = described_class.create!(
       oauth_state: SecureRandom.alphanumeric(10),
       oidc_nonce: SecureRandom.alphanumeric(10),
-      redirect_path: SecureRandom.alphanumeric(10),
+      redirect_path: "/" + SecureRandom.alphanumeric(10),
     )
     request2 = described_class.create!(
       oauth_state: request1.oauth_state,
@@ -13,5 +13,23 @@ RSpec.describe AuthRequest do
 
     expect(described_class.from_oauth_state(request1.to_oauth_state).id).to eq(request1.id)
     expect(described_class.from_oauth_state(request2.to_oauth_state).id).to eq(request2.id)
+  end
+
+  it "allows an empty redirect" do
+    expect(described_class.new(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "")).to be_valid
+    expect(described_class.new(oauth_state: "foo", oidc_nonce: "bar", redirect_path: nil)).to be_valid
+  end
+
+  it "allows path-relative redirects" do
+    expect(described_class.new(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "/good-page")).to be_valid
+  end
+
+  it "forbids protocol-relative redirects" do
+    expect(described_class.new(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "//malicious-site.com")).not_to be_valid
+  end
+
+  it "forbids absolute redirects" do
+    expect(described_class.new(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "http://malicious-site.com")).not_to be_valid
+    expect(described_class.new(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "https://malicious-site.com")).not_to be_valid
   end
 end

--- a/spec/models/auth_request_spec.rb
+++ b/spec/models/auth_request_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe AuthRequest do
+  it "can be found from the OAuth state param" do
+    request1 = described_class.create!(
+      oauth_state: SecureRandom.alphanumeric(10),
+      oidc_nonce: SecureRandom.alphanumeric(10),
+      redirect_path: SecureRandom.alphanumeric(10),
+    )
+    request2 = described_class.create!(
+      oauth_state: request1.oauth_state,
+      oidc_nonce: request1.oidc_nonce,
+      redirect_path: request1.redirect_path,
+    )
+
+    expect(described_class.from_oauth_state(request1.to_oauth_state).id).to eq(request1.id)
+    expect(described_class.from_oauth_state(request2.to_oauth_state).id).to eq(request2.id)
+  end
+end

--- a/spec/requests/authentication_controller_spec.rb
+++ b/spec/requests/authentication_controller_spec.rb
@@ -1,0 +1,70 @@
+RSpec.describe AuthenticationController do
+  before do
+    discovery_response = instance_double(
+      "OpenIDConnect::Discovery::Provider::Config::Response",
+      authorization_endpoint: "http://openid-provider/authorization-endpoint",
+      token_endpoint: "http://openid-provider/token-endpoint",
+      userinfo_endpoint: "http://openid-provider/userinfo-endpoint",
+      end_session_endpoint: "http://openid-provider/end-session-endpoint",
+    )
+
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(OidcClient).to receive(:discover).and_return(discovery_response)
+    allow_any_instance_of(OidcClient).to receive(:tokens!).and_return({ access_token: "access-token", refresh_token: "refresh-token" })
+    # rubocop:enable RSpec/AnyInstance
+  end
+
+  describe "/sign-in" do
+    it "creates an AuthRequest to persist the attributes" do
+      expect { get sign_in_path }.to change(AuthRequest, :count)
+      expect(response).to be_successful
+
+      auth_request = AuthRequest.last
+
+      expect(JSON.parse(response.body)["state"]).to eq(auth_request.to_oauth_state)
+
+      auth_uri = JSON.parse(response.body)["auth_uri"]
+
+      expect(auth_uri).to include("nonce=#{auth_request.oidc_nonce}")
+      expect(auth_uri).to include("state=#{auth_request.to_oauth_state.sub(':', '%3A')}")
+    end
+
+    it "uses a provided state_id" do
+      get sign_in_path(state_id: "hello-world")
+      expect(AuthRequest.last.oauth_state).to eq("hello-world")
+    end
+
+    it "uses a provided redirect_path" do
+      get sign_in_path(redirect_path: "/hello-world")
+      expect(AuthRequest.last.redirect_path).to eq("/hello-world")
+    end
+  end
+
+  describe "/callback" do
+    let!(:auth_request) { AuthRequest.create!(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "/some-path") }
+
+    it "fetches the tokens & GA client ID" do
+      stub_request(:get, Plek.find("account-manager") + "/api/v1/ephemeral-state")
+        .with(headers: { "Authorization" => "Bearer access-token" })
+        .to_return(status: 200, body: { _ga: "ga-client-id" }.to_json)
+
+      post callback_path(state: auth_request.to_oauth_state, code: "12345")
+      expect(response).to be_successful
+      expect(JSON.parse(response.body)).to include("govuk_account_session", "redirect_path" => auth_request.redirect_path, "ga_client_id" => "ga-client-id")
+    end
+
+    it "returns a 401 if there is no matching AuthRequest" do
+      post callback_path(state: "something-else")
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns a 401 if the auth code is rejected" do
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(OidcClient).to receive(:tokens!).and_raise(OidcClient::OAuthFailure)
+      # rubocop:enable RSpec/AnyInstance
+
+      post callback_path(state: auth_request.to_oauth_state, code: "12345")
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end

--- a/spec/requests/authentication_controller_spec.rb
+++ b/spec/requests/authentication_controller_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe AuthenticationController do
       get sign_in_path(redirect_path: "/hello-world")
       expect(AuthRequest.last.redirect_path).to eq("/hello-world")
     end
+
+    it "deletes old expired AuthRequests" do
+      auth_request_id = AuthRequest.create!(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "/some-path", created_at: 1.day.ago).id
+      get sign_in_path
+      expect(AuthRequest.exists?(auth_request_id)).to be(false)
+    end
   end
 
   describe "/callback" do

--- a/spec/requests/authentication_controller_spec.rb
+++ b/spec/requests/authentication_controller_spec.rb
@@ -1,15 +1,8 @@
 RSpec.describe AuthenticationController do
   before do
-    discovery_response = instance_double(
-      "OpenIDConnect::Discovery::Provider::Config::Response",
-      authorization_endpoint: "http://openid-provider/authorization-endpoint",
-      token_endpoint: "http://openid-provider/token-endpoint",
-      userinfo_endpoint: "http://openid-provider/userinfo-endpoint",
-      end_session_endpoint: "http://openid-provider/end-session-endpoint",
-    )
+    stub_oidc_discovery
 
     # rubocop:disable RSpec/AnyInstance
-    allow_any_instance_of(OidcClient).to receive(:discover).and_return(discovery_response)
     allow_any_instance_of(OidcClient).to receive(:tokens!).and_return({ access_token: "access-token", refresh_token: "refresh-token" })
     # rubocop:enable RSpec/AnyInstance
   end

--- a/spec/requests/authentication_controller_spec.rb
+++ b/spec/requests/authentication_controller_spec.rb
@@ -67,4 +67,16 @@ RSpec.describe AuthenticationController do
       expect(response).to have_http_status(:unauthorized)
     end
   end
+
+  describe "/state" do
+    it "submits a JWT to the account manager" do
+      stub_request(:post, Plek.find("account-manager") + "/api/v1/jwt")
+        .with(headers: { "Authorization" => "Bearer access-token" })
+        .to_return(status: 200, body: { id: "jwt-id" }.to_json)
+
+      post state_path(attributes: { key: "value" })
+      expect(response).to be_successful
+      expect(JSON.parse(response.body)).to include("state_id" => "jwt-id")
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,12 @@ RSpec.configure do |config|
     config.after { Bullet.end_request }
   end
 
+  config.around do |example|
+    ClimateControl.modify(GOVUK_ACCOUNT_OAUTH_CLIENT_ID: "client-id", GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET: "client-secret") do
+      example.run
+    end
+  end
+
   config.expose_dsl_globally = false
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!

--- a/spec/support/helpers/oidc_client_helper.rb
+++ b/spec/support/helpers/oidc_client_helper.rb
@@ -1,0 +1,41 @@
+module OidcClientHelper
+  def stub_oidc_discovery
+    discovery_response = instance_double(
+      "OpenIDConnect::Discovery::Provider::Config::Response",
+      authorization_endpoint: "http://openid-provider/authorization-endpoint",
+      token_endpoint: "http://openid-provider/token-endpoint",
+      userinfo_endpoint: "http://openid-provider/userinfo-endpoint",
+      end_session_endpoint: "http://openid-provider/end-session-endpoint",
+    )
+
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(OidcClient).to receive(:discover).and_return(discovery_response)
+    # rubocop:enable RSpec/AnyInstance
+  end
+
+  def stub_oidc_client(client = nil)
+    oidc_client = instance_double("OpenIDConnect::Client")
+
+    if client
+      allow(client).to receive(:client).and_return(oidc_client)
+    else
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(OidcClient).to receive(:client).and_return(oidc_client)
+      # rubocop:enable RSpec/AnyInstance
+    end
+
+    oidc_client
+  end
+
+  def allow_token_refresh(client)
+    new_access_token = Rack::OAuth2::AccessToken::Bearer.new(
+      access_token: "new-access-token",
+      refresh_token: "new-refresh-token",
+    )
+
+    allow(client).to receive(:"refresh_token=").with("refresh-token")
+    allow(client).to receive(:access_token!).and_return(new_access_token)
+  end
+end
+
+RSpec.configuration.send :include, OidcClientHelper


### PR DESCRIPTION
This PR adds the three authentication endpoints from the RFC, at 95.41% line coverage (enough for continuous deployment).

The way the auth flow will work for the Transition Checker is:

1. finder-frontend calls `/api/oauth2/state` with the attributes, which returns a `state_id`
2. finder-frontend redirects the user to `/sign-in?state_id={...}&redirect_path={...}` (which is rendered by frontend)
3. frontend calls `/api/oauth2/sign-in` with the `state_id` and `redirect_path`, which returns an `auth_uri` and a `state`
4. frontend stores the `state` in the session (this is for CSRF protection) and redirects the user to the `auth_uri`
5. the user authenticates, and is sent to `/sign-in/callback?code={...}&state={...}` (which is rendered by frontend)
6. frontend checks that the `state` param matches the value in the session (for CSRF protection), and calls `/api/oauth2/callback` with the `code` and the `state`, which returns a `govuk_account_session`, `redirect_path`, and `ga_client_id`
7. frontend stores the `govuk_account_session` in the session, and redirects to `{redirect_path}?_ga={ga_client_id}`
8. the user ends up back in the transition checker, logged in

Much of the logic is copied and pasted from finder-frontend.

---

[Trello card](https://trello.com/c/Y8z5rsJl/653-move-oauth-sign-in-logic-from-the-transition-checker-to-the-new-app)