### PR TITLE
Write Pact provider configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 
+/spec/reports/pacts
 /spec/examples.txt
 /coverage

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ group :development, :test do
   gem "bullet"
   gem "factory_bot_rails"
   gem "govuk_test"
+  gem "pact", require: false
+  gem "pact_broker-client"
   gem "pry-byebug"
   gem "pry-rails"
   gem "rspec-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
       rexml
     crass (1.0.6)
     diff-lcs (1.4.4)
+    dig_rb (1.0.1)
     docile (1.3.5)
     erubi (1.10.0)
     factory_bot (6.1.0)
@@ -104,6 +105,8 @@ GEM
       ruby2_keywords
     faraday-net_http (1.0.1)
     ffi (1.15.0)
+    filelock (1.1.1)
+    find_a_port (1.0.1)
     gds-sso (16.0.0)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
@@ -128,9 +131,13 @@ GEM
       webdrivers (>= 4)
     hashdiff (1.0.1)
     hashie (4.1.0)
+    httparty (0.18.1)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
     httpclient (2.8.3)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
+    json (2.5.1)
     json-jwt (1.13.0)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -151,6 +158,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2021.0225)
     mimemagic (0.3.5)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
@@ -188,6 +198,36 @@ GEM
       validate_email
       validate_url
       webfinger (>= 1.0.1)
+    pact (1.57.0)
+      pact-mock_service (~> 3.0, >= 3.3.1)
+      pact-support (~> 1.15)
+      rack-test (>= 0.6.3, < 2.0.0)
+      rspec (~> 3.0)
+      term-ansicolor (~> 1.0)
+      thor (>= 0.20, < 2.0)
+      webrick (~> 1.3)
+    pact-mock_service (3.8.0)
+      filelock (~> 1.1)
+      find_a_port (~> 1.0.1)
+      json
+      pact-support (~> 1.16, >= 1.16.4)
+      rack (~> 2.0)
+      rspec (>= 2.14)
+      term-ansicolor (~> 1.0)
+      thor (>= 0.19, < 2.0)
+      webrick (~> 1.3)
+    pact-support (1.16.7)
+      awesome_print (~> 1.1)
+      diff-lcs (~> 1.4)
+      randexp (~> 0.1.7)
+      term-ansicolor (~> 1.0)
+    pact_broker-client (1.37.1)
+      dig_rb (~> 1.0)
+      httparty (~> 0.18)
+      rake (~> 13.0)
+      table_print (~> 1.5)
+      term-ansicolor (~> 1.7)
+      thor (>= 0.20, < 2.0)
     parallel (1.20.1)
     parser (3.0.0.0)
       ast (~> 2.4.1)
@@ -243,6 +283,7 @@ GEM
     rainbow (3.0.0)
     raindrops (0.19.1)
     rake (13.0.3)
+    randexp (0.1.7)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -250,6 +291,10 @@ GEM
     request_store (1.5.0)
       rack (>= 1.4)
     rexml (3.2.4)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.1)
@@ -318,7 +363,13 @@ GEM
       activesupport (>= 3)
       attr_required (>= 0.0.5)
       httpclient (>= 2.4)
+    sync (0.5.0)
+    table_print (1.5.7)
+    term-ansicolor (1.7.1)
+      tins (~> 1.0)
     thor (1.1.0)
+    tins (1.28.0)
+      sync
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.7.0)
@@ -347,6 +398,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    webrick (1.7.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -368,6 +420,8 @@ DEPENDENCIES
   govuk_test
   listen
   openid_connect
+  pact
+  pact_broker-client
   pg
   pry-byebug
   pry-rails

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -2,9 +2,8 @@ class AuthenticationController < ApplicationController
   def sign_in
     AuthRequest.expired.delete_all
 
-    auth_request = AuthRequest.create!(
-      oauth_state: params.fetch(:state_id, SecureRandom.hex(16)),
-      oidc_nonce: SecureRandom.hex(16),
+    auth_request = AuthRequest.generate!(
+      oauth_state: params[:state_id],
       redirect_path: params[:redirect_path],
     )
 

--- a/app/models/auth_request.rb
+++ b/app/models/auth_request.rb
@@ -4,6 +4,14 @@ class AuthRequest < ApplicationRecord
 
   validate :redirect_path_is_safe
 
+  def self.generate!(options = {})
+    create!(
+      oauth_state: options[:oauth_state] || SecureRandom.hex(16),
+      oidc_nonce: SecureRandom.hex(16),
+      redirect_path: options[:redirect_path],
+    )
+  end
+
   # This has to be something which the account manager can use to retrieve a JWT, if there is one:
   # https://github.com/alphagov/govuk-account-manager-prototype/blob/6a68e02055fe3c70083b3899b474b10cc944ffa5/config/initializers/doorkeeper.rb#L14
   def to_oauth_state

--- a/lib/tasks/pact.rake
+++ b/lib/tasks/pact.rake
@@ -1,0 +1,4 @@
+return if Rails.env.production?
+
+require "pact/tasks"
+require "pact_broker/client/tasks"

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -1,0 +1,89 @@
+require "webmock"
+require "pact/provider/rspec"
+
+Pact.configure do |config|
+  config.reports_dir = "spec/reports/pacts"
+  config.include WebMock::API
+  config.include WebMock::Matchers
+end
+
+Pact.service_provider "Account API" do
+  honours_pact_with "GDS API Adapters" do
+    if ENV["PACT_URI"]
+      pact_uri ENV["PACT_URI"]
+    else
+      abort("Not set up to work with the pact-broker yet, only local usage is implemented.
+      1. Run the gds-api-adapters tests
+      2. Call with PACT_URI=../gds-api-adapters/spec/pacts/gds_api_adapters-account_api.json")
+    end
+  end
+end
+
+Pact.provider_states_for "GDS API Adapters" do
+  set_up do
+    ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_ID"] = "client-id"
+    ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET"] = "client-secret"
+
+    WebMock.enable!
+    WebMock.reset!
+
+    discovery_response = instance_double(
+      "OpenIDConnect::Discovery::Provider::Config::Response",
+      authorization_endpoint: "http://openid-provider/authorization-endpoint",
+      token_endpoint: "http://openid-provider/token-endpoint",
+      userinfo_endpoint: "http://openid-provider/userinfo-endpoint",
+      end_session_endpoint: "http://openid-provider/end-session-endpoint",
+    )
+
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(OidcClient).to receive(:discover).and_return(discovery_response)
+    allow_any_instance_of(OidcClient).to receive(:tokens!).and_return({ access_token: "access-token", refresh_token: "refresh-token" })
+    allow_any_instance_of(ApplicationController).to receive(:from_account_session).and_return({ access_token: "access-token", refresh_token: "refresh-token" })
+    # rubocop:enable RSpec/AnyInstance
+
+    stub_request(:post, Plek.find("account-manager") + "/api/v1/jwt").to_return(status: 200, body: { id: "jwt-id" }.to_json)
+  end
+
+  tear_down do
+    WebMock.disable!
+  end
+
+  provider_state "there is a valid OAuth response" do
+    set_up do
+      auth_request = AuthRequest.generate!
+      allow(AuthRequest).to receive(:from_oauth_state).and_return(auth_request)
+
+      stub_request(:get, Plek.find("account-manager") + "/api/v1/ephemeral-state").to_return(status: 200, body: { _ga: "ga-client-id" }.to_json)
+    end
+  end
+
+  provider_state "there is a valid OAuth response, with the redirect path '/some-arbitrary-path'" do
+    set_up do
+      auth_request = AuthRequest.generate!(redirect_path: "/some-arbitrary-path")
+      allow(AuthRequest).to receive(:from_oauth_state).and_return(auth_request)
+
+      stub_request(:get, Plek.find("account-manager") + "/api/v1/ephemeral-state").to_return(status: 200, body: { _ga: "ga-client-id" }.to_json)
+    end
+  end
+
+  provider_state "there is a valid user session" do
+    set_up do
+      stub_request(:get, Plek.find("account-manager") + "/api/v1/transition-checker/email-subscription").to_return(status: 404)
+      stub_request(:post, Plek.find("account-manager") + "/api/v1/transition-checker/email-subscription").to_return(status: 200)
+      stub_request(:get, "http://openid-provider/v1/attributes/foo").to_return(status: 404)
+      stub_request(:post, "http://openid-provider/v1/attributes").to_return(status: 200)
+    end
+  end
+
+  provider_state "there is a valid user session, with a transition checker email subscription" do
+    set_up do
+      stub_request(:get, Plek.find("account-manager") + "/api/v1/transition-checker/email-subscription").to_return(status: 204)
+    end
+  end
+
+  provider_state "there is a valid user session, with an attribute called 'foo'" do
+    set_up do
+      stub_request(:get, "http://openid-provider/v1/attributes/foo").to_return(status: 200, body: { claim_value: { bar: "baz" } }.to_json)
+    end
+  end
+end


### PR DESCRIPTION
This is step 2 of the [Writing Pact tests](https://docs.publishing.service.gov.uk/manual/pact-broker.html#writing-pact-tests) docs, see also https://github.com/alphagov/gds-api-adapters/pull/1043.

---

Pact provider configuration specifies which contracts are
honoured (currently only gds-api-adapters) and defines a set of
"provider states", which are a sort of precondition that the consumer
tests expect.

A Pact test has two parts:

1. The consumer test, which specifies which provider state is
expected, gives the request, and an expected response.

2. The provider configuration, which defines all of the provider
states.

There are no actual tests in the provider: rather, the requests
defined by the consumer tests are run against the provider, and pact
checks that the responses match.

---

[Trello card](https://trello.com/c/OcRffYwv/674-set-up-pact-tests-for-our-account-api-app)