### PR TITLE
Return 401 if an invalid account header is given

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,9 +12,9 @@ class ApplicationController < ActionController::API
         request.headers.to_h["GOVUK-Account-Session"]
       end
 
-    head :unauthorized and return unless govuk_account_session_header
-
     @govuk_account_session = from_account_session(govuk_account_session_header)
+
+    head :unauthorized unless @govuk_account_session
   end
 
 protected

--- a/spec/requests/attributes_controller_spec.rb
+++ b/spec/requests/attributes_controller_spec.rb
@@ -52,6 +52,13 @@ RSpec.describe AttributesController do
       end
     end
 
+    context "when an invalid govuk-account-session is provided" do
+      it "returns a 401" do
+        get attributes_path, headers: { "GOVUK-Account-Session" => "not-a-base64-string" }, params: params
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
     context "when multiple attributes are requested" do
       before do
         stub_request(:get, "http://openid-provider/v1/attributes/#{attribute_name2}")


### PR DESCRIPTION
The finder-frontend smokey tests picked this up, maybe it's sending a
weird cookie value?  In any case, this header value ultimately comes
from a user-controlled input, so we shouldn't throw an internal server
error if the format isn't what we expect.

---

Also we don't have sentry set up properly for account-api (no sentry_dsn in the env), fixing that is the next thing to do.