### PR TITLE
Gracefully handle pact not being available at deploy time

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,11 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require "pact/tasks"
+begin
+  require "pact/tasks"
+rescue LoadError
+  # Pact isn't available in all environments
+end
 
 require_relative "config/application"
 


### PR DESCRIPTION
We have precedent for this pattern, eg see how publishing-api handles
rubocop[1].

[1]: https://github.com/alphagov/publishing-api/blob/1f595a4bc6693cc8c44b410bcddc2c1f07fb3f9a/Rakefile
