### PR TITLE
Do not require a bearer token for /api/oauth2/{sign-in,callback}

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -1,4 +1,6 @@
 class AuthenticationController < ApplicationController
+  skip_before_action :authorise, only: %i[sign_in callback]
+
   def sign_in
     AuthRequest.expired.delete_all
 


### PR DESCRIPTION
These endpoints don't let you do anything nefarious, so they don't
need auth to access.  Unprotecting these means we don't need to set up
a bearer token for frontend.