### PR TITLE
Amend Rails session headers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,12 +5,7 @@ class ApplicationController < ActionController::API
   before_action :authorise
 
   def fetch_govuk_account_session
-    govuk_account_session_header =
-      if request.headers["HTTP_GOVUK_ACCOUNT_SESSION"]
-        request.headers["HTTP_GOVUK_ACCOUNT_SESSION"]
-      elsif request.headers.to_h["GOVUK-Account-Session"]
-        request.headers.to_h["GOVUK-Account-Session"]
-      end
+    govuk_account_session_header = request.headers["HTTP_GOVUK_ACCOUNT_SESSION"]
 
     @govuk_account_session = from_account_session(govuk_account_session_header)
 


### PR DESCRIPTION
[Trello ticket][1]

In [frontend#2668][2] we worked out that Rails makes request headers available as

```
request.headers["HTTP_" + header_name.gsub(/-/,"_").upcase]
```

So in particular, our header is available at

```
request.headers["HTTP_GOVUK_ACCOUNT_SESSION"]
```

However, account-api has code to look up the header under a different name, because we weren't previously sure of the correct behaviour.

Now that we know what the correct behaviour is, the code for the incorrect case is redundant and can be removed.

[1]: https://trello.com/c/6GWYTVMM/681-remove-the-redundant-header-logic-in-finder-frontend-and-account-api

[2]: https://github.com/alphagov/frontend/pull/2668

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
