### PR TITLE
Return the up-to-date account session header with the attributes

### DIFF
--- a/app/controllers/attributes_controller.rb
+++ b/app/controllers/attributes_controller.rb
@@ -19,7 +19,7 @@ class AttributesController < ApplicationController
     end
 
     render json: {
-      govuk_account_session: to_account_session(@govuk_account_session[:access_token], @govuk_account_session[:refresh_token]),
+      govuk_account_session: to_account_session(access_token, refresh_token),
       values: values.compact,
     }
   rescue OidcClient::OAuthFailure


### PR DESCRIPTION
Currently, if the access token expires and gets refreshed while
fetching attributes, we return the old tokens instead of the new ones.