### PR TITLE
Store the level of authentication in the session 

### DIFF
--- a/app/controllers/attributes_controller.rb
+++ b/app/controllers/attributes_controller.rb
@@ -22,6 +22,7 @@ class AttributesController < ApplicationController
       govuk_account_session: to_account_session(
         access_token: access_token,
         refresh_token: refresh_token,
+        level_of_authentication: @govuk_account_session[:level_of_authentication],
       ),
       values: values.compact,
     }
@@ -42,6 +43,7 @@ class AttributesController < ApplicationController
       govuk_account_session: to_account_session(
         access_token: oauth_response[:access_token],
         refresh_token: oauth_response[:refresh_token],
+        level_of_authentication: @govuk_account_session[:level_of_authentication],
       ),
     }
   rescue OidcClient::OAuthFailure

--- a/app/controllers/attributes_controller.rb
+++ b/app/controllers/attributes_controller.rb
@@ -19,7 +19,10 @@ class AttributesController < ApplicationController
     end
 
     render json: {
-      govuk_account_session: to_account_session(access_token, refresh_token),
+      govuk_account_session: to_account_session(
+        access_token: access_token,
+        refresh_token: refresh_token,
+      ),
       values: values.compact,
     }
   rescue OidcClient::OAuthFailure
@@ -36,7 +39,10 @@ class AttributesController < ApplicationController
     )
 
     render json: {
-      govuk_account_session: to_account_session(oauth_response[:access_token], oauth_response[:refresh_token]),
+      govuk_account_session: to_account_session(
+        access_token: oauth_response[:access_token],
+        refresh_token: oauth_response[:refresh_token],
+      ),
     }
   rescue OidcClient::OAuthFailure
     head :unauthorized

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -32,11 +32,12 @@ class AuthenticationController < ApplicationController
 
     render json: {
       govuk_account_session: to_account_session(
-        access_token: oauth_response[:access_token],
-        refresh_token: oauth_response[:refresh_token],
+        access_token: oauth_response.fetch(:access_token),
+        refresh_token: oauth_response.fetch(:refresh_token),
+        level_of_authentication: oauth_response.fetch(:result).fetch("level_of_authentication"),
       ),
       redirect_path: redirect_path,
-      ga_client_id: oauth_response[:result]["_ga"],
+      ga_client_id: oauth_response.fetch(:result)["_ga"],
     }
   rescue OidcClient::OAuthFailure
     head :unauthorized

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -31,7 +31,10 @@ class AuthenticationController < ApplicationController
     auth_request.delete
 
     render json: {
-      govuk_account_session: to_account_session(oauth_response[:access_token], oauth_response[:refresh_token]),
+      govuk_account_session: to_account_session(
+        access_token: oauth_response[:access_token],
+        refresh_token: oauth_response[:refresh_token],
+      ),
       redirect_path: redirect_path,
       ga_client_id: oauth_response[:result]["_ga"],
     }

--- a/app/controllers/transition_checker_email_subscription_controller.rb
+++ b/app/controllers/transition_checker_email_subscription_controller.rb
@@ -11,6 +11,7 @@ class TransitionCheckerEmailSubscriptionController < ApplicationController
       govuk_account_session: to_account_session(
         access_token: oauth_response[:access_token],
         refresh_token: oauth_response[:refresh_token],
+        level_of_authentication: @govuk_account_session[:level_of_authentication],
       ),
       has_subscription: oauth_response[:result],
     }
@@ -29,6 +30,7 @@ class TransitionCheckerEmailSubscriptionController < ApplicationController
       govuk_account_session: to_account_session(
         access_token: oauth_response[:access_token],
         refresh_token: oauth_response[:refresh_token],
+        level_of_authentication: @govuk_account_session[:level_of_authentication],
       ),
     }
   rescue OidcClient::OAuthFailure

--- a/app/controllers/transition_checker_email_subscription_controller.rb
+++ b/app/controllers/transition_checker_email_subscription_controller.rb
@@ -8,7 +8,10 @@ class TransitionCheckerEmailSubscriptionController < ApplicationController
     )
 
     render json: {
-      govuk_account_session: to_account_session(oauth_response[:access_token], oauth_response[:refresh_token]),
+      govuk_account_session: to_account_session(
+        access_token: oauth_response[:access_token],
+        refresh_token: oauth_response[:refresh_token],
+      ),
       has_subscription: oauth_response[:result],
     }
   rescue OidcClient::OAuthFailure
@@ -23,7 +26,10 @@ class TransitionCheckerEmailSubscriptionController < ApplicationController
     )
 
     render json: {
-      govuk_account_session: to_account_session(oauth_response[:access_token], oauth_response[:refresh_token]),
+      govuk_account_session: to_account_session(
+        access_token: oauth_response[:access_token],
+        refresh_token: oauth_response[:refresh_token],
+      ),
     }
   rescue OidcClient::OAuthFailure
     head :unauthorized

--- a/app/helpers/session_header_helper.rb
+++ b/app/helpers/session_header_helper.rb
@@ -1,10 +1,11 @@
 module SessionHeaderHelper
-  def to_account_session(access_token:, refresh_token:)
+  def to_account_session(access_token:, refresh_token:, level_of_authentication:)
     SessionEncryptor
       .new(session_signing_key: Rails.application.secrets.session_signing_key)
       .encrypt_session(
         access_token: access_token,
         refresh_token: refresh_token,
+        level_of_authentication: level_of_authentication,
       )
   end
 
@@ -26,6 +27,7 @@ module SessionHeaderHelper
       {
         access_token: Base64.urlsafe_decode64(bits[0]),
         refresh_token: Base64.urlsafe_decode64(bits[1]),
+        level_of_authentication: SessionEncryptor::LOWEST_LEVEL_OF_AUTHENTICATION,
       }
     end
   rescue ArgumentError

--- a/app/helpers/session_header_helper.rb
+++ b/app/helpers/session_header_helper.rb
@@ -1,5 +1,5 @@
 module SessionHeaderHelper
-  def to_account_session(access_token, refresh_token)
+  def to_account_session(access_token:, refresh_token:)
     SessionEncryptor
       .new(session_signing_key: Rails.application.secrets.session_signing_key)
       .encrypt_session(

--- a/app/lib/session_encryptor.rb
+++ b/app/lib/session_encryptor.rb
@@ -1,15 +1,20 @@
+# frozen_string_literal: true
+
 class SessionEncryptor
   KEY_LEN = ActiveSupport::MessageEncryptor.key_len
+
+  LOWEST_LEVEL_OF_AUTHENTICATION = "level0"
 
   def initialize(session_signing_key:)
     @session_signing_key = session_signing_key
   end
 
-  def encrypt_session(access_token:, refresh_token:)
+  def encrypt_session(access_token:, refresh_token:, level_of_authentication:)
     encrypt_string(
       {
         access_token: access_token,
         refresh_token: refresh_token,
+        level_of_authentication: level_of_authentication,
       }.to_json,
     )
   end
@@ -20,7 +25,9 @@ class SessionEncryptor
     plaintext = decrypt_string(ciphertext)
     return unless plaintext
 
-    JSON.parse(plaintext).symbolize_keys
+    {
+      level_of_authentication: LOWEST_LEVEL_OF_AUTHENTICATION,
+    }.merge(JSON.parse(plaintext).symbolize_keys)
   end
 
 private

--- a/spec/helpers/session_header_helper_spec.rb
+++ b/spec/helpers/session_header_helper_spec.rb
@@ -1,11 +1,14 @@
 RSpec.describe SessionHeaderHelper do
-  let(:tokens) { { access_token: SecureRandom.hex(10), refresh_token: SecureRandom.hex(10) } }
+  let(:access_token) { SecureRandom.hex(10) }
+  let(:refresh_token) { SecureRandom.hex(10) }
+  let(:level_of_authentication) { SessionEncryptor::LOWEST_LEVEL_OF_AUTHENTICATION }
+  let(:params) { { access_token: access_token, refresh_token: refresh_token, level_of_authentication: level_of_authentication } }
 
   it "round-trips" do
-    encoded = to_account_session(**tokens)
+    encoded = to_account_session(**params)
     decoded = from_account_session(encoded)
 
-    expect(decoded).to eq(tokens)
+    expect(decoded).to eq(params)
   end
 
   it "returns nil on a missing value" do
@@ -14,10 +17,10 @@ RSpec.describe SessionHeaderHelper do
   end
 
   it "accepts a legacy unsigned session header" do
-    encoded = "#{Base64.urlsafe_encode64(tokens[:access_token])}.#{Base64.urlsafe_encode64(tokens[:refresh_token])}"
+    encoded = "#{Base64.urlsafe_encode64(access_token)}.#{Base64.urlsafe_encode64(refresh_token)}"
     decoded = from_account_session(encoded)
 
-    expect(decoded).to eq(tokens)
+    expect(decoded).to eq(params)
   end
 
   describe "from_legacy_account_session" do

--- a/spec/helpers/session_header_helper_spec.rb
+++ b/spec/helpers/session_header_helper_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe SessionHeaderHelper do
   let(:tokens) { { access_token: SecureRandom.hex(10), refresh_token: SecureRandom.hex(10) } }
 
   it "round-trips" do
-    encoded = to_account_session(*token_values(tokens))
+    encoded = to_account_session(**tokens)
     decoded = from_account_session(encoded)
 
     expect(decoded).to eq(tokens)
@@ -29,9 +29,5 @@ RSpec.describe SessionHeaderHelper do
       expect(from_legacy_account_session(Base64.urlsafe_encode64("1"))).to be_nil
       expect(from_legacy_account_session(Base64.urlsafe_encode64("1") + "." + Base64.urlsafe_encode64("2") + "." + Base64.urlsafe_encode64("3"))).to be_nil
     end
-  end
-
-  def token_values(access_token:, refresh_token:)
-    [access_token, refresh_token]
   end
 end

--- a/spec/lib/session_encryptor_spec.rb
+++ b/spec/lib/session_encryptor_spec.rb
@@ -1,6 +1,14 @@
 RSpec.describe SessionEncryptor do
   let(:key) { "encryption-key" }
-  let(:encoded) { described_class.new(session_signing_key: key).encrypt_session(access_token: "access-token", refresh_token: "refresh-token") }
+  let(:encoded) do
+    described_class
+      .new(session_signing_key: key)
+      .encrypt_session(
+        access_token: "access-token",
+        refresh_token: "refresh-token",
+        level_of_authentication: "level42",
+      )
+  end
 
   it "rejects if the salt has been tampered with" do
     bits = Base64.urlsafe_decode64(encoded).split("$$")

--- a/spec/requests/authentication_controller_spec.rb
+++ b/spec/requests/authentication_controller_spec.rb
@@ -44,10 +44,10 @@ RSpec.describe AuthenticationController do
   describe "/callback" do
     let!(:auth_request) { AuthRequest.create!(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "/some-path") }
 
-    it "fetches the tokens & GA client ID" do
+    it "fetches the tokens & ephemeral state" do
       stub_request(:get, Plek.find("account-manager") + "/api/v1/ephemeral-state")
         .with(headers: { "Authorization" => "Bearer access-token" })
-        .to_return(status: 200, body: { _ga: "ga-client-id" }.to_json)
+        .to_return(status: 200, body: { _ga: "ga-client-id", level_of_authentication: "level42" }.to_json)
 
       post callback_path, headers: headers, params: { state: auth_request.to_oauth_state, code: "12345" }.to_json
       expect(response).to be_successful

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -59,7 +59,7 @@ Pact.provider_states_for "GDS API Adapters" do
       auth_request = AuthRequest.generate!
       allow(AuthRequest).to receive(:from_oauth_state).and_return(auth_request)
 
-      stub_request(:get, Plek.find("account-manager") + "/api/v1/ephemeral-state").to_return(status: 200, body: { _ga: "ga-client-id" }.to_json)
+      stub_request(:get, Plek.find("account-manager") + "/api/v1/ephemeral-state").to_return(status: 200, body: { _ga: "ga-client-id", level_of_authentication: "level0" }.to_json)
     end
   end
 
@@ -68,7 +68,7 @@ Pact.provider_states_for "GDS API Adapters" do
       auth_request = AuthRequest.generate!(redirect_path: "/some-arbitrary-path")
       allow(AuthRequest).to receive(:from_oauth_state).and_return(auth_request)
 
-      stub_request(:get, Plek.find("account-manager") + "/api/v1/ephemeral-state").to_return(status: 200, body: { _ga: "ga-client-id" }.to_json)
+      stub_request(:get, Plek.find("account-manager") + "/api/v1/ephemeral-state").to_return(status: 200, body: { _ga: "ga-client-id", level_of_authentication: "level0" }.to_json)
     end
   end
 


### PR DESCRIPTION
This should be deployed after the change to the account manager, as it
throws an error if the expected level_of_authentication parameter
isn't returned.

The use of LOWEST_LEVEL_OF_AUTHENTICATION in the SessionHeaderHelper
means that current sessions will be upgraded to level0 sessions.  This
won't be enough to use the Transition Checker, so they will end up
needing to reauthenticate, but it is enough to use the bookmark
experiment.

---

[Trello card](https://trello.com/c/yCLEBvxW/714-store-the-level-of-authentication-in-the-users-session)