### PR TITLE
Remove legacy /healthcheck route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,4 @@
 Rails.application.routes.draw do
-  get "/healthcheck", to: GovukHealthcheck.rack_response(
-    GovukHealthcheck::ActiveRecord,
-  )
-
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
     GovukHealthcheck::ActiveRecord,

--- a/docs/api.md
+++ b/docs/api.md
@@ -20,7 +20,6 @@ management. This API is not for other government services.
   - [`POST /api/transition-checker-email-subscription`](#post-apitransition-checker-email-subscription)
 - [API errors](#api-errors)
   - [Unknown attribute names](#unknown-attribute-names)
-- [Healthcheck](#healthcheck)
 
 ## Nomenclature
 
@@ -529,19 +528,3 @@ The `attributes` response field lists these.
 - check that you don't have a typo in the attribute names
 - check that the attributes are defined in `config/user_attributes.yml`
 - check that you are running the latest version of account-api
-
-
-## Healthcheck
-
-A database health check endpoint is available at `/healthcheck`.
-
-```json
-{
-  "checks": {
-    "database_connectivity": {
-      "status": "ok"
-    }
-  },
-  "status": "ok"
-}
-```


### PR DESCRIPTION
govuk-puppet and govuk-aws have now been updated to only use the new
routes, so the old one is no longer needed.

See RFC 141 for more information.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)
