### PR TITLE
Add GOV.UK Error initalizer

### DIFF
--- a/config/initializers/govuk_error.rb
+++ b/config/initializers/govuk_error.rb
@@ -1,0 +1,2 @@
+GovukError.configure do
+end


### PR DESCRIPTION
As part of the steps to set up sentry for a new GOV.UK repository.
See documentation here: https://docs.publishing.service.gov.uk/manual/sentry.html#how-sentry-is-integrated-on-govuk