### PR TITLE
Add endpoints to manage attributes 

### DIFF
--- a/app/controllers/attributes_controller.rb
+++ b/app/controllers/attributes_controller.rb
@@ -1,0 +1,44 @@
+class AttributesController < ApplicationController
+  before_action :fetch_govuk_account_session
+
+  def show
+    attribute_names = params.fetch(:attributes)
+
+    access_token = @govuk_account_session[:access_token]
+    refresh_token = @govuk_account_session[:refresh_token]
+
+    values = attribute_names.each_with_object({}) do |name, values_hash|
+      oauth_response = OidcClient.new.get_attribute(
+        attribute: name,
+        access_token: access_token,
+        refresh_token: refresh_token,
+      )
+      access_token = oauth_response[:access_token]
+      refresh_token = oauth_response[:refresh_token]
+      values_hash[name] = oauth_response[:result]
+    end
+
+    render json: {
+      govuk_account_session: to_account_session(@govuk_account_session[:access_token], @govuk_account_session[:refresh_token]),
+      values: values.compact,
+    }
+  rescue OidcClient::OAuthFailure
+    head :unauthorized
+  end
+
+  def update
+    attributes = params.fetch(:attributes).permit!.to_h
+
+    oauth_response = OidcClient.new.bulk_set_attributes(
+      attributes: attributes,
+      access_token: @govuk_account_session[:access_token],
+      refresh_token: @govuk_account_session[:refresh_token],
+    )
+
+    render json: {
+      govuk_account_session: to_account_session(oauth_response[:access_token], oauth_response[:refresh_token]),
+    }
+  rescue OidcClient::OAuthFailure
+    head :unauthorized
+  end
+end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,26 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 70,
+      "fingerprint": "561df849df725485ca107e96433c44479c5e3977e99ff4b0eab18e62f0ffd971",
+      "check_name": "MassAssignment",
+      "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
+      "file": "app/controllers/attributes_controller.rb",
+      "line": 30,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.fetch(:attributes).permit!",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "AttributesController",
+        "method": "update"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "note": "This isn't a problem as if an invalid attribute name is given the attribute-service will reject it."
+    }
+  ],
+  "updated": "2021-03-12 12:50:04 +0000",
+  "brakeman_version": "4.10.1"
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,9 @@ Rails.application.routes.draw do
       post "/state", to: "authentication#create_state"
     end
 
+    get "/attributes", to: "attributes#show"
+    patch "/attributes", to: "attributes#update"
+
     get "/transition-checker-email-subscription", to: "transition_checker_email_subscription#show"
     post "/transition-checker-email-subscription", to: "transition_checker_email_subscription#update"
   end

--- a/spec/requests/attributes_controller_spec.rb
+++ b/spec/requests/attributes_controller_spec.rb
@@ -1,0 +1,117 @@
+RSpec.describe AttributesController do
+  before { stub_oidc_discovery }
+
+  let(:headers) { { "GOVUK-Account-Session" => placeholder_govuk_account_session } }
+
+  let(:attribute_name1) { "name" }
+  let(:attribute_value1) { { "some" => "complex", "value" => 42 } }
+
+  let(:attribute_name2) { "name2" }
+  let(:attribute_value2) { [1, 2, 3, 4, 5] }
+
+  describe "GET" do
+    before do
+      stub_request(:get, "http://openid-provider/v1/attributes/#{attribute_name1}")
+        .to_return(status: status, body: { claim_value: attribute_value1 }.compact.to_json)
+    end
+
+    let(:params) { { attributes: [attribute_name1] } }
+    let(:status) { 200 }
+
+    it "returns the attribute" do
+      get attributes_path, headers: headers, params: params
+      expect(response).to be_successful
+      expect(JSON.parse(response.body)["values"]).to eq({ attribute_name1 => attribute_value1 })
+    end
+
+    context "when the attribute is not found" do
+      let(:status) { 404 }
+
+      it "returns no value" do
+        get attributes_path, headers: headers, params: params
+        expect(response).to be_successful
+        expect(JSON.parse(response.body)["values"]).to eq({})
+      end
+    end
+
+    context "when the tokens are rejected" do
+      before { stub_request(:post, "http://openid-provider/token-endpoint").to_return(status: 401) }
+
+      let(:status) { 401 }
+
+      it "returns a 401" do
+        get attributes_path, headers: headers, params: params
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "when no govuk-account-session is provided" do
+      it "returns a 401" do
+        get attributes_path, params: params
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "when multiple attributes are requested" do
+      before do
+        stub_request(:get, "http://openid-provider/v1/attributes/#{attribute_name2}")
+          .to_return(status: 200, body: { claim_value: attribute_value2 }.compact.to_json)
+      end
+
+      let(:params) { { attributes: [attribute_name1, attribute_name2] } }
+
+      it "returns all the attributes" do
+        get attributes_path, headers: headers, params: params
+        expect(response).to be_successful
+        expect(JSON.parse(response.body)["values"]).to eq({ attribute_name1 => attribute_value1, attribute_name2 => attribute_value2 })
+      end
+
+      context "when one of the attributes is not found" do
+        let(:status) { 404 }
+
+        it "returns only the present attribute" do
+          get attributes_path, headers: headers, params: params
+          expect(response).to be_successful
+          expect(JSON.parse(response.body)["values"]).to eq({ attribute_name2 => attribute_value2 })
+        end
+      end
+    end
+  end
+
+  describe "PATCH" do
+    let(:attributes) { { attribute_name1 => attribute_value1.to_json, attribute_name2 => attribute_value2.to_json } }
+    let(:params) { { attributes: attributes } }
+
+    it "calls the attribute service" do
+      stub = stub_request(:post, "http://openid-provider/v1/attributes")
+        .with(body: { attributes: attributes })
+        .to_return(status: 200)
+
+      patch attributes_path, headers: headers, params: params
+      expect(response).to be_successful
+      expect(stub).to have_been_made
+    end
+
+    context "when the tokens are rejected" do
+      before do
+        stub_request(:post, "http://openid-provider/token-endpoint").to_return(status: 401)
+
+        stub_request(:post, "http://openid-provider/v1/attributes")
+          .with(body: { attributes: attributes })
+          .to_return(status: 401)
+      end
+
+      it "returns a 401" do
+        patch attributes_path, headers: headers, params: params
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "when no govuk-account-session is provided" do
+      it "returns a 401" do
+        patch attributes_path, params: params
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently these just delegate to the govuk-attribute-service-prototype
running on the PaaS, but at some point soon we will begin storing
attributes in this app's database too.  We might migrate the
Transition Checker attributes, or we might just retire the checker -
that depends on how long it'll be staying around, which is a product
decision.

For the update endpoint, the attribute values are given as
JSON-encoded strings.  I think this is reasonable, because there isn't
really a standard for how complex nested data gets turned into HTTP
field data.  We can do the `to_json`ing in gds-api-adapters, so that
other apps don't need to worry about it.

---

[Trello card](https://trello.com/c/uRMyiEHZ/654-move-oauth-attribute-logic-from-the-transition-checker-to-the-new-app)