### PR TITLE
Set Transition Checker "get" permission to level1

### DIFF
--- a/config/user_attributes.yml
+++ b/config/user_attributes.yml
@@ -3,5 +3,5 @@ transition_checker_state:
   is_stored_locally: false
   permissions:
     check: 0
-    get: 0
+    get: 1
     set: 1


### PR DESCRIPTION
We want "check" to be 0, so that we can show on the dashboard whether
the user has completed the Transition Checker or not; but we don't
want the user to be able to get back to the saved results without
going through MFA.
