### PR TITLE
Implement support for local attributes

### DIFF
--- a/app/controllers/attributes/names_controller.rb
+++ b/app/controllers/attributes/names_controller.rb
@@ -1,10 +1,13 @@
 class Attributes::NamesController < AttributesController
   def show
-    remote_attributes = get_attributes_from_params(
+    local_attributes, remote_attributes = get_attributes_from_params(
       params.fetch(:attributes),
       permission_level: :check,
     )
 
-    render_api_response values: @govuk_account_session.get_remote_attributes(remote_attributes).compact.keys
+    values = @govuk_account_session.get_local_attributes(local_attributes)
+      .merge(@govuk_account_session.get_remote_attributes(remote_attributes))
+
+    render_api_response values: values.compact.keys
   end
 end

--- a/app/controllers/attributes/names_controller.rb
+++ b/app/controllers/attributes/names_controller.rb
@@ -1,13 +1,8 @@
 class Attributes::NamesController < AttributesController
   def show
-    local_attributes, remote_attributes = get_attributes_from_params(
-      params.fetch(:attributes),
-      permission_level: :check,
-    )
+    attributes = params.fetch(:attributes)
+    validate_attributes!(attributes, :check)
 
-    values = @govuk_account_session.get_local_attributes(local_attributes)
-      .merge(@govuk_account_session.get_remote_attributes(remote_attributes))
-
-    render_api_response values: values.compact.keys
+    render_api_response values: @govuk_account_session.get_attributes(attributes).keys
   end
 end

--- a/app/controllers/attributes/names_controller.rb
+++ b/app/controllers/attributes/names_controller.rb
@@ -1,6 +1,5 @@
 class Attributes::NamesController < AttributesController
   def show
-    attributes = params.fetch(:attributes)
     validate_attributes!(attributes, :check)
 
     render_api_response values: @govuk_account_session.get_attributes(attributes).keys

--- a/app/controllers/attributes_controller.rb
+++ b/app/controllers/attributes_controller.rb
@@ -2,14 +2,13 @@ class AttributesController < ApplicationController
   include AuthenticatedApiConcern
 
   def show
-    attributes = params.fetch(:attributes)
     validate_attributes!(attributes, :get)
 
     render_api_response values: @govuk_account_session.get_attributes(attributes)
   end
 
   def update
-    attributes = params.fetch(:attributes).permit!.to_h
+    @attributes = attributes.permit!.to_h
     validate_attributes!(attributes.keys, :set)
 
     @govuk_account_session.set_attributes(attributes)
@@ -17,6 +16,10 @@ class AttributesController < ApplicationController
   end
 
 private
+
+  def attributes
+    @attributes ||= params.fetch(:attributes)
+  end
 
   def validate_attributes!(attribute_names, permission_level)
     unknown_attributes = attribute_names.reject { |name| user_attributes.defined? name }

--- a/app/lib/account_session.rb
+++ b/app/lib/account_session.rb
@@ -52,6 +52,10 @@ class AccountSession
     nil
   end
 
+  def user
+    OidcUser.find_or_create_by!(sub: user_id)
+  end
+
   def level_of_authentication_as_integer
     @level_of_authentication_as_integer ||= LevelOfAuthentication.name_to_integer level_of_authentication
   end

--- a/app/lib/account_session.rb
+++ b/app/lib/account_session.rb
@@ -74,6 +74,20 @@ class AccountSession
     }
   end
 
+  def get_local_attributes(local_attributes)
+    user.local_attributes.where(name: local_attributes).map { |attr| [attr.name, attr.value] }.to_h
+  end
+
+  def set_local_attributes(local_attributes)
+    return if local_attributes.empty?
+
+    LocalAttribute.upsert_all(
+      local_attributes.map { |name, value| { oidc_user_id: user.id, name: name, value: value } },
+      unique_by: :index_local_attributes_on_oidc_user_id_and_name,
+      returning: false,
+    )
+  end
+
   def get_remote_attributes(remote_attributes)
     remote_attributes.index_with { |name| oidc_do :get_attribute, { attribute: name } }
   end

--- a/app/models/local_attribute.rb
+++ b/app/models/local_attribute.rb
@@ -1,0 +1,3 @@
+class LocalAttribute < ApplicationRecord
+  belongs_to :oidc_user
+end

--- a/app/models/oidc_user.rb
+++ b/app/models/oidc_user.rb
@@ -1,0 +1,2 @@
+class OidcUser < ApplicationRecord
+end

--- a/app/models/oidc_user.rb
+++ b/app/models/oidc_user.rb
@@ -1,2 +1,3 @@
 class OidcUser < ApplicationRecord
+  has_many :local_attributes, dependent: :destroy
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -15,6 +15,7 @@ Rails.application.configure do
     Bullet.enable = true
     Bullet.bullet_logger = true
     Bullet.rails_logger = true
+    Bullet.raise = true
   end
 
   # Do not eager load code on boot. This avoids loading your whole application

--- a/db/migrate/20210429121634_create_oidc_users.rb
+++ b/db/migrate/20210429121634_create_oidc_users.rb
@@ -1,0 +1,11 @@
+class CreateOidcUsers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :oidc_users do |t|
+      t.string :sub, null: false
+
+      t.timestamps default: -> { "now()" }, null: false
+    end
+
+    add_index :oidc_users, :sub, unique: true
+  end
+end

--- a/db/migrate/20210429123551_create_local_attributes.rb
+++ b/db/migrate/20210429123551_create_local_attributes.rb
@@ -1,0 +1,13 @@
+class CreateLocalAttributes < ActiveRecord::Migration[6.1]
+  def change
+    create_table :local_attributes do |t|
+      t.references :oidc_user, null: false
+      t.string     :name,      null: false
+      t.jsonb      :value,     null: false
+
+      t.timestamps default: -> { "now()" }, null: false
+    end
+
+    add_index :local_attributes, %i[oidc_user_id name], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_29_121634) do
+ActiveRecord::Schema.define(version: 2021_04_29_123551) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,16 @@ ActiveRecord::Schema.define(version: 2021_04_29_121634) do
     t.string "redirect_path"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "local_attributes", force: :cascade do |t|
+    t.bigint "oidc_user_id", null: false
+    t.string "name", null: false
+    t.jsonb "value", null: false
+    t.datetime "created_at", precision: 6, default: -> { "now()" }, null: false
+    t.datetime "updated_at", precision: 6, default: -> { "now()" }, null: false
+    t.index ["oidc_user_id", "name"], name: "index_local_attributes_on_oidc_user_id_and_name", unique: true
+    t.index ["oidc_user_id"], name: "index_local_attributes_on_oidc_user_id"
   end
 
   create_table "oidc_users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_10_153334) do
+ActiveRecord::Schema.define(version: 2021_04_29_121634) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,13 @@ ActiveRecord::Schema.define(version: 2021_03_10_153334) do
     t.string "redirect_path"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "oidc_users", force: :cascade do |t|
+    t.string "sub", null: false
+    t.datetime "created_at", precision: 6, default: -> { "now()" }, null: false
+    t.datetime "updated_at", precision: 6, default: -> { "now()" }, null: false
+    t.index ["sub"], name: "index_oidc_users_on_sub", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/fixtures/user_attributes.yml
+++ b/spec/fixtures/user_attributes.yml
@@ -12,6 +12,13 @@ test_attribute_2:
     get: 0
     set: 0
 
+test_local_attribute:
+  is_stored_locally: true
+  permissions:
+    check: 0
+    get: 0
+    set: 0
+
 foo:
   is_stored_locally: false
   permissions:

--- a/spec/lib/account_session_spec.rb
+++ b/spec/lib/account_session_spec.rb
@@ -72,6 +72,24 @@ RSpec.describe AccountSession do
     end
   end
 
+  describe "user" do
+    let(:account_session) { described_class.new(session_signing_key: "key", **params) }
+
+    it "returns a user with the same 'sub' as the session" do
+      expect(account_session.user.sub).to eq(account_session.user_id)
+    end
+
+    it "creates a user record if one does not exist" do
+      expect { account_session.user }.to change(OidcUser, :count)
+    end
+
+    it "re-uses a user record if one does exist" do
+      current_user = account_session.user
+      expect { account_session.user }.not_to change(OidcUser, :count)
+      expect(account_session.user.id).to eq(current_user.id)
+    end
+  end
+
   describe "OAuth" do
     before { stub_oidc_discovery }
 

--- a/spec/lib/account_session_spec.rb
+++ b/spec/lib/account_session_spec.rb
@@ -1,9 +1,22 @@
 RSpec.describe AccountSession do
+  before do
+    stub_oidc_discovery
+
+    fixture_file = YAML.safe_load(File.read(Rails.root.join("spec/fixtures/user_attributes.yml"))).with_indifferent_access
+    allow(UserAttributes).to receive(:load_config_file).and_return(fixture_file)
+  end
+
   let(:user_id) { SecureRandom.hex(10) }
   let(:access_token) { SecureRandom.hex(10) }
   let(:refresh_token) { SecureRandom.hex(10) }
   let(:level_of_authentication) { AccountSession::LOWEST_LEVEL_OF_AUTHENTICATION }
   let(:params) { { user_id: user_id, access_token: access_token, refresh_token: refresh_token, level_of_authentication: level_of_authentication }.compact }
+  let(:account_session) { described_class.new(session_signing_key: "key", **params) }
+
+  it "throws an error if making an OAuth call after serialising the session" do
+    account_session.serialise
+    expect { account_session.get_attributes(%w[foo bar]) }.to raise_error(AccountSession::Frozen)
+  end
 
   describe "serialisation / deserialisation" do
     it "round-trips" do
@@ -31,8 +44,6 @@ RSpec.describe AccountSession do
       let(:userinfo_status) { 200 }
 
       before do
-        stub_oidc_discovery
-
         stub_request(:get, "http://openid-provider/userinfo-endpoint")
           .to_return(status: userinfo_status, body: { sub: user_id_from_userinfo }.to_json)
       end
@@ -73,8 +84,6 @@ RSpec.describe AccountSession do
   end
 
   describe "user" do
-    let(:account_session) { described_class.new(session_signing_key: "key", **params) }
-
     it "returns a user with the same 'sub' as the session" do
       expect(account_session.user.sub).to eq(account_session.user_id)
     end
@@ -90,37 +99,15 @@ RSpec.describe AccountSession do
     end
   end
 
-  describe "local attributes" do
-    let(:account_session) { described_class.new(session_signing_key: "key", **params) }
-
-    it "handles an empty list of attributes" do
-      expect { account_session.set_local_attributes({}) }.not_to change(LocalAttribute, :count)
-    end
-
-    it "round-trips complex local attributes" do
-      local_attributes = { "foo" => %w[list of words], "bar" => { "some" => { "nested" => ["thing", 1, 2, 3] } } }
-
-      expect { account_session.set_local_attributes(local_attributes) }.to change(LocalAttribute, :count)
-      expect(account_session.get_local_attributes(local_attributes.keys)).to eq(local_attributes)
-    end
-  end
-
-  describe "OAuth" do
-    before { stub_oidc_discovery }
-
-    let(:account_session) { described_class.new(session_signing_key: "key", **params) }
-
-    let(:attribute_name1) { "foo" }
-    let(:attribute_name2) { "bar" }
+  describe "attributes" do
+    let(:attribute_name1) { "test_attribute_1" }
+    let(:attribute_name2) { "test_attribute_2" }
+    let(:local_attribute_name) { "test_local_attribute" }
     let(:attribute_value1) { { "some" => "complex", "value" => 42 } }
     let(:attribute_value2) { [1, 2, 3, 4, 5] }
+    let(:local_attribute_value) { [1, 2, { "buckle" => %w[my shoe] }] }
 
-    it "throws an error if making an OAuth call after serialising the session" do
-      account_session.serialise
-      expect { account_session.get_remote_attributes(%w[foo bar]) }.to raise_error(AccountSession::Frozen)
-    end
-
-    describe "get_remote_attributes" do
+    describe "get_attributes" do
       before do
         stub_request(:get, "http://openid-provider/v1/attributes/#{attribute_name1}")
           .to_return(status: status, body: { claim_value: attribute_value1 }.compact.to_json)
@@ -131,42 +118,65 @@ RSpec.describe AccountSession do
       let(:status) { 200 }
 
       it "returns the attributes" do
-        expect(account_session.get_remote_attributes([attribute_name1, attribute_name2])).to eq({ attribute_name1 => attribute_value1, attribute_name2 => attribute_value2 })
+        LocalAttribute.create!(
+          oidc_user: OidcUser.find_or_create_by(sub: user_id),
+          name: local_attribute_name,
+          value: local_attribute_value,
+        )
+
+        values = account_session.get_attributes([attribute_name1, attribute_name2, local_attribute_name])
+        expect(values).to eq({ attribute_name1 => attribute_value1, attribute_name2 => attribute_value2, local_attribute_name => local_attribute_value })
       end
 
       context "when some attributes are not found" do
         let(:status) { 404 }
 
         it "returns no value" do
-          expect(account_session.get_remote_attributes([attribute_name1, attribute_name2])).to eq({ attribute_name1 => nil, attribute_name2 => attribute_value2 })
+          expect(account_session.get_attributes([attribute_name1, attribute_name2])).to eq({ attribute_name2 => attribute_value2 })
         end
       end
     end
 
-    describe "set_remote_attributes" do
-      let(:attributes) { { attribute_name1 => attribute_value1, attribute_name2 => attribute_value2 } }
+    describe "set_attributes" do
+      let(:remote_attributes) { { attribute_name1 => attribute_value1, attribute_name2 => attribute_value2 } }
+      let(:local_attributes) { { local_attribute_name => local_attribute_value } }
+      let(:attributes) { remote_attributes.merge(local_attributes) }
 
-      it "calls the attribute service" do
-        stub = stub_request(:post, "http://openid-provider/v1/attributes")
-          .with(body: { attributes: attributes.transform_values(&:to_json) })
-          .to_return(status: 200)
-
-        account_session.set_remote_attributes attributes
+      it "calls the attribute service for remote attributes, calls the database for local attributes" do
+        stub = stub_set_remote_attributes
+        expect { account_session.set_attributes(attributes) }.to change(LocalAttribute, :count)
         expect(stub).to have_been_made
       end
 
-      context "when there are no attributes" do
-        it "doesn't call the attribute service" do
-          stub = stub_request(:post, "http://openid-provider/v1/attributes")
-            .with(body: { attributes: {} })
-            .to_return(status: 200)
+      context "when there are no local attributes" do
+        let(:local_attributes) { {} }
 
-          account_session.set_remote_attributes({})
+        it "doesn't update the database" do
+          stub = stub_set_remote_attributes
+          expect { account_session.set_attributes(attributes) }.not_to change(LocalAttribute, :count)
+          expect(stub).to have_been_made
+        end
+      end
+
+      context "when there are no remote attributes" do
+        let(:remote_attributes) { {} }
+
+        it "doesn't call the attribute service" do
+          stub = stub_set_remote_attributes
+          account_session.set_attributes(attributes)
           expect(stub).not_to have_been_made
         end
       end
-    end
 
+      def stub_set_remote_attributes
+        stub_request(:post, "http://openid-provider/v1/attributes")
+          .with(body: { attributes: remote_attributes.transform_values(&:to_json) })
+          .to_return(status: 200)
+      end
+    end
+  end
+
+  describe "email subscriptions" do
     describe "has_email_subscription?" do
       before do
         stub_request(:get, Plek.find("account-manager") + "/api/v1/transition-checker/email-subscription").to_return(status: status)

--- a/spec/lib/account_session_spec.rb
+++ b/spec/lib/account_session_spec.rb
@@ -90,6 +90,21 @@ RSpec.describe AccountSession do
     end
   end
 
+  describe "local attributes" do
+    let(:account_session) { described_class.new(session_signing_key: "key", **params) }
+
+    it "handles an empty list of attributes" do
+      expect { account_session.set_local_attributes({}) }.not_to change(LocalAttribute, :count)
+    end
+
+    it "round-trips complex local attributes" do
+      local_attributes = { "foo" => %w[list of words], "bar" => { "some" => { "nested" => ["thing", 1, 2, 3] } } }
+
+      expect { account_session.set_local_attributes(local_attributes) }.to change(LocalAttribute, :count)
+      expect(account_session.get_local_attributes(local_attributes.keys)).to eq(local_attributes)
+    end
+  end
+
   describe "OAuth" do
     before { stub_oidc_discovery }
 

--- a/spec/requests/attributes/names_controller_spec.rb
+++ b/spec/requests/attributes/names_controller_spec.rb
@@ -12,11 +12,13 @@ RSpec.describe Attributes::NamesController do
   # names must be defined in spec/fixtures/user_attributes.yml
   let(:attribute_name1) { "test_attribute_1" }
   let(:attribute_name2) { "test_attribute_2" }
+  let(:local_attribute_name) { "test_local_attribute" }
   let(:unknown_attribute_name1) { "this_does_not_exist1" }
   let(:unknown_attribute_name2) { "this_does_not_exist2" }
 
   let(:attribute_value1) { "some_value1" }
   let(:attribute_value2) { "some_value2" }
+  let(:local_attribute_value) { [1, 2, { "buckle" => %w[my shoe] }] }
 
   let(:status) { 200 }
   let(:response_body) { JSON.parse(response.body) }
@@ -69,20 +71,27 @@ RSpec.describe Attributes::NamesController do
         stub_request(:get, "http://openid-provider/v1/attributes/#{attribute_name2}")
           .to_return(status: 200, body: { claim_value: attribute_value2 }.compact.to_json)
 
+        LocalAttribute.create!(
+          oidc_user: OidcUser.find_or_create_by(sub: "user-id"),
+          name: local_attribute_name,
+          value: local_attribute_value,
+        )
+
         get attributes_names_path, headers: headers, params: params
       end
 
       context "when all attributes are known" do
-        let(:params) { { attributes: [attribute_name1, attribute_name2] } }
+        let(:params) { { attributes: [attribute_name1, attribute_name2, local_attribute_name] } }
 
         context "when all attributes have a value" do
           it "returns all attributes names" do
             expect(response).to be_successful
-            expect(response_body["values"]).to eq([attribute_name1, attribute_name2])
+            expect(response_body["values"].sort).to eq([attribute_name1, attribute_name2, local_attribute_name].sort)
           end
         end
 
         context "when all attributes have no value" do
+          let(:params) { { attributes: [attribute_name1, attribute_name2] } }
           let(:attribute_value1) { nil }
           let(:attribute_value2) { nil }
 
@@ -97,7 +106,7 @@ RSpec.describe Attributes::NamesController do
 
           it "returns only names of attributes with a value" do
             expect(response).to be_successful
-            expect(response_body["values"]).to eq([attribute_name1])
+            expect(response_body["values"].sort).to eq([attribute_name1, local_attribute_name].sort)
           end
         end
       end

--- a/spec/requests/attributes_controller_spec.rb
+++ b/spec/requests/attributes_controller_spec.rb
@@ -12,8 +12,10 @@ RSpec.describe AttributesController do
   # names must be defined in spec/fixtures/user_attributes.yml
   let(:attribute_name1) { "test_attribute_1" }
   let(:attribute_name2) { "test_attribute_2" }
+  let(:local_attribute_name) { "test_local_attribute" }
   let(:attribute_value1) { { "some" => "complex", "value" => 42 } }
   let(:attribute_value2) { [1, 2, 3, 4, 5] }
+  let(:local_attribute_value) { [1, 2, { "buckle" => %w[my shoe] }] }
 
   describe "GET" do
     before do
@@ -93,14 +95,26 @@ RSpec.describe AttributesController do
       before do
         stub_request(:get, "http://openid-provider/v1/attributes/#{attribute_name2}")
           .to_return(status: 200, body: { claim_value: attribute_value2 }.compact.to_json)
+
+        LocalAttribute.create!(
+          oidc_user: OidcUser.find_or_create_by(sub: "user-id"),
+          name: local_attribute_name,
+          value: local_attribute_value,
+        )
       end
 
-      let(:params) { { attributes: [attribute_name1, attribute_name2] } }
+      let(:params) { { attributes: [attribute_name1, attribute_name2, local_attribute_name] } }
 
       it "returns all the attributes" do
         get attributes_path, headers: headers, params: params
         expect(response).to be_successful
-        expect(JSON.parse(response.body)["values"]).to eq({ attribute_name1 => attribute_value1, attribute_name2 => attribute_value2 })
+        expect(JSON.parse(response.body)["values"]).to eq(
+          {
+            attribute_name1 => attribute_value1,
+            attribute_name2 => attribute_value2,
+            local_attribute_name => local_attribute_value,
+          },
+        )
       end
 
       context "when one of the attributes is not found" do
@@ -109,7 +123,7 @@ RSpec.describe AttributesController do
         it "returns only the present attribute" do
           get attributes_path, headers: headers, params: params
           expect(response).to be_successful
-          expect(JSON.parse(response.body)["values"]).to eq({ attribute_name2 => attribute_value2 })
+          expect(JSON.parse(response.body)["values"]).to eq({ attribute_name2 => attribute_value2, local_attribute_name => local_attribute_value })
         end
       end
 
@@ -141,6 +155,40 @@ RSpec.describe AttributesController do
       patch attributes_path, headers: headers, params: params.to_json
       expect(response).to be_successful
       expect(stub).to have_been_made
+    end
+
+    context "when there is a local attribute" do
+      let(:remote_attributes) { { attribute_name1 => attribute_value1, attribute_name2 => attribute_value2 } }
+      let(:attributes) { remote_attributes.merge(local_attribute_name => local_attribute_value) }
+
+      before do
+        stub_request(:post, "http://openid-provider/v1/attributes")
+          .with(body: { attributes: remote_attributes.transform_values(&:to_json) })
+          .to_return(status: 200)
+      end
+
+      it "doesn't send the local attribute to the attribute service" do
+        patch attributes_path, headers: headers, params: params.to_json
+        expect(response).to be_successful
+      end
+
+      it "correctly round-trips the local attribute" do
+        old_value = "hello world"
+
+        LocalAttribute.create!(
+          oidc_user: OidcUser.find_or_create_by(sub: "user-id"),
+          name: local_attribute_name,
+          value: old_value,
+        )
+
+        get attributes_path, headers: headers, params: { attributes: [local_attribute_name] }
+        expect(JSON.parse(response.body)["values"]).to eq({ local_attribute_name => old_value })
+
+        patch attributes_path, headers: headers, params: params.to_json
+
+        get attributes_path, headers: headers, params: { attributes: [local_attribute_name] }
+        expect(JSON.parse(response.body)["values"]).to eq({ local_attribute_name => local_attribute_value })
+      end
     end
 
     context "when there are no attributes" do


### PR DESCRIPTION
We don't have any of these defined in the config file yet, so this code is essentially dead, but we will do when we start to work on the location experiment.

I decided to create an `OidcUser` model, which the `LocalAttribute`s are connected to, rather than just store the subject identifier in the `LocalAttribute`s directly, because this approach means that if subject identifiers change (which they almost certainly will do when we migrate from our OIDC provider to Digital Identity's) we only have one record per user to update.