### PR TITLE
Use correct callback path

### DIFF
--- a/app/lib/oidc_client.rb
+++ b/app/lib/oidc_client.rb
@@ -166,8 +166,8 @@ protected
   end
 
   def redirect_uri
-    host = Rails.env.production? ? ENV["GOVUK_WEBSITE_ROOT"] : Plek.find("finder-frontend")
-    host + "/transition-check/login/callback"
+    host = Rails.env.production? ? ENV["GOVUK_WEBSITE_ROOT"] : Plek.find("frontend")
+    host + "/sign-in/callback"
   end
 
   def ephemeral_state_uri

--- a/app/models/auth_request.rb
+++ b/app/models/auth_request.rb
@@ -29,7 +29,7 @@ class AuthRequest < ApplicationRecord
     return if redirect_path.nil?
     return if redirect_path.empty?
 
-    if redirect_path&.starts_with? "//"
+    if redirect_path.starts_with? "//"
       errors.add(:redirect_path, "can't be protocol-relative")
       return
     end


### PR DESCRIPTION
We're logging people in via /transition-check/login/callback currently, whoops.  Well, the fact that that has worked flawlessly just shows that we did the migration without breaking compatibility anywhere.