### PR TITLE
Remove support for giving attributes as JSON strings

### DIFF
--- a/app/controllers/attributes_controller.rb
+++ b/app/controllers/attributes_controller.rb
@@ -29,11 +29,8 @@ class AttributesController < ApplicationController
   def update
     attributes = params.fetch(:attributes).permit!.to_h
 
-    already_encoded = attributes.values.all? { |v| is_json_encoded v }
-
     oauth_response = OidcClient.new.bulk_set_attributes(
       attributes: attributes,
-      already_encoded: already_encoded,
       access_token: @govuk_account_session[:access_token],
       refresh_token: @govuk_account_session[:refresh_token],
     )
@@ -43,16 +40,5 @@ class AttributesController < ApplicationController
     }
   rescue OidcClient::OAuthFailure
     head :unauthorized
-  end
-
-protected
-
-  def is_json_encoded(value)
-    return false unless value.is_a? String
-
-    JSON.parse(value)
-    true
-  rescue JSON::ParserError
-    false
   end
 end

--- a/app/lib/oidc_client.rb
+++ b/app/lib/oidc_client.rb
@@ -83,13 +83,13 @@ class OidcClient
     end
   end
 
-  def bulk_set_attributes(attributes:, already_encoded:, access_token:, refresh_token: nil)
+  def bulk_set_attributes(attributes:, access_token:, refresh_token: nil)
     oauth_request(
       access_token: access_token,
       refresh_token: refresh_token,
       method: :post,
       uri: bulk_attribute_uri,
-      arg: attributes.transform_keys { |key| "attributes[#{key}]" }.transform_values { |v| already_encoded ? v : v.to_json },
+      arg: attributes.transform_keys { |key| "attributes[#{key}]" }.transform_values(&:to_json),
     )
   end
 

--- a/spec/requests/attributes_controller_spec.rb
+++ b/spec/requests/attributes_controller_spec.rb
@@ -87,12 +87,11 @@ RSpec.describe AttributesController do
 
   describe "PATCH" do
     let(:attributes) { { attribute_name1 => attribute_value1, attribute_name2 => attribute_value2 } }
-    let(:encoded_attributes) { { attribute_name1 => attribute_value1.to_json, attribute_name2 => attribute_value2.to_json } }
     let(:params) { { attributes: attributes } }
 
     it "calls the attribute service" do
       stub = stub_request(:post, "http://openid-provider/v1/attributes")
-        .with(body: { attributes: encoded_attributes })
+        .with(body: { attributes: attributes.transform_values(&:to_json) })
         .to_return(status: 200)
 
       patch attributes_path, headers: headers, params: params.to_json
@@ -100,26 +99,12 @@ RSpec.describe AttributesController do
       expect(stub).to have_been_made
     end
 
-    context "with JSON-encoded values" do
-      let(:attributes) { encoded_attributes }
-
-      it "doesn't double-encode the attributes" do
-        stub = stub_request(:post, "http://openid-provider/v1/attributes")
-          .with(body: { attributes: encoded_attributes })
-          .to_return(status: 200)
-
-        patch attributes_path, headers: headers, params: params.to_json
-        expect(response).to be_successful
-        expect(stub).to have_been_made
-      end
-    end
-
     context "when the tokens are rejected" do
       before do
         stub_request(:post, "http://openid-provider/token-endpoint").to_return(status: 401)
 
         stub_request(:post, "http://openid-provider/v1/attributes")
-          .with(body: { attributes: encoded_attributes })
+          .with(body: { attributes: attributes.transform_values(&:to_json) })
           .to_return(status: 401)
       end
 


### PR DESCRIPTION
This removes the compatibility code introduced in c7c9a5b, as a new
release of gds-api-adapters has been made (and deployed) which
switches to the new encoding.

---

[Trello card](https://trello.com/c/E5J5kzNP/679-remove-the-redundant-json-encoding-of-attribute-values-in-account-api)