### PR TITLE
Enforce levels of authentication, gated behind a feature flag

### DIFF
--- a/app/controllers/attributes_controller.rb
+++ b/app/controllers/attributes_controller.rb
@@ -2,7 +2,10 @@ class AttributesController < ApplicationController
   before_action :require_govuk_account_session!
 
   def show
-    remote_attributes = get_attributes_from_params(params.fetch(:attributes))
+    remote_attributes = get_attributes_from_params(
+      params.fetch(:attributes),
+      permission_level: :get,
+    )
 
     values = @govuk_account_session.get_remote_attributes(remote_attributes)
 
@@ -15,7 +18,11 @@ class AttributesController < ApplicationController
   end
 
   def update
-    remote_attributes = get_attributes_from_params(params.fetch(:attributes).permit!.to_h, is_hash: true)
+    remote_attributes = get_attributes_from_params(
+      params.fetch(:attributes).permit!.to_h,
+      permission_level: :set,
+      is_hash: true,
+    )
 
     @govuk_account_session.set_remote_attributes(remote_attributes)
 
@@ -28,11 +35,17 @@ class AttributesController < ApplicationController
 
 private
 
-  def get_attributes_from_params(attributes, is_hash: false)
+  def get_attributes_from_params(attributes, permission_level:, is_hash: false)
     attribute_names = is_hash ? attributes.keys : attributes
 
     unknown_attributes = attribute_names.reject { |name| user_attributes.defined? name }
-    raise ApiError::UnknownAttributeNames, unknown_attributes if unknown_attributes.any?
+    raise ApiError::UnknownAttributeNames, { attributes: unknown_attributes } if unknown_attributes.any?
+
+    forbidden_attributes = attribute_names.reject { |name| user_attributes.has_permission_for? name, permission_level, @govuk_account_session }
+    if forbidden_attributes.any?
+      needed_level_of_authentication = forbidden_attributes.map { |name| user_attributes.level_of_authentication_for name, permission_level }.max
+      raise ApiError::LevelOfAuthenticationTooLow, { attributes: forbidden_attributes, needed_level_of_authentication: needed_level_of_authentication }
+    end
 
     local_attributes = attributes.select { |name| user_attributes.stored_locally? name }
     remote_attributes = attributes.reject { |name| user_attributes.stored_locally? name }

--- a/app/controllers/attributes_controller.rb
+++ b/app/controllers/attributes_controller.rb
@@ -41,10 +41,12 @@ private
     unknown_attributes = attribute_names.reject { |name| user_attributes.defined? name }
     raise ApiError::UnknownAttributeNames, { attributes: unknown_attributes } if unknown_attributes.any?
 
-    forbidden_attributes = attribute_names.reject { |name| user_attributes.has_permission_for? name, permission_level, @govuk_account_session }
-    if forbidden_attributes.any?
-      needed_level_of_authentication = forbidden_attributes.map { |name| user_attributes.level_of_authentication_for name, permission_level }.max
-      raise ApiError::LevelOfAuthenticationTooLow, { attributes: forbidden_attributes, needed_level_of_authentication: needed_level_of_authentication }
+    if Rails.application.config.feature_flag_enforce_levels_of_authentication
+      forbidden_attributes = attribute_names.reject { |name| user_attributes.has_permission_for? name, permission_level, @govuk_account_session }
+      if forbidden_attributes.any?
+        needed_level_of_authentication = forbidden_attributes.map { |name| user_attributes.level_of_authentication_for name, permission_level }.max
+        raise ApiError::LevelOfAuthenticationTooLow, { attributes: forbidden_attributes, needed_level_of_authentication: needed_level_of_authentication }
+      end
     end
 
     local_attributes = attributes.select { |name| user_attributes.stored_locally? name }

--- a/app/lib/account_session.rb
+++ b/app/lib/account_session.rb
@@ -52,6 +52,10 @@ class AccountSession
     nil
   end
 
+  def level_of_authentication_as_integer
+    @level_of_authentication_as_integer ||= LevelOfAuthentication.name_to_integer level_of_authentication
+  end
+
   def serialise
     @frozen = true
     StringEncryptor.new(signing_key: session_signing_key).encrypt_string(to_hash.to_json)

--- a/app/lib/api_error/level_of_authentication_too_low.rb
+++ b/app/lib/api_error/level_of_authentication_too_low.rb
@@ -1,0 +1,27 @@
+module ApiError
+  class LevelOfAuthenticationTooLow < ApiError::Base
+    def initialize(attributes:, needed_level_of_authentication:)
+      @attributes = attributes
+      @needed_level_of_authentication = LevelOfAuthentication.integer_to_name needed_level_of_authentication
+    end
+
+    def status_code
+      :forbidden
+    end
+
+    def detail
+      I18n.t(
+        "errors.level_of_authentication_too_low.detail",
+        attributes: @attributes.join(", "),
+        needed_level_of_authentication: @needed_level_of_authentication,
+      )
+    end
+
+    def extra_detail
+      {
+        attributes: @attributes,
+        needed_level_of_authentication: @needed_level_of_authentication,
+      }
+    end
+  end
+end

--- a/app/lib/api_error/unknown_attribute_names.rb
+++ b/app/lib/api_error/unknown_attribute_names.rb
@@ -1,16 +1,16 @@
 module ApiError
   class UnknownAttributeNames < ApiError::Base
-    def initialize(attribute_names)
-      @attribute_names = attribute_names
+    def initialize(attributes:)
+      @attributes = attributes
     end
 
     def detail
-      I18n.t("errors.unknown_attribute_names.detail", attribute_names: @attribute_names.join(", "))
+      I18n.t("errors.unknown_attribute_names.detail", attributes: @attributes.join(", "))
     end
 
     def extra_detail
       {
-        attributes: @attribute_names,
+        attributes: @attributes,
       }
     end
   end

--- a/app/lib/level_of_authentication.rb
+++ b/app/lib/level_of_authentication.rb
@@ -1,0 +1,9 @@
+module LevelOfAuthentication
+  def self.name_to_integer(name)
+    Integer(name.delete_prefix("level"))
+  end
+
+  def self.integer_to_name(integer)
+    "level#{integer}"
+  end
+end

--- a/app/lib/user_attributes.rb
+++ b/app/lib/user_attributes.rb
@@ -5,16 +5,7 @@ class UserAttributes
   attr_reader :attributes
 
   def initialize(attributes = nil)
-    if attributes
-      @attributes = attributes
-    else
-      @attributes = YAML.safe_load(File.read(Rails.root.join("config/user_attributes.yml"))).with_indifferent_access
-
-      if Rails.env.test?
-        test_attributes = YAML.safe_load(File.read(Rails.root.join("spec/fixtures/user_attributes.yml"))).with_indifferent_access
-        @attributes.merge!(test_attributes)
-      end
-    end
+    @attributes = attributes || UserAttributes.load_config_file
   end
 
   def defined?(name)
@@ -75,5 +66,9 @@ class UserAttributes
 
       errors[name] = this_errors if this_errors.any?
     end
+  end
+
+  def self.load_config_file
+    YAML.safe_load(File.read(Rails.root.join("config/user_attributes.yml"))).with_indifferent_access
   end
 end

--- a/app/lib/user_attributes.rb
+++ b/app/lib/user_attributes.rb
@@ -25,6 +25,14 @@ class UserAttributes
     attributes.fetch(name)[:is_stored_locally]
   end
 
+  def has_permission_for?(name, permission_level, user_session)
+    user_session.level_of_authentication_as_integer >= level_of_authentication_for(name, permission_level)
+  end
+
+  def level_of_authentication_for(name, permission_level)
+    attributes.fetch(name)[:permissions].fetch(permission_level)
+  end
+
   def self.validate(attributes)
     new(attributes).errors
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,5 +36,7 @@ module AccountApi
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    config.feature_flag_enforce_levels_of_authentication = ENV["FEATURE_FLAG_ENFORCE_LEVELS_OF_AUTHENTICATION"] == "enabled"
   end
 end

--- a/config/locales/errors.en.yml
+++ b/config/locales/errors.en.yml
@@ -1,7 +1,11 @@
 ---
 en:
   errors:
+    level_of_authentication_too_low:
+      type: https://github.com/alphagov/account-api/blob/main/docs/api.md#level-of-authentication-too-low
+      title: Level of authentication too low
+      detail: Attributes %{attributes} require at least %{needed_level_of_authentication}, which is greater level of authentication that you currently have.
     unknown_attribute_names:
       type: https://github.com/alphagov/account-api/blob/main/docs/api.md#unknown-attribute-names
       title: Unknown attribute names
-      detail: Attribute names %{attribute_names} are unknown, have they been added to config/user_attributes.yml?
+      detail: Attribute names %{attributes} are unknown, have they been added to config/user_attributes.yml?

--- a/config/user_attributes.yml
+++ b/config/user_attributes.yml
@@ -1,3 +1,7 @@
 ---
 transition_checker_state:
   is_stored_locally: false
+  permissions:
+    check: 0
+    get: 0
+    set: 1

--- a/docs/api.md
+++ b/docs/api.md
@@ -19,6 +19,7 @@ management. This API is not for other government services.
   - [`GET /api/transition-checker-email-subscription`](#get-apitransition-checker-email-subscription)
   - [`POST /api/transition-checker-email-subscription`](#post-apitransition-checker-email-subscription)
 - [API errors](#api-errors)
+  - [Level of authentication too low](#level-of-authentication-too-low)
   - [Unknown attribute names](#unknown-attribute-names)
 
 ## Nomenclature
@@ -346,6 +347,7 @@ Retrieves attribute values for the current user.
 #### Response codes
 
 - 422 if any attributes are unknown (see [error: unknown attribute names](#unknown-attribute-names))
+- 403 if the session's level of authentication is too low (see [error: level of authentication too low](#level-of-authentication-too-low))
 - 401 if the session identifier is invalid
 - 200 otherwise
 
@@ -394,6 +396,7 @@ Updates the attributes of the current user.
 #### Response codes
 
 - 422 if any attributes are unknown (see [error: unknown attribute names](#unknown-attribute-names))
+- 403 if the session's level of authentication is too low (see [error: level of authentication too low](#level-of-authentication-too-low))
 - 401 if the session identifier is invalid
 - 200 otherwise
 
@@ -517,6 +520,18 @@ the following format:
 Each error type may define additional response fields.
 
 [RFC 7807]: https://tools.ietf.org/html/rfc7807
+
+### Level of authentication too low
+
+You have tried to access something which the current user is not
+authenticated highly enough to use.  The
+`needed_level_of_authentication` response field gives the required
+level.
+
+#### Debugging steps
+
+This is not an error, the user must be reauthenticated at the higher
+level to access.
 
 ### Unknown attribute names
 

--- a/spec/fixtures/user_attributes.yml
+++ b/spec/fixtures/user_attributes.yml
@@ -1,11 +1,27 @@
 test_attribute_1:
   is_stored_locally: false
+  permissions:
+    check: 0
+    get: 0
+    set: 0
 
 test_attribute_2:
   is_stored_locally: false
+  permissions:
+    check: 0
+    get: 0
+    set: 0
 
 foo:
   is_stored_locally: false
+  permissions:
+    check: 0
+    get: 0
+    set: 0
 
 bar:
   is_stored_locally: false
+  permissions:
+    check: 0
+    get: 0
+    set: 0

--- a/spec/lib/user_attributes_spec.rb
+++ b/spec/lib/user_attributes_spec.rb
@@ -5,8 +5,10 @@ RSpec.describe UserAttributes do
 
   describe "validation" do
     let(:attributes) { { "foo" => foo_properties, "bar" => bar_properties } }
-    let(:foo_properties) { { "is_stored_locally" => true } }
-    let(:bar_properties) { { "is_stored_locally" => false } }
+    let(:foo_properties) { { "is_stored_locally" => true, "permissions" => foo_permissions } }
+    let(:foo_permissions) { { "check" => 0, "get" => 0, "set" => 1 } }
+    let(:bar_properties) { { "is_stored_locally" => false, "permissions" => bar_permissions } }
+    let(:bar_permissions) { { "check" => 1, "get" => 1, "set" => 1 } }
 
     let(:errors) { described_class.validate(attributes) }
 
@@ -14,27 +16,71 @@ RSpec.describe UserAttributes do
       expect(errors).to eq({})
     end
 
-    context "when a key is missing" do
-      let(:foo_properties) { {} }
+    describe "errors with top-level keys" do
+      context "when a key is missing" do
+        let(:foo_properties) { {} }
 
-      it "rejects" do
-        expect(errors).to eq({ "foo" => { missing_keys: %w[is_stored_locally] } })
+        it "rejects" do
+          expect(errors).to eq({ "foo" => { missing_keys: %w[is_stored_locally permissions] } })
+        end
+      end
+
+      context "when an unexpected top-level key is present" do
+        let(:bar_properties) { { "is_stored_loally" => true, "permissions" => bar_permissions } }
+
+        it "rejects" do
+          expect(errors).to eq({ "bar" => { missing_keys: %w[is_stored_locally], unknown_keys: %w[is_stored_loally] } })
+        end
+      end
+
+      context "when a key has an unexpected value" do
+        let(:foo_properties) { { "is_stored_locally" => "banana", "permissions" => foo_permissions } }
+
+        it "rejects" do
+          expect(errors).to eq({ "foo" => { invalid_keys: %w[is_stored_locally] } })
+        end
       end
     end
 
-    context "when an unexpected key is present" do
-      let(:bar_properties) { { "is_stored_loally" => true } }
+    describe "errors with permission keys" do
+      context "when a key is missing" do
+        let(:foo_permissions) { { "get" => 1 } }
 
-      it "rejects" do
-        expect(errors).to eq({ "bar" => { missing_keys: %w[is_stored_locally], unknown_keys: %w[is_stored_loally] } })
+        it "rejects" do
+          expect(errors).to eq({ "foo" => { missing_keys: %w[permissions.check permissions.set] } })
+        end
       end
-    end
 
-    context "when a key has an unexpected value" do
-      let(:foo_properties) { { "is_stored_locally" => "truee" } }
+      context "when an unexpected key is present" do
+        let(:foo_permissions) { { "check" => 1, "get" => 1, "sett" => 1 } }
 
-      it "rejects" do
-        expect(errors).to eq({ "foo" => { invalid_keys: %w[is_stored_locally] } })
+        it "rejects" do
+          expect(errors).to eq({ "foo" => { missing_keys: %w[permissions.set], unknown_keys: %w[permissions.sett] } })
+        end
+      end
+
+      context "when a key has an non-integral value" do
+        let(:foo_permissions) { { "check" => "apple", "get" => 1, "set" => 1 } }
+
+        it "rejects" do
+          expect(errors).to eq({ "foo" => { invalid_keys: %w[permissions.check] } })
+        end
+      end
+
+      context "when check requires a higher permission than get" do
+        let(:foo_permissions) { { "check" => 1, "get" => 0, "set" => 0 } }
+
+        it "rejects" do
+          expect(errors).to eq({ "foo" => { invalid_keys: %w[permissions.check] } })
+        end
+      end
+
+      context "when get requires a higher permission than set" do
+        let(:foo_permissions) { { "check" => 0, "get" => 1, "set" => 0 } }
+
+        it "rejects" do
+          expect(errors).to eq({ "foo" => { invalid_keys: %w[permissions.get] } })
+        end
       end
     end
   end

--- a/spec/lib/user_attributes_spec.rb
+++ b/spec/lib/user_attributes_spec.rb
@@ -2,4 +2,40 @@ RSpec.describe UserAttributes do
   it "validates the config file" do
     expect(described_class.new.errors).to be_empty
   end
+
+  describe "validation" do
+    let(:attributes) { { "foo" => foo_properties, "bar" => bar_properties } }
+    let(:foo_properties) { { "is_stored_locally" => true } }
+    let(:bar_properties) { { "is_stored_locally" => false } }
+
+    let(:errors) { described_class.validate(attributes) }
+
+    it "accepts valid configuration" do
+      expect(errors).to eq({})
+    end
+
+    context "when a key is missing" do
+      let(:foo_properties) { {} }
+
+      it "rejects" do
+        expect(errors).to eq({ "foo" => { missing_keys: %w[is_stored_locally] } })
+      end
+    end
+
+    context "when an unexpected key is present" do
+      let(:bar_properties) { { "is_stored_loally" => true } }
+
+      it "rejects" do
+        expect(errors).to eq({ "bar" => { missing_keys: %w[is_stored_locally], unknown_keys: %w[is_stored_loally] } })
+      end
+    end
+
+    context "when a key has an unexpected value" do
+      let(:foo_properties) { { "is_stored_locally" => "truee" } }
+
+      it "rejects" do
+        expect(errors).to eq({ "foo" => { invalid_keys: %w[is_stored_locally] } })
+      end
+    end
+  end
 end

--- a/spec/requests/attributes_controller_spec.rb
+++ b/spec/requests/attributes_controller_spec.rb
@@ -1,5 +1,10 @@
 RSpec.describe AttributesController do
-  before { stub_oidc_discovery }
+  before do
+    stub_oidc_discovery
+
+    fixture_file = YAML.safe_load(File.read(Rails.root.join("spec/fixtures/user_attributes.yml"))).with_indifferent_access
+    allow(UserAttributes).to receive(:load_config_file).and_return(fixture_file)
+  end
 
   let(:session_identifier) { placeholder_govuk_account_session }
   let(:headers) { { "Content-Type" => "application/json", "GOVUK-Account-Session" => session_identifier } }

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -68,6 +68,9 @@ Pact.provider_states_for "GDS API Adapters" do
     )
     allow(AccountSession).to receive(:deserialise).and_return(account_session)
 
+    fixture_file = YAML.safe_load(File.read(Rails.root.join("spec/fixtures/user_attributes.yml"))).with_indifferent_access
+    allow(UserAttributes).to receive(:load_config_file).and_return(fixture_file)
+
     stub_request(:post, Plek.find("account-manager") + "/api/v1/jwt").to_return(status: 200, body: { id: "jwt-id" }.to_json)
   end
 


### PR DESCRIPTION
We can't switch this feature on until we have a way to authenticate a user to a specific level (there's a separate card for that) and then update finder-frontend to gracefully handle 403 errors.

Something I'm not entirely satisfied with in this PR is how the level of authentication stored in the session is a string, but really for comparison purposes we want an integer:

- Strings are good because it means that we're going to be using the same level names as Digital Identity, reducing the potential for confusion.
- Integers are good because we need a total ordering, which ideally is pretty efficient to compute, on the levels.

Having both is perhaps not so good, but I think the advantage of keeping around the original level in the session is good, because it means that if Digital Identity update their levels, we can handle that gracefully, as we already have a level-to-integer conversion going on.

---

[Trello card](https://trello.com/c/G2uYUDuz/716-check-the-level-of-authentication-when-using-attributes-in-the-account-api)