### PR TITLE
Return nil when a session has expired tokens and cannot fetch the ID

### DIFF
--- a/app/lib/account_session.rb
+++ b/app/lib/account_session.rb
@@ -34,6 +34,8 @@ class AccountSession
         session_signing_key: session_signing_key,
       )
     end
+  rescue OidcClient::OAuthFailure
+    nil
   end
 
   def self.deserialise_legacy_base64_session(encoded_session:, session_signing_key:)


### PR DESCRIPTION
If a session is sufficiently old, it may have expired tokens in it,
which cause the UserInfo request to fail.

Elsewhere in the app we catch the OAuth failure and return a 401
response (logging the user out) so, to be consistent with that, if the
user's session has expired tokens then log them out.
