### PR TITLE
Set the updated_at time when storing new local attribute values

### DIFF
--- a/app/lib/account_session.rb
+++ b/app/lib/account_session.rb
@@ -109,7 +109,7 @@ private
     return if local_attributes.empty?
 
     LocalAttribute.upsert_all(
-      local_attributes.map { |name, value| { oidc_user_id: user.id, name: name, value: value } },
+      local_attributes.map { |name, value| { oidc_user_id: user.id, name: name, value: value, updated_at: Time.zone.now } },
       unique_by: :index_local_attributes_on_oidc_user_id_and_name,
       returning: false,
     )

--- a/spec/lib/account_session_spec.rb
+++ b/spec/lib/account_session_spec.rb
@@ -148,6 +148,18 @@ RSpec.describe AccountSession do
         expect(stub).to have_been_made
       end
 
+      context "when the local attribute already exists" do
+        it "increases the updated_at time" do
+          attribute = LocalAttribute.create!(
+            oidc_user: OidcUser.find_or_create_by(sub: user_id),
+            name: local_attribute_name,
+            value: local_attribute_value,
+          )
+
+          expect { account_session.set_attributes(local_attributes) }.to(change { attribute.reload.updated_at })
+        end
+      end
+
       context "when there are no local attributes" do
         let(:local_attributes) { {} }
 


### PR DESCRIPTION
By default upsert_all does not change the updated_at timestamp.  This
is fine if nothing has actually changed (eg, saving a duplicate page);
but in general saving an attribute value *is* a change, and so we want
the timestamp to change.
