### PR TITLE
Send application/json requests in the request specs

### DIFF
--- a/spec/requests/attributes_controller_spec.rb
+++ b/spec/requests/attributes_controller_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe AttributesController do
   before { stub_oidc_discovery }
 
-  let(:headers) { { "GOVUK-Account-Session" => placeholder_govuk_account_session } }
+  let(:headers) { { "Content-Type" => "application/json", "GOVUK-Account-Session" => placeholder_govuk_account_session } }
 
   let(:attribute_name1) { "name" }
   let(:attribute_value1) { { "some" => "complex", "value" => 42 } }
@@ -94,7 +94,7 @@ RSpec.describe AttributesController do
         .with(body: { attributes: attributes })
         .to_return(status: 200)
 
-      patch attributes_path, headers: headers, params: params
+      patch attributes_path, headers: headers, params: params.to_json
       expect(response).to be_successful
       expect(stub).to have_been_made
     end
@@ -109,14 +109,14 @@ RSpec.describe AttributesController do
       end
 
       it "returns a 401" do
-        patch attributes_path, headers: headers, params: params
+        patch attributes_path, headers: headers, params: params.to_json
         expect(response).to have_http_status(:unauthorized)
       end
     end
 
     context "when no govuk-account-session is provided" do
       it "returns a 401" do
-        patch attributes_path, params: params
+        patch attributes_path, headers: { "Content-Type" => "application/json" }, params: params.to_json
         expect(response).to have_http_status(:unauthorized)
       end
     end

--- a/spec/requests/transition_checker_email_subscription_controller_spec.rb
+++ b/spec/requests/transition_checker_email_subscription_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe TransitionCheckerEmailSubscriptionController do
     # rubocop:enable RSpec/AnyInstance
   end
 
-  let(:headers) { { "GOVUK-Account-Session" => placeholder_govuk_account_session } }
+  let(:headers) { { "Content-Type" => "application/json", "GOVUK-Account-Session" => placeholder_govuk_account_session } }
 
   describe "GET" do
     before do
@@ -71,7 +71,7 @@ RSpec.describe TransitionCheckerEmailSubscriptionController do
         .with(body: hash_including(topic_slug: "slug"))
         .to_return(status: 200)
 
-      post transition_checker_email_subscription_path, headers: headers, params: { slug: "slug" }
+      post transition_checker_email_subscription_path, headers: headers, params: { slug: "slug" }.to_json
       expect(response).to be_successful
       expect(stub).to have_been_made
     end
@@ -84,7 +84,7 @@ RSpec.describe TransitionCheckerEmailSubscriptionController do
           .with(body: hash_including(topic_slug: "slug"))
           .to_return(status: 401)
 
-        post transition_checker_email_subscription_path, headers: headers, params: { slug: "slug" }
+        post transition_checker_email_subscription_path, headers: headers, params: { slug: "slug" }.to_json
         expect(response).to have_http_status(:unauthorized)
       end
     end


### PR DESCRIPTION
By default, Rails request specs send parameters as
application/x-www-form-urlencoded, but this has two problems:

1. gds-api-adapters sends JSON requests, so sending form data means
our test & production behaviours are very different.

2. form-data is bad at encoding complex nested data (or even just
numbers - which are decoded as strings), so we limit our app to only
what form-data supports.

A concrete problem caused by (2) is that the PATCH attributes endpoint
requires attribute values to be passed in as strings of JSON-encoded
data.  This is weird and confusing, and not at all like publishing-api
or email-alert-api.  It would be good to fix that, but first we need
these tests to do the right thing.

By instead sending JSON data in our tests (which publishing-api does
in its tests), we make our tests more closely match production
behaviour.

---

[Trello card](https://trello.com/c/E5J5kzNP/679-remove-the-redundant-json-encoding-of-attribute-values-in-account-api)