### PR TITLE
Allow non-encoded attribute values

### DIFF
--- a/app/lib/oidc_client.rb
+++ b/app/lib/oidc_client.rb
@@ -83,13 +83,13 @@ class OidcClient
     end
   end
 
-  def bulk_set_attributes(attributes:, access_token:, refresh_token: nil)
+  def bulk_set_attributes(attributes:, already_encoded:, access_token:, refresh_token: nil)
     oauth_request(
       access_token: access_token,
       refresh_token: refresh_token,
       method: :post,
       uri: bulk_attribute_uri,
-      arg: attributes.transform_keys { |key| "attributes[#{key}]" },
+      arg: attributes.transform_keys { |key| "attributes[#{key}]" }.transform_values { |v| already_encoded ? v : v.to_json },
     )
   end
 


### PR DESCRIPTION
The create-state endpoint accepts plain JSON, rather than encoded
values.  This commit makes the update-attributes endpoint also accept
plain JSON, to be consistent.

To support backwards compatibility, encoded attribute values are also
accepted.  If all of the attribute values are JSON strings, then the
assumption is made that they have been encoded by the sender.  In
practice, this is the case, because gds-api-adapters is the only thing
which uses this endpoint so far and that's what it does.

After this has been deployed we can:

1. update gds-api-adapters to *not* encode the attribute values
2. deploy a finder-frontend with the updated gds-api-adapters
3. remove the backwards compatibility code here

Moving to accept plain JSON values (rather than strings of encoded
values) makes this endpoint consistent with other GOV.UK API apps.

---

[Trello card](https://trello.com/c/E5J5kzNP/679-remove-the-redundant-json-encoding-of-attribute-values-in-account-api)