### PR TITLE
Store the user ID in the session

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -33,6 +33,7 @@ class AuthenticationController < ApplicationController
     render json: {
       govuk_account_session: AccountSession.new(
         session_signing_key: Rails.application.secrets.session_signing_key,
+        user_id: tokens[:id_token].sub,
         access_token: oauth_response.fetch(:access_token),
         refresh_token: oauth_response.fetch(:refresh_token),
         level_of_authentication: oauth_response.fetch(:result).fetch("level_of_authentication"),

--- a/app/lib/account_session.rb
+++ b/app/lib/account_session.rb
@@ -5,14 +5,16 @@ class AccountSession
 
   LOWEST_LEVEL_OF_AUTHENTICATION = "level0"
 
-  attr_reader :level_of_authentication
+  attr_reader :user_id, :level_of_authentication
 
-  def initialize(session_signing_key:, access_token:, refresh_token:, level_of_authentication:)
+  def initialize(session_signing_key:, access_token:, refresh_token:, level_of_authentication:, user_id: nil)
     @session_signing_key = session_signing_key
     @access_token = access_token
     @refresh_token = refresh_token
     @level_of_authentication = level_of_authentication
     @frozen = false
+
+    @user_id = user_id || oidc_do(:userinfo)["sub"]
   end
 
   def self.deserialise(encoded_session:, session_signing_key:)
@@ -55,6 +57,7 @@ class AccountSession
 
   def to_hash
     {
+      user_id: user_id,
       access_token: @access_token,
       refresh_token: @refresh_token,
       level_of_authentication: level_of_authentication,

--- a/app/lib/oidc_client.rb
+++ b/app/lib/oidc_client.rb
@@ -52,6 +52,21 @@ class OidcClient
     raise OAuthFailure
   end
 
+  def userinfo(access_token:, refresh_token:)
+    response = oauth_request(
+      access_token: access_token,
+      refresh_token: refresh_token,
+      method: :get,
+      uri: userinfo_endpoint,
+    )
+
+    begin
+      response.merge(result: JSON.parse(response[:result].body))
+    rescue JSON::ParserError
+      raise OAuthFailure
+    end
+  end
+
   def get_ephemeral_state(access_token:, refresh_token:)
     response = oauth_request(
       access_token: access_token,

--- a/spec/lib/account_session_spec.rb
+++ b/spec/lib/account_session_spec.rb
@@ -1,8 +1,9 @@
 RSpec.describe AccountSession do
+  let(:user_id) { SecureRandom.hex(10) }
   let(:access_token) { SecureRandom.hex(10) }
   let(:refresh_token) { SecureRandom.hex(10) }
   let(:level_of_authentication) { AccountSession::LOWEST_LEVEL_OF_AUTHENTICATION }
-  let(:params) { { access_token: access_token, refresh_token: refresh_token, level_of_authentication: level_of_authentication } }
+  let(:params) { { user_id: user_id, access_token: access_token, refresh_token: refresh_token, level_of_authentication: level_of_authentication }.compact }
 
   describe "serialisation / deserialisation" do
     it "round-trips" do
@@ -24,11 +25,27 @@ RSpec.describe AccountSession do
       expect(described_class.deserialise(encoded_session: "", session_signing_key: "secret")).to be_nil
     end
 
-    it "accepts a legacy unsigned session header" do
-      encoded = "#{Base64.urlsafe_encode64(access_token)}.#{Base64.urlsafe_encode64(refresh_token)}"
-      decoded = described_class.deserialise(encoded_session: encoded, session_signing_key: "secret").to_hash
+    context "when there isn't a user ID in the header" do
+      let(:user_id) { nil }
+      let(:user_id_from_userinfo) { "user-id-from-userinfo" }
 
-      expect(decoded).to eq(params)
+      before do
+        stub_oidc_discovery
+
+        stub_request(:get, "http://openid-provider/userinfo-endpoint")
+          .to_return(status: 200, body: { sub: user_id_from_userinfo }.to_json)
+      end
+
+      it "queries userinfo for the user ID" do
+        expect(described_class.new(session_signing_key: "secret", **params).to_hash).to eq(params.merge(user_id: user_id_from_userinfo))
+      end
+
+      it "accepts a legacy unsigned session header, and queries userinfo for the user ID" do
+        encoded = "#{Base64.urlsafe_encode64(access_token)}.#{Base64.urlsafe_encode64(refresh_token)}"
+        decoded = described_class.deserialise(encoded_session: encoded, session_signing_key: "secret").to_hash
+
+        expect(decoded).to eq(params.merge(user_id: user_id_from_userinfo))
+      end
     end
 
     describe "deserialise_legacy_base64_session" do

--- a/spec/requests/authentication_controller_spec.rb
+++ b/spec/requests/authentication_controller_spec.rb
@@ -1,10 +1,7 @@
 RSpec.describe AuthenticationController do
   before do
     stub_oidc_discovery
-
-    # rubocop:disable RSpec/AnyInstance
-    allow_any_instance_of(OidcClient).to receive(:tokens!).and_return({ access_token: "access-token", refresh_token: "refresh-token" })
-    # rubocop:enable RSpec/AnyInstance
+    stub_token_response
   end
 
   let(:headers) { { "Content-Type" => "application/json" } }

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -41,13 +41,27 @@ Pact.provider_states_for "GDS API Adapters" do
       end_session_endpoint: "http://openid-provider/end-session-endpoint",
     )
 
+    token_response = {
+      access_token: "access-token",
+      refresh_token: "refresh-token",
+      id_token: instance_double(
+        "OpenIDConnect::ResponseObject::IdToken",
+        iss: "http://openid-provider",
+        sub: "user-id",
+        aud: "oauth-client",
+        exp: 300,
+        iat: 0,
+      ),
+    }
+
     # rubocop:disable RSpec/AnyInstance
     allow_any_instance_of(OidcClient).to receive(:discover).and_return(discovery_response)
-    allow_any_instance_of(OidcClient).to receive(:tokens!).and_return({ access_token: "access-token", refresh_token: "refresh-token" })
+    allow_any_instance_of(OidcClient).to receive(:tokens!).and_return(token_response)
     # rubocop:enable RSpec/AnyInstance
 
     account_session = AccountSession.new(
       session_signing_key: Rails.application.secrets.session_signing_key,
+      user_id: "user-id",
       access_token: "access-token",
       refresh_token: "refresh-token",
       level_of_authentication: "level1",

--- a/spec/support/helpers/govuk_account_session_helper.rb
+++ b/spec/support/helpers/govuk_account_session_helper.rb
@@ -1,6 +1,14 @@
 module GovukAccountSessionHelper
-  def placeholder_govuk_account_session(access_token: "access-token", refresh_token: "refresh-token")
-    "#{Base64.urlsafe_encode64(access_token)}.#{Base64.urlsafe_encode64(refresh_token)}"
+  def placeholder_govuk_account_session(options = {})
+    AccountSession.new(
+      **{
+        session_signing_key: Rails.application.secrets.session_signing_key,
+        user_id: "user-id",
+        access_token: "access-token",
+        refresh_token: "refresh-token",
+        level_of_authentication: AccountSession::LOWEST_LEVEL_OF_AUTHENTICATION,
+      }.merge(options),
+    ).serialise
   end
 end
 

--- a/spec/support/helpers/oidc_client_helper.rb
+++ b/spec/support/helpers/oidc_client_helper.rb
@@ -13,6 +13,25 @@ module OidcClientHelper
     # rubocop:enable RSpec/AnyInstance
   end
 
+  def stub_token_response
+    token_response = {
+      access_token: "access-token",
+      refresh_token: "refresh-token",
+      id_token: instance_double(
+        "OpenIDConnect::ResponseObject::IdToken",
+        iss: "http://openid-provider",
+        sub: "user-id",
+        aud: "oauth-client",
+        exp: 300,
+        iat: 0,
+      ),
+    }
+
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(OidcClient).to receive(:tokens!).and_return(token_response)
+    # rubocop:enable RSpec/AnyInstance
+  end
+
   def stub_oidc_client(client = nil)
     oidc_client = instance_double("OpenIDConnect::Client")
 


### PR DESCRIPTION
When we start storing information in the account-api database, like
attributes or saved pages, we'll need an identifier to save them
under.  In preparation, this PR stores the user ID from the OIDC ID
Token in the session.

To upgrade existing sessions, the OIDC UserInfo endpoint is called to
fetch the ID.
