### PR TITLE
Validate attributes and flag where they're stored

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,4 +17,12 @@ protected
   def authorise
     authorise_user!("internal_app")
   end
+
+  def account_session_header_value
+    to_account_session(
+      access_token: @govuk_account_session[:access_token],
+      refresh_token: @govuk_account_session[:refresh_token],
+      level_of_authentication: @govuk_account_session[:level_of_authentication],
+    )
+  end
 end

--- a/app/controllers/attributes_controller.rb
+++ b/app/controllers/attributes_controller.rb
@@ -6,30 +6,23 @@ class AttributesController < ApplicationController
 
     return unless validate_attributes(attribute_names)
 
-    access_token = @govuk_account_session[:access_token]
-    refresh_token = @govuk_account_session[:refresh_token]
-
     values = attribute_names.each_with_object({}) do |name, values_hash|
       if user_attributes.stored_locally? name
         raise NotImplementedError
       else
         oauth_response = OidcClient.new.get_attribute(
           attribute: name,
-          access_token: access_token,
-          refresh_token: refresh_token,
+          access_token: @govuk_account_session[:access_token],
+          refresh_token: @govuk_account_session[:refresh_token],
         )
-        access_token = oauth_response[:access_token]
-        refresh_token = oauth_response[:refresh_token]
+        @govuk_account_session[:access_token] = oauth_response[:access_token]
+        @govuk_account_session[:refresh_token] = oauth_response[:refresh_token]
         values_hash[name] = oauth_response[:result]
       end
     end
 
     render json: {
-      govuk_account_session: to_account_session(
-        access_token: access_token,
-        refresh_token: refresh_token,
-        level_of_authentication: @govuk_account_session[:level_of_authentication],
-      ),
+      govuk_account_session: account_session_header_value,
       values: values.compact,
     }
   rescue OidcClient::OAuthFailure
@@ -41,9 +34,6 @@ class AttributesController < ApplicationController
 
     return unless validate_attributes(attributes.keys)
 
-    access_token = @govuk_account_session[:access_token]
-    refresh_token = @govuk_account_session[:refresh_token]
-
     local_attributes = attributes.select { |name| user_attributes.stored_locally? name }
     remote_attributes = attributes.reject { |name| user_attributes.stored_locally? name }
 
@@ -54,19 +44,15 @@ class AttributesController < ApplicationController
     if remote_attributes.any?
       oauth_response = OidcClient.new.bulk_set_attributes(
         attributes: remote_attributes,
-        access_token: access_token,
-        refresh_token: refresh_token,
+        access_token: @govuk_account_session[:access_token],
+        refresh_token: @govuk_account_session[:refresh_token],
       )
-      access_token = oauth_response[:access_token]
-      refresh_token = oauth_response[:refresh_token]
+      @govuk_account_session[:access_token] = oauth_response[:access_token]
+      @govuk_account_session[:refresh_token] = oauth_response[:refresh_token]
     end
 
     render json: {
-      govuk_account_session: to_account_session(
-        access_token: access_token,
-        refresh_token: refresh_token,
-        level_of_authentication: @govuk_account_session[:level_of_authentication],
-      ),
+      govuk_account_session: account_session_header_value,
     }
   rescue OidcClient::OAuthFailure
     head :unauthorized

--- a/app/controllers/attributes_controller.rb
+++ b/app/controllers/attributes_controller.rb
@@ -77,7 +77,13 @@ private
   def validate_attributes(names)
     undefined = names.reject { |n| user_attributes.defined? n }
     if undefined.any?
-      render json: { title: "undefined attributes", detail: undefined }, status: :unprocessable_entity
+      render status: :unprocessable_entity, json:
+        {
+          type: I18n.t("errors.unknown_attribute_names.type"),
+          title: I18n.t("errors.unknown_attribute_names.title"),
+          detail: I18n.t("errors.unknown_attribute_names.detail", attribute_names: undefined.join(", ")),
+          attributes: undefined,
+        }
       return false
     end
 

--- a/app/controllers/attributes_controller.rb
+++ b/app/controllers/attributes_controller.rb
@@ -4,18 +4,24 @@ class AttributesController < ApplicationController
   def show
     attribute_names = params.fetch(:attributes)
 
+    return unless validate_attributes(attribute_names)
+
     access_token = @govuk_account_session[:access_token]
     refresh_token = @govuk_account_session[:refresh_token]
 
     values = attribute_names.each_with_object({}) do |name, values_hash|
-      oauth_response = OidcClient.new.get_attribute(
-        attribute: name,
-        access_token: access_token,
-        refresh_token: refresh_token,
-      )
-      access_token = oauth_response[:access_token]
-      refresh_token = oauth_response[:refresh_token]
-      values_hash[name] = oauth_response[:result]
+      if user_attributes.stored_locally? name
+        raise NotImplementedError
+      else
+        oauth_response = OidcClient.new.get_attribute(
+          attribute: name,
+          access_token: access_token,
+          refresh_token: refresh_token,
+        )
+        access_token = oauth_response[:access_token]
+        refresh_token = oauth_response[:refresh_token]
+        values_hash[name] = oauth_response[:result]
+      end
     end
 
     render json: {
@@ -33,20 +39,52 @@ class AttributesController < ApplicationController
   def update
     attributes = params.fetch(:attributes).permit!.to_h
 
-    oauth_response = OidcClient.new.bulk_set_attributes(
-      attributes: attributes,
-      access_token: @govuk_account_session[:access_token],
-      refresh_token: @govuk_account_session[:refresh_token],
-    )
+    return unless validate_attributes(attributes.keys)
+
+    access_token = @govuk_account_session[:access_token]
+    refresh_token = @govuk_account_session[:refresh_token]
+
+    local_attributes = attributes.select { |name| user_attributes.stored_locally? name }
+    remote_attributes = attributes.reject { |name| user_attributes.stored_locally? name }
+
+    if local_attributes.any?
+      raise NotImplementedError
+    end
+
+    if remote_attributes.any?
+      oauth_response = OidcClient.new.bulk_set_attributes(
+        attributes: remote_attributes,
+        access_token: access_token,
+        refresh_token: refresh_token,
+      )
+      access_token = oauth_response[:access_token]
+      refresh_token = oauth_response[:refresh_token]
+    end
 
     render json: {
       govuk_account_session: to_account_session(
-        access_token: oauth_response[:access_token],
-        refresh_token: oauth_response[:refresh_token],
+        access_token: access_token,
+        refresh_token: refresh_token,
         level_of_authentication: @govuk_account_session[:level_of_authentication],
       ),
     }
   rescue OidcClient::OAuthFailure
     head :unauthorized
+  end
+
+private
+
+  def validate_attributes(names)
+    undefined = names.reject { |n| user_attributes.defined? n }
+    if undefined.any?
+      render json: { title: "undefined attributes", detail: undefined }, status: :unprocessable_entity
+      return false
+    end
+
+    true
+  end
+
+  def user_attributes
+    @user_attributes ||= UserAttributes.new
   end
 end

--- a/app/controllers/transition_checker_email_subscription_controller.rb
+++ b/app/controllers/transition_checker_email_subscription_controller.rb
@@ -6,13 +6,11 @@ class TransitionCheckerEmailSubscriptionController < ApplicationController
       access_token: @govuk_account_session[:access_token],
       refresh_token: @govuk_account_session[:refresh_token],
     )
+    @govuk_account_session[:access_token] = oauth_response[:access_token]
+    @govuk_account_session[:refresh_token] = oauth_response[:refresh_token]
 
     render json: {
-      govuk_account_session: to_account_session(
-        access_token: oauth_response[:access_token],
-        refresh_token: oauth_response[:refresh_token],
-        level_of_authentication: @govuk_account_session[:level_of_authentication],
-      ),
+      govuk_account_session: account_session_header_value,
       has_subscription: oauth_response[:result],
     }
   rescue OidcClient::OAuthFailure
@@ -25,13 +23,11 @@ class TransitionCheckerEmailSubscriptionController < ApplicationController
       access_token: @govuk_account_session[:access_token],
       refresh_token: @govuk_account_session[:refresh_token],
     )
+    @govuk_account_session[:access_token] = oauth_response[:access_token]
+    @govuk_account_session[:refresh_token] = oauth_response[:refresh_token]
 
     render json: {
-      govuk_account_session: to_account_session(
-        access_token: oauth_response[:access_token],
-        refresh_token: oauth_response[:refresh_token],
-        level_of_authentication: @govuk_account_session[:level_of_authentication],
-      ),
+      govuk_account_session: account_session_header_value,
     }
   rescue OidcClient::OAuthFailure
     head :unauthorized

--- a/app/lib/user_attributes.rb
+++ b/app/lib/user_attributes.rb
@@ -1,0 +1,20 @@
+class UserAttributes
+  attr_reader :attributes
+
+  def initialize
+    @attributes = YAML.safe_load(File.read(Rails.root.join("config/user_attributes.yml"))).with_indifferent_access
+
+    if Rails.env.test?
+      test_attributes = YAML.safe_load(File.read(Rails.root.join("spec/fixtures/user_attributes.yml"))).with_indifferent_access
+      @attributes.merge!(test_attributes)
+    end
+  end
+
+  def defined?(name)
+    attributes.key? name
+  end
+
+  def stored_locally?(name)
+    attributes.fetch(name)[:is_stored_locally]
+  end
+end

--- a/app/lib/user_attributes.rb
+++ b/app/lib/user_attributes.rb
@@ -1,4 +1,6 @@
 class UserAttributes
+  CONFIG_KEYS = %w[is_stored_locally].freeze
+
   attr_reader :attributes
 
   def initialize
@@ -16,5 +18,27 @@ class UserAttributes
 
   def stored_locally?(name)
     attributes.fetch(name)[:is_stored_locally]
+  end
+
+  def errors
+    attributes.each_with_object({}) do |(name, config), errors|
+      config ||= {}
+
+      missing_keys = CONFIG_KEYS.reject { |key| config.keys.include? key }
+      unknown_keys = config.keys.reject { |key| CONFIG_KEYS.include? key }
+
+      invalid_keys = []
+      unless config["is_stored_locally"].in?([nil, false, true])
+        invalid_keys << :is_stored_locally
+      end
+
+      this_errors = {
+        missing_keys: missing_keys.any? ? missing_keys : nil,
+        unknown_keys: unknown_keys.any? ? unknown_keys : nil,
+        invalid_keys: invalid_keys.any? ? invalid_keys : nil,
+      }.compact
+
+      errors[name] = this_errors if this_errors.any?
+    end
   end
 end

--- a/config/locales/errors.en.yml
+++ b/config/locales/errors.en.yml
@@ -1,0 +1,7 @@
+---
+en:
+  errors:
+    unknown_attribute_names:
+      type: https://github.com/alphagov/account-api/blob/main/docs/api.md#unknown-attribute-names
+      title: Unknown attribute names
+      detail: Attribute names %{attribute_names} are unknown, have they been added to config/user_attributes.yml?

--- a/config/user_attributes.yml
+++ b/config/user_attributes.yml
@@ -1,0 +1,3 @@
+---
+transition_checker_state:
+  is_stored_locally: false

--- a/docs/api.md
+++ b/docs/api.md
@@ -18,6 +18,8 @@ management. This API is not for other government services.
   - [`PATCH /api/attributes`](#patch-apiattributes)
   - [`GET /api/transition-checker-email-subscription`](#get-apitransition-checker-email-subscription)
   - [`POST /api/transition-checker-email-subscription`](#post-apitransition-checker-email-subscription)
+- [API errors](#api-errors)
+  - [Unknown attribute names](#unknown-attribute-names)
 - [Healthcheck](#healthcheck)
 
 ## Nomenclature
@@ -344,6 +346,7 @@ Retrieves attribute values for the current user.
 
 #### Response codes
 
+- 422 if any attributes are unknown (see [error: unknown attribute names](#unknown-attribute-names))
 - 401 if the session identifier is invalid
 - 200 otherwise
 
@@ -391,6 +394,7 @@ Updates the attributes of the current user.
 
 #### Response codes
 
+- 422 if any attributes are unknown (see [error: unknown attribute names](#unknown-attribute-names))
 - 401 if the session identifier is invalid
 - 200 otherwise
 
@@ -496,6 +500,35 @@ Response:
     "govuk_account_session": "YWNjZXNzLXRva2Vu.cmVmcmVzaC10b2tlbg=="
 }
 ```
+
+
+## API errors
+
+API errors are returned as an [RFC 7807][] "Problem Detail" object, in
+the following format:
+
+```json
+{
+  "type": "URI which identifies the problem type and points to further information",
+  "title": "Short human-readable summary of the problem type",
+  "detail": "Human-readable explanation of this specific instance of the problem."
+}
+```
+
+Each error type may define additional response fields.
+
+[RFC 7807]: https://tools.ietf.org/html/rfc7807
+
+### Unknown attribute names
+
+One or more of the attribute names you have specified are not known.
+The `attributes` response field lists these.
+
+#### Debugging steps
+
+- check that you don't have a typo in the attribute names
+- check that the attributes are defined in `config/user_attributes.yml`
+- check that you are running the latest version of account-api
 
 
 ## Healthcheck

--- a/spec/fixtures/user_attributes.yml
+++ b/spec/fixtures/user_attributes.yml
@@ -1,0 +1,11 @@
+test_attribute_1:
+  is_stored_locally: false
+
+test_attribute_2:
+  is_stored_locally: false
+
+foo:
+  is_stored_locally: false
+
+bar:
+  is_stored_locally: false

--- a/spec/lib/user_attributes_spec.rb
+++ b/spec/lib/user_attributes_spec.rb
@@ -1,0 +1,5 @@
+RSpec.describe UserAttributes do
+  it "validates the config file" do
+    expect(described_class.new.errors).to be_empty
+  end
+end

--- a/spec/requests/attributes_controller_spec.rb
+++ b/spec/requests/attributes_controller_spec.rb
@@ -82,6 +82,20 @@ RSpec.describe AttributesController do
           expect(JSON.parse(response.body)["values"]).to eq({ attribute_name2 => attribute_value2 })
         end
       end
+
+      context "when some of the attributes are undefined" do
+        let(:bad_attributes) { %w[bad1 bad2] }
+        let(:params) { { attributes: [attribute_name1, attribute_name2] + bad_attributes } }
+
+        it "lists the undefined ones" do
+          get attributes_path, headers: headers, params: params
+          expect(response).to have_http_status(:unprocessable_entity)
+
+          error = JSON.parse(response.body)
+          expect(error["type"]).to eq(I18n.t("errors.unknown_attribute_names.type"))
+          expect(error["attributes"]).to eq(bad_attributes)
+        end
+      end
     end
   end
 

--- a/spec/requests/attributes_controller_spec.rb
+++ b/spec/requests/attributes_controller_spec.rb
@@ -3,10 +3,10 @@ RSpec.describe AttributesController do
 
   let(:headers) { { "Content-Type" => "application/json", "GOVUK-Account-Session" => placeholder_govuk_account_session } }
 
-  let(:attribute_name1) { "name" }
+  # names must be defined in spec/fixtures/user_attributes.yml
+  let(:attribute_name1) { "test_attribute_1" }
+  let(:attribute_name2) { "test_attribute_2" }
   let(:attribute_value1) { { "some" => "complex", "value" => 42 } }
-
-  let(:attribute_name2) { "name2" }
   let(:attribute_value2) { [1, 2, 3, 4, 5] }
 
   describe "GET" do

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -77,6 +77,7 @@ Pact.provider_states_for "GDS API Adapters" do
       stub_request(:get, Plek.find("account-manager") + "/api/v1/transition-checker/email-subscription").to_return(status: 404)
       stub_request(:post, Plek.find("account-manager") + "/api/v1/transition-checker/email-subscription").to_return(status: 200)
       stub_request(:get, "http://openid-provider/v1/attributes/foo").to_return(status: 404)
+      stub_request(:get, "http://openid-provider/v1/attributes/test_attribute_1").to_return(status: 404)
       stub_request(:post, "http://openid-provider/v1/attributes").to_return(status: 200)
     end
   end
@@ -90,6 +91,12 @@ Pact.provider_states_for "GDS API Adapters" do
   provider_state "there is a valid user session, with an attribute called 'foo'" do
     set_up do
       stub_request(:get, "http://openid-provider/v1/attributes/foo").to_return(status: 200, body: { claim_value: { bar: "baz" } }.to_json)
+    end
+  end
+
+  provider_state "there is a valid user session, with an attribute called 'test_attribute_1'" do
+    set_up do
+      stub_request(:get, "http://openid-provider/v1/attributes/test_attribute_1").to_return(status: 200, body: { claim_value: { bar: "baz" } }.to_json)
     end
   end
 end


### PR DESCRIPTION
This PR adds a config file holding attribute details, recording whether an attribute is stored locally or not, and adds validation to the AttributesController to reject unknown attributes.

I've also chosen to return a rejection error as an [RFC 7807 "Problem Detail" object](https://tools.ietf.org/html/rfc7807) because

1. we'll need to return some sort of structured error when we implement levels-of-authentication (to communicate back to the caller which LoA to reauthenticate the user at), and
2. it emphasises having online documentation for each distinct error type, which I think is really nice.

This PR isn't a proposal to standardise GOV.UK on using the RFC; but it would be good to be consistent within this one app at least.

---

[Trello card](https://trello.com/c/0kDToZ6G/709-validate-attribute-names-in-the-account-api)