### PR TITLE
Allow authenticating at a specific level

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -10,7 +10,7 @@ class AuthenticationController < ApplicationController
     )
 
     render json: {
-      auth_uri: OidcClient.new.auth_uri(auth_request),
+      auth_uri: OidcClient.new.auth_uri(auth_request, params.fetch(:level_of_authentication, LevelOfAuthentication::DEFAULT_FOR_SIGN_IN)),
       state: auth_request.to_oauth_state,
     }
   end

--- a/app/lib/level_of_authentication.rb
+++ b/app/lib/level_of_authentication.rb
@@ -1,4 +1,6 @@
 module LevelOfAuthentication
+  DEFAULT_FOR_SIGN_IN = "level0".freeze
+
   def self.name_to_integer(name)
     Integer(name.delete_prefix("level"))
   end

--- a/app/lib/oidc_client.rb
+++ b/app/lib/oidc_client.rb
@@ -20,9 +20,9 @@ class OidcClient
     @secret = secret || ENV.fetch("GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET")
   end
 
-  def auth_uri(auth_request)
+  def auth_uri(auth_request, level_of_authentication)
     client.authorization_uri(
-      scope: DEFAULT_SCOPES,
+      scope: DEFAULT_SCOPES + [level_of_authentication],
       state: auth_request.to_oauth_state,
       nonce: auth_request.oidc_nonce,
     )

--- a/docs/api.md
+++ b/docs/api.md
@@ -203,6 +203,8 @@ This URL should be served to the user with a 302 response to authenticate the us
 
 #### Query parameters
 
+- `level_of_authentication` *(optional)*
+  - either `level1` (require MFA) or `level0` (do not require MFA, the default)
 - `state_id` *(optional)*
   - an identifier returned from a previous call to `POST /api/oauth2/state`
 - `redirect_path` *(optional)*

--- a/spec/lib/oidc_client_spec.rb
+++ b/spec/lib/oidc_client_spec.rb
@@ -3,6 +3,12 @@ RSpec.describe OidcClient do
 
   before { stub_oidc_discovery }
 
+  describe "auth_uri" do
+    it "includes the requested level of authentication in the scopes" do
+      expect(client.auth_uri(AuthRequest.generate!, "level1234567890")).to include("scope=transition_checker%20openid%20level1234567890")
+    end
+  end
+
   describe "tokens!" do
     before do
       access_token = Rack::OAuth2::AccessToken.new(


### PR DESCRIPTION
Since levels of authentication are disabled in the account manager currently, passing `level0` authenticates the user to `level1`.  So there is no change in behaviour yet.  But that will change in a few sprints time, so we'll also need to change finder-frontend to request `level1`.

Defaulting to `level0` seems sensible, as otherwise we'll end up with users who sign up at `level0` to save some pages but then, when they click "Sign In" in the header, are prompted to set up MFA.

---

[Trello card](https://trello.com/c/qGMyYZ51/715-implement-requesting-a-specific-level-of-authentication-from-the-account-manager)
