### PR TITLE
Load seed data before tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,8 @@ RSpec.configure do |config|
     config.after { Bullet.end_request }
   end
 
+  config.before { Rails.application.load_seed }
+
   config.around do |example|
     ClimateControl.modify(GOVUK_ACCOUNT_OAUTH_CLIENT_ID: "client-id", GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET: "client-secret") do
       example.run


### PR DESCRIPTION
Some tests require a User to be present in the database. We create a
Test User in the seeds file but this is not automatically executed
before running the tests.

This config change populates the test database with seed data before
running tests so that the Test User is present.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
