### PR TITLE
Add endpoints to manage the Transition Checker email subscription 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,8 +3,31 @@ class ApplicationController < ActionController::API
 
   before_action :authorise
 
+  def fetch_govuk_account_session
+    govuk_account_session_header =
+      if request.headers["HTTP_GOVUK_ACCOUNT_SESSION"]
+        request.headers["HTTP_GOVUK_ACCOUNT_SESSION"]
+      elsif request.headers.to_h["GOVUK-Account-Session"]
+        request.headers.to_h["GOVUK-Account-Session"]
+      end
+
+    head :unauthorized and return unless govuk_account_session_header
+
+    @govuk_account_session = from_account_session(govuk_account_session_header)
+  end
+
   def to_account_session(access_token, refresh_token)
     "#{Base64.urlsafe_encode64(access_token)}.#{Base64.urlsafe_encode64(refresh_token)}"
+  end
+
+  def from_account_session(govuk_account_session)
+    bits = (govuk_account_session || "").split(".")
+    if bits.length == 2
+      {
+        access_token: Base64.urlsafe_decode64(bits[0]),
+        refresh_token: Base64.urlsafe_decode64(bits[1]),
+      }
+    end
   end
 
 protected

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::API
   include GDS::SSO::ControllerMethods
+  include SessionHeaderHelper
 
   before_action :authorise
 
@@ -14,20 +15,6 @@ class ApplicationController < ActionController::API
     head :unauthorized and return unless govuk_account_session_header
 
     @govuk_account_session = from_account_session(govuk_account_session_header)
-  end
-
-  def to_account_session(access_token, refresh_token)
-    "#{Base64.urlsafe_encode64(access_token)}.#{Base64.urlsafe_encode64(refresh_token)}"
-  end
-
-  def from_account_session(govuk_account_session)
-    bits = (govuk_account_session || "").split(".")
-    if bits.length == 2
-      {
-        access_token: Base64.urlsafe_decode64(bits[0]),
-        refresh_token: Base64.urlsafe_decode64(bits[1]),
-      }
-    end
   end
 
 protected

--- a/app/controllers/transition_checker_email_subscription_controller.rb
+++ b/app/controllers/transition_checker_email_subscription_controller.rb
@@ -1,0 +1,31 @@
+class TransitionCheckerEmailSubscriptionController < ApplicationController
+  before_action :fetch_govuk_account_session
+
+  def show
+    oauth_response = OidcClient.new.has_email_subscription(
+      access_token: @govuk_account_session[:access_token],
+      refresh_token: @govuk_account_session[:refresh_token],
+    )
+
+    render json: {
+      govuk_account_session: to_account_session(oauth_response[:access_token], oauth_response[:refresh_token]),
+      has_subscription: oauth_response[:result],
+    }
+  rescue OidcClient::OAuthFailure
+    head :unauthorized
+  end
+
+  def update
+    oauth_response = OidcClient.new.update_email_subscription(
+      slug: params.require(:slug),
+      access_token: @govuk_account_session[:access_token],
+      refresh_token: @govuk_account_session[:refresh_token],
+    )
+
+    render json: {
+      govuk_account_session: to_account_session(oauth_response[:access_token], oauth_response[:refresh_token]),
+    }
+  rescue OidcClient::OAuthFailure
+    head :unauthorized
+  end
+end

--- a/app/helpers/session_header_helper.rb
+++ b/app/helpers/session_header_helper.rb
@@ -1,0 +1,15 @@
+module SessionHeaderHelper
+  def to_account_session(access_token, refresh_token)
+    "#{Base64.urlsafe_encode64(access_token)}.#{Base64.urlsafe_encode64(refresh_token)}"
+  end
+
+  def from_account_session(govuk_account_session)
+    bits = (govuk_account_session || "").split(".")
+    if bits.length == 2
+      {
+        access_token: Base64.urlsafe_decode64(bits[0]),
+        refresh_token: Base64.urlsafe_decode64(bits[1]),
+      }
+    end
+  end
+end

--- a/app/lib/oidc_client.rb
+++ b/app/lib/oidc_client.rb
@@ -84,6 +84,27 @@ class OidcClient
     end
   end
 
+  def has_email_subscription(access_token:, refresh_token: nil)
+    response = oauth_request(
+      access_token: access_token,
+      refresh_token: refresh_token,
+      method: :get,
+      uri: email_subscription_uri,
+    )
+
+    response.merge(result: (200..299).include?(response[:result].status))
+  end
+
+  def update_email_subscription(slug:, access_token:, refresh_token: nil)
+    oauth_request(
+      access_token: access_token,
+      refresh_token: refresh_token,
+      method: :post,
+      uri: email_subscription_uri,
+      arg: { topic_slug: slug },
+    )
+  end
+
 protected
 
   OK_STATUSES = [200, 204, 404, 410].freeze
@@ -132,6 +153,12 @@ protected
   def jwt_uri
     URI.parse(provider_uri).tap do |u|
       u.path = "/api/v1/jwt"
+    end
+  end
+
+  def email_subscription_uri
+    URI.parse(provider_uri).tap do |u|
+      u.path = "/api/v1/transition-checker/email-subscription"
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,8 @@ Rails.application.routes.draw do
       post "/callback", to: "authentication#callback"
       post "/state", to: "authentication#create_state"
     end
+
+    get "/transition-checker-email-subscription", to: "transition_checker_email_subscription#show"
+    post "/transition-checker-email-subscription", to: "transition_checker_email_subscription#update"
   end
 end

--- a/spec/helpers/session_header_helper_spec.rb
+++ b/spec/helpers/session_header_helper_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe SessionHeaderHelper do
+  let(:tokens) { { access_token: SecureRandom.bytes(10), refresh_token: SecureRandom.bytes(10) } }
+
+  it "round-trips" do
+    encoded = to_account_session(*token_values(tokens))
+    decoded = from_account_session(encoded)
+
+    expect(decoded).to eq(tokens)
+  end
+
+  def token_values(access_token:, refresh_token:)
+    [access_token, refresh_token]
+  end
+end

--- a/spec/requests/transition_checker_email_subscription_controller_spec.rb
+++ b/spec/requests/transition_checker_email_subscription_controller_spec.rb
@@ -1,0 +1,99 @@
+RSpec.describe TransitionCheckerEmailSubscriptionController do
+  before do
+    stub_oidc_discovery
+
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(OidcClient).to receive(:tokens!).and_return({ access_token: "access-token", refresh_token: "refresh-token" })
+    # rubocop:enable RSpec/AnyInstance
+  end
+
+  let(:headers) { { "GOVUK-Account-Session" => placeholder_govuk_account_session } }
+
+  describe "GET" do
+    before do
+      stub_request(:get, Plek.find("account-manager") + "/api/v1/transition-checker/email-subscription").to_return(status: status)
+    end
+
+    let(:status) { 500 }
+
+    context "when the user has an email subscription" do
+      let(:status) { 204 }
+
+      it "returns 'true'" do
+        get transition_checker_email_subscription_path, headers: headers
+        expect(response).to be_successful
+        expect(JSON.parse(response.body)["has_subscription"]).to be(true)
+      end
+    end
+
+    context "when the user has a deactivated email subscription" do
+      let(:status) { 410 }
+
+      it "returns 'false'" do
+        get transition_checker_email_subscription_path, headers: headers
+        expect(response).to be_successful
+        expect(JSON.parse(response.body)["has_subscription"]).to be(false)
+      end
+    end
+
+    context "when the user does not have an email subscription" do
+      let(:status) { 404 }
+
+      it "returns 'false'" do
+        get transition_checker_email_subscription_path, headers: headers
+        expect(response).to be_successful
+        expect(JSON.parse(response.body)["has_subscription"]).to be(false)
+      end
+    end
+
+    context "when the tokens are rejected" do
+      before { stub_request(:post, "http://openid-provider/token-endpoint").to_return(status: 401) }
+
+      let(:status) { 401 }
+
+      it "returns a 401" do
+        get transition_checker_email_subscription_path, headers: headers
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "when no govuk-account-session is provided" do
+      it "returns a 401" do
+        get transition_checker_email_subscription_path
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "POST" do
+    it "calls the account manager" do
+      stub = stub_request(:post, Plek.find("account-manager") + "/api/v1/transition-checker/email-subscription")
+        .with(body: hash_including(topic_slug: "slug"))
+        .to_return(status: 200)
+
+      post transition_checker_email_subscription_path, headers: headers, params: { slug: "slug" }
+      expect(response).to be_successful
+      expect(stub).to have_been_made
+    end
+
+    context "when the tokens are rejected" do
+      before { stub_request(:post, "http://openid-provider/token-endpoint").to_return(status: 401) }
+
+      it "returns a 401" do
+        stub_request(:post, Plek.find("account-manager") + "/api/v1/transition-checker/email-subscription")
+          .with(body: hash_including(topic_slug: "slug"))
+          .to_return(status: 401)
+
+        post transition_checker_email_subscription_path, headers: headers, params: { slug: "slug" }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "when no govuk-account-session is provided" do
+      it "returns a 401" do
+        post transition_checker_email_subscription_path
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/support/helpers/govuk_account_session_helper.rb
+++ b/spec/support/helpers/govuk_account_session_helper.rb
@@ -1,0 +1,7 @@
+module GovukAccountSessionHelper
+  def placeholder_govuk_account_session(access_token: "access-token", refresh_token: "refresh-token")
+    "#{Base64.urlsafe_encode64(access_token)}.#{Base64.urlsafe_encode64(refresh_token)}"
+  end
+end
+
+RSpec.configuration.send :include, GovukAccountSessionHelper


### PR DESCRIPTION
By putting these endpoints in this app, we can fully remove the OIDC /
OAuth logic from the Transition Checker.

The name of the controller is really specific because we've not yet
got a generic way to manage email subscriptions for multiple apps, and
will need to think about how to do that if it's something we want.

---

[Trello card](https://trello.com/c/N49KKdOW/666-move-transition-checker-email-management-from-finder-frontend-to-the-new-app)