### PR TITLE
Take session from cookie when on development

### DIFF
--- a/app/controllers/concerns/authenticated_api_concern.rb
+++ b/app/controllers/concerns/authenticated_api_concern.rb
@@ -4,7 +4,7 @@ module AuthenticatedApiConcern
   included do
     before_action do
       @govuk_account_session = AccountSession.deserialise(
-        encoded_session: request.headers["HTTP_GOVUK_ACCOUNT_SESSION"],
+        encoded_session: get_govuk_account_session(request),
         session_signing_key: Rails.application.secrets.session_signing_key,
       )
 
@@ -18,5 +18,13 @@ module AuthenticatedApiConcern
 
   def render_api_response(options = {})
     render json: options.merge(govuk_account_session: @govuk_account_session.serialise)
+  end
+
+  def get_govuk_account_session(request)
+    if request.headers["HTTP_GOVUK_ACCOUNT_SESSION"].nil? && Rails.env.development?
+      return request.cookies["govuk_account_session"]
+    end
+
+    request.headers["HTTP_GOVUK_ACCOUNT_SESSION"]
   end
 end


### PR DESCRIPTION
This section expects that the Bearer token will always arrive via a
header, however on development we put it in a cookie.

This adds a short method that conditionally reads from there if you are
on dev.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
