### PR TITLE
Run Pact tests as part of the default rake task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "pg"
 group :development, :test do
   gem "awesome_print"
   gem "bullet"
+  gem "climate_control"
   gem "factory_bot_rails"
   gem "govuk_test"
   gem "pact", require: false
@@ -31,7 +32,6 @@ group :development do
 end
 
 group :test do
-  gem "climate_control"
   gem "simplecov"
   gem "webmock"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -7,4 +7,4 @@ Rails.application.load_tasks
 
 Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
 
-task default: %i[lint spec]
+task default: %i[lint spec pact:verify]

--- a/lib/tasks/pact.rake
+++ b/lib/tasks/pact.rake
@@ -1,4 +1,18 @@
 return if Rails.env.production?
 
 require "pact/tasks"
+require "pact/tasks/task_helper"
 require "pact_broker/client/tasks"
+
+desc "Verify that Account API honours all contracts in the pactfile created by a given branch of gds-api-adapters"
+task "pact:verify:branch", [:branch_name] => :environment do |t, args|
+  abort "Please provide a branch name. eg rake #{t.name}[my_feature_branch]" unless args[:branch_name]
+
+  pact_version = args[:branch_name] == "master" ? args[:branch_name] : "branch-#{args[:branch_name]}"
+
+  ClimateControl.modify GDS_API_ADAPTERS_PACT_VERSION: pact_version do
+    Pact::TaskHelper.handle_verification_failure do
+      Pact::TaskHelper.execute_pact_verify
+    end
+  end
+end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -7,14 +7,20 @@ Pact.configure do |config|
   config.include WebMock::Matchers
 end
 
+def url_encode(str)
+  ERB::Util.url_encode(str)
+end
+
 Pact.service_provider "Account API" do
   honours_pact_with "GDS API Adapters" do
     if ENV["PACT_URI"]
       pact_uri ENV["PACT_URI"]
     else
-      abort("Not set up to work with the pact-broker yet, only local usage is implemented.
-      1. Run the gds-api-adapters tests
-      2. Call with PACT_URI=../gds-api-adapters/spec/pacts/gds_api_adapters-account_api.json")
+      base_url = "https://pact-broker.cloudapps.digital"
+      path = "pacts/provider/#{url_encode(name)}/consumer/#{url_encode(consumer_name)}"
+      version_modifier = "versions/#{url_encode(ENV.fetch('GDS_API_ADAPTERS_PACT_VERSION', 'master'))}"
+
+      pact_uri("#{base_url}/#{path}/#{version_modifier}")
     end
   end
 end


### PR DESCRIPTION
This is step 4 of the [Writing Pact tests](https://docs.publishing.service.gov.uk/manual/pact-broker.html#writing-pact-tests) docs.

---

The gds-api-adapters contract is now being published to the
pact-broker, so these tests will pass.

---

[Trello card](https://trello.com/c/OcRffYwv/674-set-up-pact-tests-for-our-account-api-app)