### PR TITLE
Fix naming convention for request specs

### DIFF
--- a/spec/requests/attributes/names_spec.rb
+++ b/spec/requests/attributes/names_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Attributes::NamesController do
+RSpec.describe "Attribute names" do
   before do
     stub_oidc_discovery
 

--- a/spec/requests/attributes_spec.rb
+++ b/spec/requests/attributes_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe AttributesController do
+RSpec.describe "Attributes" do
   before do
     stub_oidc_discovery
 

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe AuthenticationController do
+RSpec.describe "Authentication" do
   before do
     stub_oidc_discovery
     stub_token_response

--- a/spec/requests/transition_checker_email_subscription_spec.rb
+++ b/spec/requests/transition_checker_email_subscription_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe TransitionCheckerEmailSubscriptionController do
+RSpec.describe "Transition Checker email subscriptions" do
   before do
     stub_oidc_discovery
 


### PR DESCRIPTION
These have always been request specs, because they're in spec/requests
and we have `config.infer_spec_type_from_file_location!`

The rspec docs[1] show that request spec files should be called
"`<thing>_spec.rb`"; not "`<thing>_controller_spec.rb`" or
"`<thing>_request_spec.rb`", and should have a string name for the
top-level `describe` rather than a class name.

[1] https://relishapp.com/rspec/rspec-rails/docs/request-specs/request-spec
