### PR TITLE
Save a page

### DIFF
--- a/app/controllers/saved_pages_controller.rb
+++ b/app/controllers/saved_pages_controller.rb
@@ -6,6 +6,17 @@ class SavedPagesController < ApplicationController
     render_api_response(saved_pages: user.saved_pages.map(&:to_hash))
   end
 
+  # PUT /api/saved_pages/:page_path
+  def update
+    saved_page = SavedPage.find_or_create_by(oidc_user_id: user.id, page_path: params[:page_path])
+
+    if saved_page.persisted?
+      render_api_response(saved_page: saved_page.to_hash)
+    else
+      raise ApiError::CannotSavePage, { page_path: params[:page_path], errors: saved_page.errors }
+    end
+  end
+
 private
 
   def user

--- a/app/controllers/saved_pages_controller.rb
+++ b/app/controllers/saved_pages_controller.rb
@@ -1,0 +1,14 @@
+class SavedPagesController < ApplicationController
+  include AuthenticatedApiConcern
+
+  # GET /api/saved_pages
+  def index
+    render_api_response(saved_pages: user.saved_pages.map(&:to_hash))
+  end
+
+private
+
+  def user
+    @user ||= @govuk_account_session.user
+  end
+end

--- a/app/controllers/saved_pages_controller.rb
+++ b/app/controllers/saved_pages_controller.rb
@@ -1,6 +1,8 @@
 class SavedPagesController < ApplicationController
   include AuthenticatedApiConcern
 
+  before_action :check_saved_page_exists, only: %i[destroy]
+
   # GET /api/saved_pages
   def index
     render_api_response(saved_pages: user.saved_pages.map(&:to_hash))
@@ -17,9 +19,23 @@ class SavedPagesController < ApplicationController
     end
   end
 
+  # DELETE /api/saved_pages/:page_path
+  def destroy
+    saved_page.destroy!
+    head :no_content
+  end
+
 private
 
   def user
     @user ||= @govuk_account_session.user
+  end
+
+  def saved_page
+    @saved_page ||= SavedPage.find_by(oidc_user_id: user.id, page_path: params[:page_path])
+  end
+
+  def check_saved_page_exists
+    head :not_found if saved_page.nil?
   end
 end

--- a/app/controllers/saved_pages_controller.rb
+++ b/app/controllers/saved_pages_controller.rb
@@ -1,11 +1,16 @@
 class SavedPagesController < ApplicationController
   include AuthenticatedApiConcern
 
-  before_action :check_saved_page_exists, only: %i[destroy]
+  before_action :check_saved_page_exists, only: %i[destroy show]
 
   # GET /api/saved_pages
   def index
     render_api_response(saved_pages: user.saved_pages.map(&:to_hash))
+  end
+
+  # GET /api/saved_pages/:page_path
+  def show
+    render_api_response(saved_page: saved_page.to_hash)
   end
 
   # PUT /api/saved_pages/:page_path

--- a/app/lib/api_error/cannot_save_page.rb
+++ b/app/lib/api_error/cannot_save_page.rb
@@ -1,0 +1,25 @@
+module ApiError
+  class CannotSavePage < ApiError::Base
+    attr_reader :page_path, :errors
+
+    def initialize(page_path:, errors:)
+      @page_path = page_path
+      @errors = errors
+    end
+
+    def status_code
+      :unprocessable_entity
+    end
+
+    def detail
+      I18n.t("errors.cannot_save_page.detail", page_path: page_path)
+    end
+
+    def extra_detail
+      {
+        page_path: page_path,
+        errors: errors,
+      }
+    end
+  end
+end

--- a/app/models/oidc_user.rb
+++ b/app/models/oidc_user.rb
@@ -1,3 +1,4 @@
 class OidcUser < ApplicationRecord
   has_many :local_attributes, dependent: :destroy
+  has_many :saved_pages, dependent: :destroy
 end

--- a/app/models/saved_page.rb
+++ b/app/models/saved_page.rb
@@ -1,9 +1,25 @@
 class SavedPage < ApplicationRecord
   belongs_to :oidc_user
 
+  validates :page_path, uniqueness: { scope: :oidc_user_id }, presence: true
+
+  validate :page_path_is_valid_path
+
   def to_hash
     {
       "page_path" => page_path,
     }
+  end
+
+private
+
+  def page_path_is_valid_path
+    errors.add(:page_path, :invalid_path, message: "must only include URL path") unless is_valid_path?
+  end
+
+  def is_valid_path?
+    page_path&.starts_with?("/") && URI(page_path).path == page_path
+  rescue StandardError
+    false
   end
 end

--- a/app/models/saved_page.rb
+++ b/app/models/saved_page.rb
@@ -1,0 +1,9 @@
+class SavedPage < ApplicationRecord
+  belongs_to :oidc_user
+
+  def to_hash
+    {
+      "page_path" => page_path,
+    }
+  end
+end

--- a/config/locales/errors.en.yml
+++ b/config/locales/errors.en.yml
@@ -9,3 +9,7 @@ en:
       type: https://github.com/alphagov/account-api/blob/main/docs/api.md#unknown-attribute-names
       title: Unknown attribute names
       detail: Attribute names %{attributes} are unknown, have they been added to config/user_attributes.yml?
+    cannot_save_page:
+      type: https://github.com/alphagov/account-api/blob/main/docs/api.md#cannot-save-page
+      title: Cannot save page
+      detail: Cannot save page with path %{page_path}, check it is not blank, and is a well formatted url path.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
       get "/names", to: "names#show"
     end
 
+    resources :saved_pages, only: %i[index show update destroy], param: :page_path
+
     get "/transition-checker-email-subscription", to: "transition_checker_email_subscription#show"
     post "/transition-checker-email-subscription", to: "transition_checker_email_subscription#update"
   end

--- a/db/migrate/20210512111851_create_saved_pages.rb
+++ b/db/migrate/20210512111851_create_saved_pages.rb
@@ -1,0 +1,12 @@
+class CreateSavedPages < ActiveRecord::Migration[6.1]
+  def change
+    create_table :saved_pages do |t|
+      t.references :oidc_user, null: false
+      t.string     :page_path, null: false
+
+      t.timestamps
+    end
+
+    add_index :saved_pages, %i[oidc_user_id page_path], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_29_123551) do
+ActiveRecord::Schema.define(version: 2021_05_12_111851) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,6 +38,15 @@ ActiveRecord::Schema.define(version: 2021_04_29_123551) do
     t.datetime "created_at", precision: 6, default: -> { "now()" }, null: false
     t.datetime "updated_at", precision: 6, default: -> { "now()" }, null: false
     t.index ["sub"], name: "index_oidc_users_on_sub", unique: true
+  end
+
+  create_table "saved_pages", force: :cascade do |t|
+    t.bigint "oidc_user_id", null: false
+    t.string "page_path", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["oidc_user_id", "page_path"], name: "index_saved_pages_on_oidc_user_id_and_page_path", unique: true
+    t.index ["oidc_user_id"], name: "index_saved_pages_on_oidc_user_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,7 +5,11 @@ up www.gov.uk) to implement personalisation and user session
 management. This API is not for other government services.
 
 - [Nomenclature](#nomenclature)
+  - [Identity provider](#identity-provider)
+  - [Session identifier](#session-identifier)
 - [Requirements for API consumers](#requirements-for-api-consumers)
+  - [Request custom headers](#request-custom-headers)
+  - [Response custom headers](#response-custom-headers)
   - [Update the user's session if a new session identifier is returned](#update-the-users-session-if-a-new-session-identifier-is-returned)
   - [End the user's session if an endpoint returns a `401: Unauthenticated`](#end-the-users-session-if-an-endpoint-returns-a-401-unauthenticated)
   - [Ensure responses are not cached](#ensure-responses-are-not-cached)

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,9 +24,11 @@ management. This API is not for other government services.
   - [`GET /api/transition-checker-email-subscription`](#get-apitransition-checker-email-subscription)
   - [`POST /api/transition-checker-email-subscription`](#post-apitransition-checker-email-subscription)
   - [`GET /api/saved_pages`](#get-apisaved_pages)
+  - [`PUT /api/saved_pages/:page_path`](#put-apisaved_pagespage_path)
 - [API errors](#api-errors)
   - [Level of authentication too low](#level-of-authentication-too-low)
   - [Unknown attribute names](#unknown-attribute-names)
+  - [Page cannot be saved](#page-cannot-be-saved)
 
 ## Nomenclature
 
@@ -611,6 +613,53 @@ Response when a user has saved two pages:
 }
 ```
 
+### `PUT /api/saved_pages/:page_path`
+
+Upsert a saved page in a user's account
+
+#### Request headers
+
+- `GOVUK-Account-Session`
+  - the user's session identifier
+
+#### Request parameters
+
+- `page_path`
+  - An escaped URL safe string that identifies the path of a saved page.
+
+#### JSON response fields
+
+- `govuk_account_session` *(optional)*
+  - a new session identifier
+- `saved_page`
+  - an object containing the page path of the successfully saved page
+
+#### Response codes
+
+- 401 if the session identifier is invalid
+- 422 if the page could not be saved (see [error: page cannot be saved](#page-cannot-be-saved))
+- 200 otherwise
+
+#### Example request / response
+
+Request (with gds-api-adapters):
+
+```ruby
+GdsApi.saved_page_api.save_page(
+    page_path: "/guidance/foo",
+    govuk_account_session: "session-identifier",
+)
+```
+
+```json
+{
+    "govuk_account_session": "YWNjZXNzLXRva2Vu.cmVmcmVzaC10b2tlbg==",
+    "saved_page": {
+      "page_path": "/guidance/foo"
+    },
+}
+```
+
 ## API errors
 
 API errors are returned as an [RFC 7807][] "Problem Detail" object, in
@@ -650,3 +699,11 @@ The `attributes` response field lists these.
 - check that you don't have a typo in the attribute names
 - check that the attributes are defined in `config/user_attributes.yml`
 - check that you are running the latest version of account-api
+
+### Page cannot be saved
+
+The page you have specified could not be saved. The errors response field lists the problems.
+
+#### Debugging steps
+
+- check the `errors` returned as an extra detail in the response for specific error messages

--- a/docs/api.md
+++ b/docs/api.md
@@ -23,6 +23,7 @@ management. This API is not for other government services.
   - [`GET /api/attributes/names`](#get-apiattributesnames)
   - [`GET /api/transition-checker-email-subscription`](#get-apitransition-checker-email-subscription)
   - [`POST /api/transition-checker-email-subscription`](#post-apitransition-checker-email-subscription)
+  - [`GET /api/saved_pages`](#get-apisaved_pages)
 - [API errors](#api-errors)
   - [Level of authentication too low](#level-of-authentication-too-low)
   - [Unknown attribute names](#unknown-attribute-names)
@@ -558,6 +559,57 @@ Response:
 }
 ```
 
+### `GET /api/saved_pages`
+
+Returns all a user's saved pages
+
+#### Request headers
+
+- `GOVUK-Account-Session`
+  - the user's session identifier
+
+#### JSON response fields
+
+- `govuk_account_session` *(optional)*
+  - a new session identifier
+- `saved_pages`
+  - an array of pages the user has saved, identified by their page path
+
+#### Response codes
+
+- 401 if the session identifier is invalid
+- 200 otherwise
+
+#### Example request / response
+
+Request (with gds-api-adapters):
+
+```ruby
+GdsApi.saved_page_api.get_saved_pages(
+    govuk_account_session: "session-identifier",
+)
+```
+
+Response when no pages are saved:
+
+```json
+{
+    "govuk_account_session": "YWNjZXNzLXRva2Vu.cmVmcmVzaC10b2tlbg==",
+    "saved_pages": []
+}
+```
+
+Response when a user has saved two pages:
+
+```json
+{
+    "govuk_account_session": "YWNjZXNzLXRva2Vu.cmVmcmVzaC10b2tlbg==",
+    "saved_pages": [
+      { "page_path": "/government/organisations/government-digital-service" },
+      { "page_path": "/government/organisations/cabinet-office" },
+  ]
+}
+```
 
 ## API errors
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -26,6 +26,7 @@ management. This API is not for other government services.
   - [`GET /api/saved_pages`](#get-apisaved_pages)
   - [`PUT /api/saved_pages/:page_path`](#put-apisaved_pagespage_path)
   - [`DELETE /api/saved_pages/:page_path`](#delete-apisaved_pagespage_path)
+  - [`GET /api/saved_pages/:page_path`](#get-apisaved_pagespage_path)
 - [API errors](#api-errors)
   - [Level of authentication too low](#level-of-authentication-too-low)
   - [Unknown attribute names](#unknown-attribute-names)
@@ -693,6 +694,53 @@ GdsApi.saved_page_api.delete_saved_page(
 ```
 
 Response is status code only.
+
+### `GET /api/saved_pages/:page_path`
+
+Query if a specific path has been saved by the user
+
+#### Request headers
+
+- `GOVUK-Account-Session`
+  - the user's session identifier
+
+#### Request parameters
+
+- `page_path`
+  - An escaped URL safe string that identifies the path of a saved page.
+
+#### JSON response fields
+
+- `govuk_account_session` *(optional)*
+  - a new session identifier
+- `saved_page`
+  - an object containing the page path of the successfully queried page
+
+#### Response codes
+
+- 401 if the session identifier is invalid
+- 404 cannot find a page with the provided path
+- 200 otherwise
+
+#### Example request / response
+
+Request (with gds-api-adapters):
+
+```ruby
+GdsApi.saved_page_api.get_saved_page(
+    page_path: "/guidance/bar",
+    govuk_account_session: "session-identifier",
+)
+```
+
+```json
+{
+    "govuk_account_session": "YWNjZXNzLXRva2Vu.cmVmcmVzaC10b2tlbg==",
+    "saved_page": {
+      "page_path": "/guidance/bar"
+    },
+}
+```
 
 ## API errors
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -25,6 +25,7 @@ management. This API is not for other government services.
   - [`POST /api/transition-checker-email-subscription`](#post-apitransition-checker-email-subscription)
   - [`GET /api/saved_pages`](#get-apisaved_pages)
   - [`PUT /api/saved_pages/:page_path`](#put-apisaved_pagespage_path)
+  - [`DELETE /api/saved_pages/:page_path`](#delete-apisaved_pagespage_path)
 - [API errors](#api-errors)
   - [Level of authentication too low](#level-of-authentication-too-low)
   - [Unknown attribute names](#unknown-attribute-names)
@@ -660,6 +661,39 @@ GdsApi.saved_page_api.save_page(
 }
 ```
 
+### `DELETE /api/saved_pages/:page_path`
+
+Remove a saved page from a user's account
+
+#### Request headers
+
+- `GOVUK-Account-Session`
+  - the user's session identifier
+
+#### Request parameters
+
+- `page_path`
+  - An escaped URL safe string that identifies the path of a saved page.
+
+#### Response codes
+
+- 401 if the session identifier is invalid
+- 404 cannot find a page with the provided path
+- 204 successfully deleted
+
+#### Example request / response
+
+Request (with gds-api-adapters):
+
+```ruby
+GdsApi.saved_page_api.delete_saved_page(
+    page_path: "/guidance/bar",
+    govuk_account_session: "session-identifier",
+)
+```
+
+Response is status code only.
+
 ## API errors
 
 API errors are returned as an [RFC 7807][] "Problem Detail" object, in
@@ -693,12 +727,6 @@ level to access.
 
 One or more of the attribute names you have specified are not known.
 The `attributes` response field lists these.
-
-#### Debugging steps
-
-- check that you don't have a typo in the attribute names
-- check that the attributes are defined in `config/user_attributes.yml`
-- check that you are running the latest version of account-api
 
 ### Page cannot be saved
 

--- a/spec/factories/oidc_user_factory.rb
+++ b/spec/factories/oidc_user_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :oidc_user do
+    sequence(:sub) { |n| "user-id-#{n}" }
+  end
+end

--- a/spec/factories/saved_page_factory.rb
+++ b/spec/factories/saved_page_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :saved_page do
+    oidc_user
+    sequence(:page_path) { |n| "/page-path/#{n}" }
+  end
+end

--- a/spec/models/saved_page_spec.rb
+++ b/spec/models/saved_page_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe SavedPage do
+  describe "to_hash" do
+    let(:saved_page) { FactoryBot.build(:saved_page) }
+
+    it "returns a hash with stringified keys containing the page path" do
+      expect(saved_page.to_hash).to eq({ "page_path" => saved_page.page_path })
+    end
+  end
+end

--- a/spec/models/saved_page_spec.rb
+++ b/spec/models/saved_page_spec.rb
@@ -1,4 +1,53 @@
 RSpec.describe SavedPage do
+  describe "validations" do
+    let(:saved_page) { FactoryBot.build(:saved_page) }
+
+    it "rejects duplicate saved pages, scoped to a user" do
+      saved_page.save!
+      duplicate = saved_page.dup
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:page_path]).to include("has already been taken")
+    end
+
+    it "allows duplicate saved pages, between different users" do
+      saved_page.save!
+      not_a_duplicate = FactoryBot.build(:saved_page, page_path: saved_page.page_path)
+      expect(not_a_duplicate).to be_valid
+    end
+
+    it "rejects blank values as page paths" do
+      [nil, ""].each do |blank_value|
+        saved_page.page_path = blank_value
+        expect(saved_page).not_to be_valid
+        expect(saved_page.errors[:page_path]).to include("can't be blank")
+      end
+    end
+
+    it "rejects paths that do not start with /" do
+      saved_page.page_path = "foo"
+      expect(saved_page).not_to be_valid
+      expect(saved_page.errors[:page_path]).to include("must only include URL path")
+    end
+
+    it "rejects paths that contain spaces" do
+      saved_page.page_path = "/foo bar"
+      expect(saved_page).not_to be_valid
+      expect(saved_page.errors[:page_path]).to include("must only include URL path")
+    end
+
+    it "rejects page paths with parameters" do
+      saved_page.page_path = "/foo/bar?i_am_tracking_identifier=abc123"
+      expect(saved_page).not_to be_valid
+      expect(saved_page.errors[:page_path]).to include("must only include URL path")
+    end
+
+    it "rejects pages with fragment identifiers" do
+      saved_page.page_path = "/guidance/about-the-thing#heading1"
+      expect(saved_page).not_to be_valid
+      expect(saved_page.errors[:page_path]).to include("must only include URL path")
+    end
+  end
+
   describe "to_hash" do
     let(:saved_page) { FactoryBot.build(:saved_page) }
 

--- a/spec/requests/saved_pages_spec.rb
+++ b/spec/requests/saved_pages_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe "Saved pages" do
+  context "when receiving an unauthenticated request" do
+    it "returns unauthorised for GET /api/saved_pages" do
+      get saved_pages_path
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  context "when receiving an authenticated request" do
+    let(:headers) { { "Content-Type" => "application/json", "GOVUK-Account-Session" => session_identifier } }
+    let(:session_identifier) { placeholder_govuk_account_session(user_id: user.sub) }
+    let(:user) { FactoryBot.create(:oidc_user) }
+
+    describe "GET /api/saved_pages" do
+      it "returns an empty array if there are no saved pages" do
+        get saved_pages_path, headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)["saved_pages"]).to eq([])
+      end
+
+      it "returns an array of saved_pages if they exist" do
+        list = FactoryBot.create_list(:saved_page, 2, oidc_user_id: user.id)
+        expected_response = list.map(&:to_hash)
+
+        get saved_pages_path, headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)["saved_pages"]).to eq(expected_response)
+      end
+    end
+  end
+end

--- a/spec/requests/saved_pages_spec.rb
+++ b/spec/requests/saved_pages_spec.rb
@@ -5,6 +5,12 @@ RSpec.describe "Saved pages" do
 
       expect(response).to have_http_status(:unauthorized)
     end
+
+    it "returns unauthorised for PUT /api/saved_pages/:page_path" do
+      put saved_page_path({ page_path: "/my-saved-page-path" })
+
+      expect(response).to have_http_status(:unauthorized)
+    end
   end
 
   context "when receiving an authenticated request" do
@@ -28,6 +34,63 @@ RSpec.describe "Saved pages" do
 
         expect(response).to have_http_status(:ok)
         expect(JSON.parse(response.body)["saved_pages"]).to eq(expected_response)
+      end
+    end
+
+    describe "PUT /api/saved_pages/:page_path" do
+      it "returns a page path hash if the page persists correctly" do
+        put saved_page_path(page_path: "/page-path/1"), headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)["saved_page"]).to eq({ "page_path" => "/page-path/1" })
+      end
+
+      it "returns status 200 and upserts the record if the page already exists" do
+        FactoryBot.create(:saved_page, oidc_user_id: user.id, page_path: "/page-path/1")
+        put saved_page_path(page_path: "/page-path/1"), headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)["saved_page"]).to eq({ "page_path" => "/page-path/1" })
+      end
+
+      it "increases the count of saved pages if the page does not already exist" do
+        expect {
+          put saved_page_path(page_path: "/page-path/1"), headers: headers
+        }.to change(SavedPage, :count).by(1)
+      end
+
+      it "does not increase the count of saved pages if the page does already exist" do
+        FactoryBot.create(:saved_page, oidc_user_id: user.id, page_path: "/page-path/1")
+
+        expect {
+          put saved_page_path(page_path: "/page-path/1"), headers: headers
+        }.not_to change(SavedPage, :count)
+      end
+
+      it "returns status 422 Unprocessable Entity with a RFC 7807 'problem detail' object if the page path contains query parameters" do
+        page_path = "/foo/bar?uhoh"
+        put saved_page_path(page_path: page_path), headers: headers
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        error = JSON.parse(response.body)
+        expect(error["title"]).to eq(I18n.t("errors.cannot_save_page.title"))
+        expect(error["type"]).to eq(I18n.t("errors.cannot_save_page.type"))
+        expect(error["detail"]).to eq(I18n.t("errors.cannot_save_page.detail", page_path: page_path))
+        expect(error["page_path"]).to eq(page_path)
+        expect(error["errors"]["page_path"]).to include("must only include URL path")
+      end
+
+      it "returns status 422 Unprocessable Entity with a RFC 7807 'problem detail' object if the page path contains a fragment identifier" do
+        page_path = "/foo/bar#heading1"
+        put saved_page_path(page_path: page_path), headers: headers
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        error = JSON.parse(response.body)
+        expect(error["title"]).to eq(I18n.t("errors.cannot_save_page.title"))
+        expect(error["type"]).to eq(I18n.t("errors.cannot_save_page.type"))
+        expect(error["detail"]).to eq(I18n.t("errors.cannot_save_page.detail", page_path: page_path))
+        expect(error["page_path"]).to eq(page_path)
+        expect(error["errors"]["page_path"]).to include("must only include URL path")
       end
     end
   end

--- a/spec/requests/saved_pages_spec.rb
+++ b/spec/requests/saved_pages_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe "Saved pages" do
 
       expect(response).to have_http_status(:unauthorized)
     end
+
+    it "returns unauthorised for GET /api/saved_pages/:page_path " do
+      get saved_page_path("/my-saved-page-path")
+
+      expect(response).to have_http_status(:unauthorized)
+    end
   end
 
   context "when receiving an authenticated request" do
@@ -118,6 +124,22 @@ RSpec.describe "Saved pages" do
 
       it "returns status 404 Not Found if there is no saved page with the provided path" do
         delete saved_page_path(page_path: "/page-path/1"), headers: headers
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    describe "GET /api/saved_pages/:page_path" do
+      it "returns status 200 and a saved page record if a page exists" do
+        FactoryBot.create(:saved_page, oidc_user_id: user.id, page_path: "/page-path/1")
+        get saved_page_path(page_path: "/page-path/1"), headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)["saved_page"]).to eq({ "page_path" => "/page-path/1" })
+      end
+
+      it "returns status 404 Not Found if there is no saved page with the provided path" do
+        get saved_page_path(page_path: "/page-path/1"), headers: headers
 
         expect(response).to have_http_status(:not_found)
       end


### PR DESCRIPTION
[Trello card](https://trello.com/c/OvsvoWsO/766-implement-an-api-to-save-a-page-unsave-a-page-check-if-a-page-is-saved-and-return-the-list-of-saved-pages)

Also relevant: [gds-api-adapters#1067](https://github.com/alphagov/gds-api-adapters/pull/1067)

## What

Add save page endpoints allowing an authenticated user to get an index of all their saved pages, as well ass add, delete or query a single saved page.