### PR TITLE
Add new provider_state for pact tests

### DIFF
--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -118,6 +118,12 @@ Pact.provider_states_for "GDS API Adapters" do
     end
   end
 
+  provider_state "there is a valid user session, with an attribute called 'foo' that has no value" do
+    set_up do
+      stub_request(:get, "http://openid-provider/v1/attributes/foo").to_return(status: 404, body: { claim_value: nil }.to_json)
+    end
+  end
+
   provider_state "there is a valid user session, with an attribute called 'test_attribute_1'" do
     set_up do
       stub_request(:get, "http://openid-provider/v1/attributes/test_attribute_1").to_return(status: 200, body: { claim_value: { bar: "baz" } }.to_json)


### PR DESCRIPTION
This adds a new provider_state to capture the case when an attribute
name is present but it has no value.

This is used in https://github.com/alphagov/gds-api-adapters/pull/1060

Trello card: https://trello.com/c/e7JQlXx9/710-add-an-endpoint-to-account-api-to-check-if-an-attribute-is-defined

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
