### PR TITLE
Add RFC 141 healthcheck endpoints

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,11 @@ Rails.application.routes.draw do
     GovukHealthcheck::ActiveRecord,
   )
 
+  get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
+  get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
+    GovukHealthcheck::ActiveRecord,
+  )
+
   scope :api do
     scope :oauth2 do
       get "/sign-in", to: "authentication#sign_in"


### PR DESCRIPTION
Once govuk-puppet has been updated, the old endpoint can be removed.

See the RFC for more details.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)
