### PR TITLE
Add `/api/attributes/names` endpoint

### DIFF
--- a/app/controllers/attributes/names_controller.rb
+++ b/app/controllers/attributes/names_controller.rb
@@ -1,0 +1,10 @@
+class Attributes::NamesController < AttributesController
+  def show
+    remote_attributes = get_attributes_from_params(
+      params.fetch(:attributes),
+      permission_level: :check,
+    )
+
+    render_api_response values: @govuk_account_session.get_remote_attributes(remote_attributes).compact.keys
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,10 @@ Rails.application.routes.draw do
     get "/attributes", to: "attributes#show"
     patch "/attributes", to: "attributes#update"
 
+    namespace :attributes do
+      get "/names", to: "names#show"
+    end
+
     get "/transition-checker-email-subscription", to: "transition_checker_email_subscription#show"
     post "/transition-checker-email-subscription", to: "transition_checker_email_subscription#update"
   end

--- a/docs/api.md
+++ b/docs/api.md
@@ -16,6 +16,7 @@ management. This API is not for other government services.
   - [`POST /api/oauth2/state`](#post-apioauth2state)
   - [`GET /api/attributes`](#get-apiattributes)
   - [`PATCH /api/attributes`](#patch-apiattributes)
+  - [`GET /api/attributes/names`](#get-apiattributesnames)
   - [`GET /api/transition-checker-email-subscription`](#get-apitransition-checker-email-subscription)
   - [`POST /api/transition-checker-email-subscription`](#post-apitransition-checker-email-subscription)
 - [API errors](#api-errors)
@@ -418,6 +419,54 @@ Response:
 ```json
 {
     "govuk_account_session": "YWNjZXNzLXRva2Vu.cmVmcmVzaC10b2tlbg=="
+}
+```
+
+### `GET /api/attributes/names`
+
+Retrieves attribute names for the current user.
+
+#### Request headers
+
+- `GOVUK-Account-Session`
+  - the user's session identifier
+
+#### Query parameters
+
+- `attributes[]` *(one for each attribute)*
+  - a list of attribute names, specified once for each name
+
+#### JSON response fields
+
+- `govuk_account_session` *(optional)*
+  - a new session identifier
+- `values`
+  - a JSON array of attribute names
+
+#### Response codes
+
+- 422 if any attributes are unknown (see [error: unknown attribute names](#unknown-attribute-names))
+- 403 if the session's level of authentication is too low (see [error: level of authentication too low](#level-of-authentication-too-low))
+- 401 if the session identifier is invalid
+- 200 otherwise
+
+#### Example request / response
+
+Request (with gds-api-adapters):
+
+```ruby
+GdsApi.account_api.get_attributes(
+    attributes: %w[name1 name2],
+    govuk_account_session: "session-identifier",
+)
+```
+
+Response:
+
+```json
+{
+    "govuk_account_session": "YWNjZXNzLXRva2Vu.cmVmcmVzaC10b2tlbg==",
+    "values": ["name1", "name2"]
 }
 ```
 

--- a/spec/requests/attributes/names_controller_spec.rb
+++ b/spec/requests/attributes/names_controller_spec.rb
@@ -1,0 +1,126 @@
+RSpec.describe Attributes::NamesController do
+  before do
+    stub_oidc_discovery
+
+    fixture_file = YAML.safe_load(File.read(Rails.root.join("spec/fixtures/user_attributes.yml"))).with_indifferent_access
+    allow(UserAttributes).to receive(:load_config_file).and_return(fixture_file)
+  end
+
+  let(:session_identifier) { placeholder_govuk_account_session }
+  let(:headers) { { "Content-Type" => "application/json", "GOVUK-Account-Session" => session_identifier } }
+
+  # names must be defined in spec/fixtures/user_attributes.yml
+  let(:attribute_name1) { "test_attribute_1" }
+  let(:attribute_name2) { "test_attribute_2" }
+  let(:unknown_attribute_name1) { "this_does_not_exist1" }
+  let(:unknown_attribute_name2) { "this_does_not_exist2" }
+
+  let(:attribute_value1) { "some_value1" }
+  let(:attribute_value2) { "some_value2" }
+
+  let(:status) { 200 }
+  let(:response_body) { JSON.parse(response.body) }
+
+  describe "GET #show" do
+    context "when a single attribute is requested" do
+      before do
+        stub_request(:get, "http://openid-provider/v1/attributes/#{attribute_name1}")
+          .to_return(status: status, body: { claim_value: attribute_value1 }.compact.to_json)
+
+        get attributes_names_path, headers: headers, params: params
+      end
+
+      context "when the attribute is known" do
+        let(:params) { { attributes: [attribute_name1] } }
+
+        context "when the attribute has a value" do
+          it "returns the attribute name" do
+            expect(response).to be_successful
+            expect(response_body["values"]).to eq([attribute_name1])
+          end
+        end
+
+        context "when the attribute has no value" do
+          let(:attribute_value1) { nil }
+
+          it "returns an empty array" do
+            expect(response).to be_successful
+            expect(response_body["values"]).to eq([])
+          end
+        end
+      end
+
+      context "when the attribute is unknown" do
+        let(:params) { { attributes: [unknown_attribute_name1] } }
+
+        it "returns the appropriate error" do
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response_body["type"]).to eq(I18n.t("errors.unknown_attribute_names.type"))
+          expect(response_body["attributes"]).to eq([unknown_attribute_name1])
+        end
+      end
+    end
+
+    context "when multiple attributes are requested" do
+      before do
+        stub_request(:get, "http://openid-provider/v1/attributes/#{attribute_name1}")
+          .to_return(status: status, body: { claim_value: attribute_value1 }.compact.to_json)
+
+        stub_request(:get, "http://openid-provider/v1/attributes/#{attribute_name2}")
+          .to_return(status: 200, body: { claim_value: attribute_value2 }.compact.to_json)
+
+        get attributes_names_path, headers: headers, params: params
+      end
+
+      context "when all attributes are known" do
+        let(:params) { { attributes: [attribute_name1, attribute_name2] } }
+
+        context "when all attributes have a value" do
+          it "returns all attributes names" do
+            expect(response).to be_successful
+            expect(response_body["values"]).to eq([attribute_name1, attribute_name2])
+          end
+        end
+
+        context "when all attributes have no value" do
+          let(:attribute_value1) { nil }
+          let(:attribute_value2) { nil }
+
+          it "returns an empty array" do
+            expect(response).to be_successful
+            expect(response_body["values"]).to eq([])
+          end
+        end
+
+        context "when some attributes have no value" do
+          let(:attribute_value2) { nil }
+
+          it "returns only names of attributes with a value" do
+            expect(response).to be_successful
+            expect(response_body["values"]).to eq([attribute_name1])
+          end
+        end
+      end
+
+      context "when all attributes are unknown" do
+        let(:params) { { attributes: [unknown_attribute_name1, unknown_attribute_name2] } }
+
+        it "returns the appropriate error" do
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response_body["type"]).to eq(I18n.t("errors.unknown_attribute_names.type"))
+          expect(response_body["attributes"]).to eq([unknown_attribute_name1, unknown_attribute_name2])
+        end
+      end
+
+      context "when some attributes are unknown" do
+        let(:params) { { attributes: [attribute_name1, unknown_attribute_name1] } }
+
+        it "returns the appropriate error" do
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response_body["type"]).to eq(I18n.t("errors.unknown_attribute_names.type"))
+          expect(response_body["attributes"]).to eq([unknown_attribute_name1])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This endpoint allows querying if the user has a value stored for an
attribute, without returning the value.

It is very similar to `/api/attributes`, with the difference
that it only returns the name of the attribute instead of the name and
the value.

Trello card: https://trello.com/c/e7JQlXx9/710-add-an-endpoint-to-account-api-to-check-if-an-attribute-is-defined

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
