### PR TITLE
Fetch content ID & title when saving a page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "rails", "6.1.3.2"
 
 gem "bootsnap"
 gem "dalli"
+gem "gds-api-adapters"
 gem "gds-sso"
 gem "govuk_app_config"
 gem "openid_connect"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,8 @@ GEM
     diff-lcs (1.4.4)
     dig_rb (1.0.1)
     docile (1.3.5)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     erubi (1.10.0)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
@@ -116,6 +118,12 @@ GEM
     ffi (1.15.0)
     filelock (1.1.1)
     find_a_port (1.0.1)
+    gds-api-adapters (71.1.0)
+      addressable
+      link_header
+      null_logger
+      plek (>= 1.9.0)
+      rest-client (~> 2.0)
     gds-sso (16.0.0)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
@@ -140,6 +148,9 @@ GEM
       webdrivers (>= 4)
     hashdiff (1.0.1)
     hashie (4.1.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     httparty (0.18.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
@@ -153,6 +164,7 @@ GEM
       bindata
     jwt (2.2.2)
     kgio (2.11.3)
+    link_header (0.0.8)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -176,10 +188,12 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
+    netrc (0.11.0)
     nio4r (2.5.7)
     nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
+    null_logger (0.0.1)
     oauth2 (1.4.4)
       faraday (>= 0.8, < 2.0)
       jwt (>= 1.0, < 3.0)
@@ -297,7 +311,12 @@ GEM
     regexp_parser (2.1.1)
     request_store (1.5.0)
       rack (>= 1.4)
-    rexml (3.2.5)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    rexml (3.2.4)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -379,6 +398,9 @@ GEM
       sync
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
     unicorn (5.8.0)
       kgio (~> 2.6)
@@ -401,7 +423,7 @@ GEM
     webfinger (1.1.0)
       activesupport
       httpclient (>= 2.4)
-    webmock (3.13.0)
+    webmock (3.12.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
@@ -424,6 +446,7 @@ DEPENDENCIES
   dalli
   database_cleaner-active_record
   factory_bot_rails
+  gds-api-adapters
   gds-sso
   govuk_app_config
   govuk_test

--- a/app/models/saved_page.rb
+++ b/app/models/saved_page.rb
@@ -8,7 +8,9 @@ class SavedPage < ApplicationRecord
   def to_hash
     {
       "page_path" => page_path,
-    }
+      "content_id" => content_id,
+      "title" => title,
+    }.compact
   end
 
 private

--- a/db/migrate/20210521080408_add_content_store_data_to_saved_page.rb
+++ b/db/migrate/20210521080408_add_content_store_data_to_saved_page.rb
@@ -1,0 +1,8 @@
+class AddContentStoreDataToSavedPage < ActiveRecord::Migration[6.1]
+  def change
+    change_table :saved_pages, bulk: true do |t|
+      t.uuid   :content_id, null: false
+      t.string :title
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_12_111851) do
+ActiveRecord::Schema.define(version: 2021_05_21_080408) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,6 +45,8 @@ ActiveRecord::Schema.define(version: 2021_05_12_111851) do
     t.string "page_path", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.uuid "content_id", null: false
+    t.string "title"
     t.index ["oidc_user_id", "page_path"], name: "index_saved_pages_on_oidc_user_id_and_page_path", unique: true
     t.index ["oidc_user_id"], name: "index_saved_pages_on_oidc_user_id"
   end

--- a/docs/api.md
+++ b/docs/api.md
@@ -647,6 +647,8 @@ Upsert a saved page in a user's account
 #### Response codes
 
 - 401 if the session identifier is invalid
+- 404 if the page does not exist (not present in the content store)
+- 410 if the page has been removed (the latest edition is in the "gone" or "redirect" state)
 - 422 if the page could not be saved (see [error: page cannot be saved](#page-cannot-be-saved))
 - 200 otherwise
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -609,8 +609,16 @@ Response when a user has saved two pages:
 {
     "govuk_account_session": "YWNjZXNzLXRva2Vu.cmVmcmVzaC10b2tlbg==",
     "saved_pages": [
-      { "page_path": "/government/organisations/government-digital-service" },
-      { "page_path": "/government/organisations/cabinet-office" },
+      {
+        "page_path": "/government/organisations/government-digital-service",
+        "content_id": "af07d5a5-df63-4ddc-9383-6a666845ebe9",
+        "title": "Government Digital Service"
+      },
+      {
+        "page_path": "/government/organisations/cabinet-office",
+        "content_id": "96ae61d6-c2a1-48cb-8e67-da9d105ae381",
+        "title": "Cabinet Office"
+      },
   ]
 }
 ```
@@ -657,7 +665,9 @@ GdsApi.saved_page_api.save_page(
 {
     "govuk_account_session": "YWNjZXNzLXRva2Vu.cmVmcmVzaC10b2tlbg==",
     "saved_page": {
-      "page_path": "/guidance/foo"
+      "page_path": "/guidance/foo",
+      "content_id": "96ae61d6-c2a1-48cb-8e67-da9d105ae381",
+      "title": "Guidance for Foo-related Activities"
     },
 }
 ```
@@ -737,7 +747,9 @@ GdsApi.saved_page_api.get_saved_page(
 {
     "govuk_account_session": "YWNjZXNzLXRva2Vu.cmVmcmVzaC10b2tlbg==",
     "saved_page": {
-      "page_path": "/guidance/bar"
+      "page_path": "/guidance/bar",
+      "content_id": "96ae61d6-c2a1-48cb-8e67-da9d105ae381",
+      "title": "Guidance for Bar-related Activities"
     },
 }
 ```

--- a/spec/factories/saved_page_factory.rb
+++ b/spec/factories/saved_page_factory.rb
@@ -2,5 +2,7 @@ FactoryBot.define do
   factory :saved_page do
     oidc_user
     sequence(:page_path) { |n| "/page-path/#{n}" }
+    content_id { SecureRandom.uuid }
+    sequence(:title) { |n| "Page #{n}" }
   end
 end

--- a/spec/models/saved_page_spec.rb
+++ b/spec/models/saved_page_spec.rb
@@ -52,7 +52,13 @@ RSpec.describe SavedPage do
     let(:saved_page) { FactoryBot.build(:saved_page) }
 
     it "returns a hash with stringified keys containing the page path" do
-      expect(saved_page.to_hash).to eq({ "page_path" => saved_page.page_path })
+      expect(saved_page.to_hash).to eq(
+        {
+          "page_path" => saved_page.page_path,
+          "content_id" => saved_page.content_id,
+          "title" => saved_page.title,
+        },
+      )
     end
   end
 end


### PR DESCRIPTION
We'll need the content ID to handle publishing updates, as not all of
these have a base path (eg, a "vanish" update just specifies the
content ID).  So we can fetch this when the user saves a page (and
throw an error if the content item doesn't exist, rather than let them
save a non-existent page), and use it later in the message queue
consumer.

If the content item doesn't exist, return a 404.  If it does exist but
has been redirected or marked "gone", then return a 410.  I decided to
go for this over following the redirect automatically, as a redirected
page shouldn't render a save button on the original URL, it should
redirect the original URL.

We're likely to want page titles on the page which lists a user's
saved pages, so I've pulled that in here too.

---

[Trello card](https://trello.com/c/8EadgviV/772-get-account-api-consuming-publishing-messages-from-rabbitmq)