### PR TITLE
Create a concern to handle common API functionality

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,15 +5,6 @@ class ApplicationController < ActionController::API
 
   rescue_from ApiError::Base, with: :json_api_error
 
-  def require_govuk_account_session!
-    @govuk_account_session = AccountSession.deserialise(
-      encoded_session: request.headers["HTTP_GOVUK_ACCOUNT_SESSION"],
-      session_signing_key: Rails.application.secrets.session_signing_key,
-    )
-
-    head :unauthorized unless @govuk_account_session
-  end
-
 private
 
   def authorise!

--- a/app/controllers/attributes_controller.rb
+++ b/app/controllers/attributes_controller.rb
@@ -1,5 +1,5 @@
 class AttributesController < ApplicationController
-  before_action :require_govuk_account_session!
+  include AuthenticatedApiConcern
 
   def show
     remote_attributes = get_attributes_from_params(
@@ -7,14 +7,7 @@ class AttributesController < ApplicationController
       permission_level: :get,
     )
 
-    values = @govuk_account_session.get_remote_attributes(remote_attributes)
-
-    render json: {
-      govuk_account_session: @govuk_account_session.serialise,
-      values: values.compact,
-    }
-  rescue OidcClient::OAuthFailure
-    head :unauthorized
+    render_api_response values: @govuk_account_session.get_remote_attributes(remote_attributes).compact
   end
 
   def update
@@ -26,11 +19,7 @@ class AttributesController < ApplicationController
 
     @govuk_account_session.set_remote_attributes(remote_attributes)
 
-    render json: {
-      govuk_account_session: @govuk_account_session.serialise,
-    }
-  rescue OidcClient::OAuthFailure
-    head :unauthorized
+    render_api_response
   end
 
 private

--- a/app/controllers/concerns/authenticated_api_concern.rb
+++ b/app/controllers/concerns/authenticated_api_concern.rb
@@ -1,0 +1,22 @@
+module AuthenticatedApiConcern
+  extend ActiveSupport::Concern
+
+  included do
+    before_action do
+      @govuk_account_session = AccountSession.deserialise(
+        encoded_session: request.headers["HTTP_GOVUK_ACCOUNT_SESSION"],
+        session_signing_key: Rails.application.secrets.session_signing_key,
+      )
+
+      head :unauthorized unless @govuk_account_session
+    end
+
+    rescue_from OidcClient::OAuthFailure do
+      head :unauthorized
+    end
+  end
+
+  def render_api_response(options = {})
+    render json: options.merge(govuk_account_session: @govuk_account_session.serialise)
+  end
+end

--- a/app/controllers/transition_checker_email_subscription_controller.rb
+++ b/app/controllers/transition_checker_email_subscription_controller.rb
@@ -1,24 +1,12 @@
 class TransitionCheckerEmailSubscriptionController < ApplicationController
-  before_action :require_govuk_account_session!
+  include AuthenticatedApiConcern
 
   def show
-    has_subscription = @govuk_account_session.has_email_subscription?
-
-    render json: {
-      govuk_account_session: @govuk_account_session.serialise,
-      has_subscription: has_subscription,
-    }
-  rescue OidcClient::OAuthFailure
-    head :unauthorized
+    render_api_response has_subscription: @govuk_account_session.has_email_subscription?
   end
 
   def update
     @govuk_account_session.set_email_subscription(params.require(:slug))
-
-    render json: {
-      govuk_account_session: @govuk_account_session.serialise,
-    }
-  rescue OidcClient::OAuthFailure
-    head :unauthorized
+    render_api_response
   end
 end


### PR DESCRIPTION
All authenticated APIs need to respond to an OAuth failure with a
401 (because it means the user's session is invalid) and to include
the serialised session identifier in the response body.

Doing that in each controller method results in a lot of duplication,
and also confusion, as logic like this is subtly wrong:

    render json: {
      govuk_account_session: @govuk_account_session.serialise,
      foo: @govuk_account_session.go_something_oauthy,
    }

As the serialisation needs to happen *after* any other calls.
