### PR TITLE
Check permissions in the transition email controller

### DIFF
--- a/app/controllers/transition_checker_email_subscription_controller.rb
+++ b/app/controllers/transition_checker_email_subscription_controller.rb
@@ -2,11 +2,30 @@ class TransitionCheckerEmailSubscriptionController < ApplicationController
   include AuthenticatedApiConcern
 
   def show
+    check_permission! :check
+
     render_api_response has_subscription: @govuk_account_session.has_email_subscription?
   end
 
   def update
+    check_permission! :set
+
     @govuk_account_session.set_email_subscription(params.require(:slug))
     render_api_response
+  end
+
+private
+
+  def check_permission!(permission_level)
+    return unless Rails.application.config.feature_flag_enforce_levels_of_authentication
+
+    unless user_attributes.has_permission_for? "transition_checker_state", permission_level, @govuk_account_session
+      needed_level_of_authentication = user_attributes.level_of_authentication_for "transition_checker_state", permission_level
+      raise ApiError::LevelOfAuthenticationTooLow, { attributes: %w[transition_checker_state], needed_level_of_authentication: needed_level_of_authentication }
+    end
+  end
+
+  def user_attributes
+    @user_attributes ||= UserAttributes.new
   end
 end

--- a/spec/requests/transition_checker_email_subscription_controller_spec.rb
+++ b/spec/requests/transition_checker_email_subscription_controller_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe TransitionCheckerEmailSubscriptionController do
     # rubocop:enable RSpec/AnyInstance
   end
 
-  let(:headers) { { "Content-Type" => "application/json", "GOVUK-Account-Session" => placeholder_govuk_account_session } }
+  let(:headers) { { "Content-Type" => "application/json", "GOVUK-Account-Session" => session_identifier } }
+  let(:session_identifier) { placeholder_govuk_account_session }
 
   describe "GET" do
     before do
@@ -63,6 +64,31 @@ RSpec.describe TransitionCheckerEmailSubscriptionController do
         expect(response).to have_http_status(:unauthorized)
       end
     end
+
+    context "when the user doesn't have a high enough level of authentication" do
+      let(:status) { 204 }
+      let(:session_identifier) { placeholder_govuk_account_session(level_of_authentication: "level-1") }
+
+      it "checks if there is a subscription" do
+        get transition_checker_email_subscription_path, headers: headers
+        expect(response).to be_successful
+        expect(JSON.parse(response.body)["has_subscription"]).to be(true)
+      end
+
+      context "when the feature flag is toggled on" do
+        before { allow(Rails.configuration).to receive(:feature_flag_enforce_levels_of_authentication).and_return(true) }
+
+        it "returns a 403 and the required level" do
+          get transition_checker_email_subscription_path, headers: headers
+          expect(response).to have_http_status(:forbidden)
+
+          error = JSON.parse(response.body)
+          expect(error["type"]).to eq(I18n.t("errors.level_of_authentication_too_low.type"))
+          expect(error["attributes"]).to eq(%w[transition_checker_state])
+          expect(error["needed_level_of_authentication"]).to eq("level0")
+        end
+      end
+    end
   end
 
   describe "POST" do
@@ -93,6 +119,34 @@ RSpec.describe TransitionCheckerEmailSubscriptionController do
       it "returns a 401" do
         post transition_checker_email_subscription_path
         expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "when the user doesn't have a high enough level of authentication" do
+      let(:session_identifier) { placeholder_govuk_account_session(level_of_authentication: "level-1") }
+
+      it "calls the account manager" do
+        stub = stub_request(:post, Plek.find("account-manager") + "/api/v1/transition-checker/email-subscription")
+          .with(body: hash_including(topic_slug: "slug"))
+          .to_return(status: 200)
+
+        post transition_checker_email_subscription_path, headers: headers, params: { slug: "slug" }.to_json
+        expect(response).to be_successful
+        expect(stub).to have_been_made
+      end
+
+      context "when the feature flag is toggled on" do
+        before { allow(Rails.configuration).to receive(:feature_flag_enforce_levels_of_authentication).and_return(true) }
+
+        it "returns a 403 and the required level" do
+          post transition_checker_email_subscription_path, headers: headers, params: { slug: "slug" }.to_json
+          expect(response).to have_http_status(:forbidden)
+
+          error = JSON.parse(response.body)
+          expect(error["type"]).to eq(I18n.t("errors.level_of_authentication_too_low.type"))
+          expect(error["attributes"]).to eq(%w[transition_checker_state])
+          expect(error["needed_level_of_authentication"]).to eq("level1")
+        end
       end
     end
   end


### PR DESCRIPTION
The email subscription is kind of separate to the transition checker
state attribute, but also kind of tied to it, so it should have the
same access restrictions.

---

[Trello card](https://trello.com/c/G2uYUDuz/716-check-the-level-of-authentication-when-using-attributes-in-the-account-api)