### PR TITLE
Implement the message queue processor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :development, :test do
   gem "climate_control"
   gem "database_cleaner-active_record"
   gem "factory_bot_rails"
+  gem "govuk_schemas"
   gem "govuk_test"
   gem "pact", require: false
   gem "pact_broker-client"

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "dalli"
 gem "gds-api-adapters"
 gem "gds-sso"
 gem "govuk_app_config"
+gem "govuk_message_queue_consumer"
 gem "openid_connect"
 gem "pg"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,8 @@ GEM
       unicorn (>= 5.4, < 5.9)
     govuk_message_queue_consumer (3.5.0)
       bunny (~> 2.11)
+    govuk_schemas (4.3.0)
+      json-schema (~> 2.8.0)
     govuk_test (2.2.0)
       brakeman (~> 4.6)
       capybara
@@ -167,6 +169,8 @@ GEM
       activesupport (>= 4.2)
       aes_key_wrap
       bindata
+    json-schema (2.8.1)
+      addressable (>= 2.4)
     jwt (2.2.2)
     kgio (2.11.3)
     link_header (0.0.8)
@@ -455,6 +459,7 @@ DEPENDENCIES
   gds-sso
   govuk_app_config
   govuk_message_queue_consumer
+  govuk_schemas
   govuk_test
   listen
   openid_connect

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.1.0)
+    amq-protocol (2.3.2)
     ast (2.4.2)
     attr_required (1.0.1)
     awesome_print (1.9.2)
@@ -74,6 +75,8 @@ GEM
     bullet (6.1.4)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
+    bunny (2.17.0)
+      amq-protocol (~> 2.3, >= 2.3.1)
     byebug (11.1.3)
     capybara (3.35.3)
       addressable
@@ -140,6 +143,8 @@ GEM
       sentry-raven (~> 3.1.1)
       statsd-ruby (~> 1.5.0)
       unicorn (>= 5.4, < 5.9)
+    govuk_message_queue_consumer (3.5.0)
+      bunny (~> 2.11)
     govuk_test (2.2.0)
       brakeman (~> 4.6)
       capybara
@@ -449,6 +454,7 @@ DEPENDENCIES
   gds-api-adapters
   gds-sso
   govuk_app_config
+  govuk_message_queue_consumer
   govuk_test
   listen
   openid_connect

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec unicorn -c ./config/unicorn.rb -p ${PORT:-3000}
+publishing-queue-listener: rake message_queue:consumer

--- a/lib/message_queue_processor.rb
+++ b/lib/message_queue_processor.rb
@@ -1,0 +1,92 @@
+class MessageQueueProcessor
+  def process(message)
+    summary = process_message(message.payload)
+    message.ack
+    Rails.logger.info summary.to_json
+  end
+
+  # For the details of unpublishing types, the publishing-api docs are
+  # the canonical source:
+  # https://github.com/alphagov/publishing-api/blob/main/docs/model.md#unpublishing
+  def process_message(payload)
+    affected = SavedPage.where(content_id: payload["content_id"])
+    affected_count = affected.count
+
+    effect =
+      case payload["document_type"]
+      when "gone"
+        redirect_saved_pages(affected, find_alternative_path(payload))
+      when "redirect"
+        redirect_saved_pages(affected, find_alternative_path(payload))
+      when "vanish"
+        destroy_saved_pages(affected)
+      else
+        update_saved_pages(affected, payload)
+      end
+
+    {
+      type: payload["document_type"],
+      base_path: payload["base_path"],
+      content_id: payload["content_id"],
+      affected_pages: affected_count,
+      effect: effect,
+    }
+  end
+
+  def find_alternative_path(payload)
+    alternative_path = payload.dig("details", "alternative_path")
+    return alternative_path if alternative_path
+
+    exact_redirect = payload["redirects"]&.find { |r| r["type"] == "exact" && payload["base_path"] == r["path"] }
+    return exact_redirect["destination"] if exact_redirect
+
+    prefix_redirect = payload["redirects"]&.select { |r| r["type"] == "prefix" && payload["base_path"].start_with?(r["path"]) }&.max_by { |r| r["path"].length }
+    if prefix_redirect
+      if prefix_redirect["segments_mode"] == "preserve"
+        prefix_redirect["destination"] + payload["base_path"].delete_prefix(prefix_redirect["path"])
+      else
+        prefix_redirect["destination"]
+      end
+    end
+  end
+
+  def redirect_saved_pages(saved_pages, alternative_path)
+    if alternative_path
+      target_content_item = GdsApi.content_store.content_item(alternative_path).to_hash
+
+      redirected_count = 0
+      destroyed_count = 0
+      saved_pages.each do |page|
+        page.update!(
+          content_id: target_content_item.fetch("content_id"),
+          title: target_content_item["title"],
+          page_path: alternative_path,
+          updated_at: Time.zone.now,
+        )
+        redirected_count += 1
+      rescue ActiveRecord::RecordInvalid
+        page.destroy!
+        destroyed_count += 1
+      end
+
+      "redirected #{redirected_count} to #{alternative_path} and destroyed #{destroyed_count} duplicates"
+    else
+      destroy_saved_pages(saved_pages)
+    end
+  end
+
+  def destroy_saved_pages(saved_pages)
+    saved_pages.destroy_all
+
+    "destroyed"
+  end
+
+  def update_saved_pages(saved_pages, payload)
+    saved_pages.update_all(
+      title: payload["title"],
+      updated_at: Time.zone.now,
+    )
+
+    "updated"
+  end
+end

--- a/lib/tasks/message_queue.rake
+++ b/lib/tasks/message_queue.rake
@@ -1,0 +1,11 @@
+require_relative "../message_queue_processor.rb"
+
+namespace :message_queue do
+  desc "Run worker to consume messages from RabbitMQ"
+  task consumer: :environment do
+    GovukMessageQueueConsumer::Consumer.new(
+      queue_name: "account_api",
+      processor: MessageQueueProcessor.new,
+    ).run
+  end
+end

--- a/spec/lib/message_queue_processor_spec.rb
+++ b/spec/lib/message_queue_processor_spec.rb
@@ -1,0 +1,244 @@
+require "message_queue_processor"
+
+require "gds_api/test_helpers/content_store"
+require "govuk_message_queue_consumer/test_helpers"
+
+RSpec.describe MessageQueueProcessor do
+  include GdsApi::TestHelpers::ContentStore
+
+  it_behaves_like "a message queue processor"
+
+  it "acks incoming messages" do
+    message = GovukMessageQueueConsumer::MockMessage.new
+    described_class.new.process(message)
+    expect(message).to be_acked
+  end
+
+  describe "process_message" do
+    subject(:actual_output) { described_class.new.process_message(payload) }
+
+    let(:payload) { GovukSchemas::RandomExample.for_schema(notification_schema: "guide") }
+    let(:content_item) { payload }
+
+    let!(:saved_page) { FactoryBot.create(:saved_page, content_id: payload["content_id"], page_path: payload["base_path"] || "/example-page") }
+
+    let(:expected_output) do
+      {
+        type: payload["document_type"],
+        base_path: payload["base_path"],
+        content_id: payload["content_id"],
+        affected_pages: 1,
+        effect: expected_effect,
+      }
+    end
+
+    let(:expected_effect) { "updated" }
+
+    let(:expected_to_hash) do
+      {
+        "content_id" => content_item["content_id"],
+        "page_path" => content_item["base_path"],
+        "title" => content_item["title"],
+      }
+    end
+
+    it "updates the page attributes" do
+      expect(actual_output).to eq(expected_output)
+      expect(saved_page.reload.to_hash).to eq(expected_to_hash)
+    end
+
+    context "with a 'gone' notification" do
+      let(:alternative_path) { nil }
+      let(:expected_effect) { "destroyed" }
+
+      let(:payload) do
+        GovukSchemas::RandomExample.for_schema(notification_schema: "gone") do |payload|
+          payload["details"] ||= {}
+          payload["details"] = payload["details"].merge("alternative_path" => alternative_path).compact
+          payload
+        end
+      end
+
+      it "destroys matching pages" do
+        expect(actual_output).to eq(expected_output)
+        expect { saved_page.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      context "with an alternative path" do
+        let(:alternative_path) { "/alternative-path" }
+        let(:content_item) { content_item_for_base_path(alternative_path).merge("content_id" => SecureRandom.uuid) }
+        let(:expected_effect) { "redirected 1 to #{alternative_path} and destroyed 0 duplicates" }
+
+        before { stub_content_store_has_item(alternative_path, content_item) }
+
+        it "updates matching pages" do
+          expect(actual_output).to eq(expected_output)
+          expect(saved_page.reload.to_hash).to eq(expected_to_hash)
+        end
+      end
+    end
+
+    context "with a 'redirect' notification" do
+      let(:alternative_path) { "/alternative-path" }
+      let(:content_item) { content_item_for_base_path(alternative_path).merge("content_id" => SecureRandom.uuid) }
+      let(:expected_effect) { "redirected 1 to #{alternative_path} and destroyed 0 duplicates" }
+
+      let(:payload) do
+        GovukSchemas::RandomExample.for_schema(notification_schema: "redirect") do |payload|
+          payload.merge(
+            "redirects" => [{ "path" => payload["base_path"], "type" => "exact", "destination" => alternative_path }],
+          )
+        end
+      end
+
+      before { stub_content_store_has_item(alternative_path, content_item) }
+
+      it "updates matching pages" do
+        expect(actual_output).to eq(expected_output)
+        expect(saved_page.reload.to_hash).to eq(expected_to_hash)
+      end
+    end
+
+    context "with a 'vanish' notification" do
+      let(:payload) { GovukSchemas::RandomExample.for_schema(notification_schema: "vanish") }
+      let(:expected_effect) { "destroyed" }
+
+      it "destroys matching pages" do
+        expect(actual_output).to eq(expected_output)
+        expect { saved_page.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+
+  describe "find_alternative_path" do
+    subject(:alternative_path) { described_class.new.find_alternative_path(payload) }
+
+    let(:payload) { { "base_path" => "/base/path", "details" => details, "redirects" => redirects }.compact }
+    let(:details) { { "alternative_path" => "/alternative-path" } }
+    let(:redirects) { [exact_redirect, prefix_redirect].compact }
+    let(:exact_redirect) { { "type" => "exact", "path" => "/base/path", "destination" => "/exact-redirect" } }
+    let(:prefix_redirect) { { "type" => "prefix", "path" => "/base", "destination" => "/prefix-redirect" } }
+
+    it "uses the alternative_path" do
+      expect(alternative_path).to eq(details["alternative_path"])
+    end
+
+    context "when there is no alternative_path" do
+      let(:details) { nil }
+
+      it "uses the exact redirect" do
+        expect(alternative_path).to eq(exact_redirect["destination"])
+      end
+
+      context "when the exact redirect is for a different path" do
+        let(:exact_redirect) { { "type" => "exact", "path" => "/some/path2", "destination" => "/exact-redirect" } }
+
+        it "uses the prefix redirect" do
+          expect(alternative_path).to eq(prefix_redirect["destination"])
+        end
+      end
+
+      context "when there is no exact redirect" do
+        let(:exact_redirect) { nil }
+
+        it "uses the prefix redirect" do
+          expect(alternative_path).to eq(prefix_redirect["destination"])
+        end
+
+        context "when segments_mode is 'preserve'" do
+          let(:prefix_redirect) { { "type" => "prefix", "path" => "/base", "destination" => "/prefix-redirect", "segments_mode" => "preserve" } }
+
+          it "keeps the trailing bits of the path" do
+            expect(alternative_path).to eq("/prefix-redirect/path")
+          end
+        end
+
+        context "when there are multiple matching prefix redirects" do
+          let(:redirects) do
+            [
+              { "type" => "prefix", "path" => "/base", "destination" => "/prefix-redirect-0" },
+              { "type" => "prefix", "path" => "/base/path", "destination" => "/prefix-redirect-1" },
+              { "type" => "prefix", "path" => "/base/path/inner", "destination" => "/prefix-redirect-1" },
+            ]
+          end
+
+          it "uses the most specific matching one" do
+            expect(alternative_path).to eq("/prefix-redirect-1")
+          end
+        end
+
+        context "when the prefix redirect is for a different path" do
+          let(:prefix_redirect) { { "type" => "prefix", "path" => "/base2", "destination" => "/prefix-redirect" } }
+
+          it "returns nil" do
+            expect(alternative_path).to be_nil
+          end
+        end
+
+        context "when there is no prefix redirect" do
+          let(:prefix_redirect) { nil }
+
+          it "returns nil" do
+            expect(alternative_path).to be_nil
+          end
+        end
+
+        context "when there are no redirects at all" do
+          let(:redirects) { nil }
+
+          it "returns nil" do
+            expect(alternative_path).to be_nil
+          end
+        end
+      end
+    end
+  end
+
+  describe "redirect_saved_pages" do
+    subject(:effect) { described_class.new.redirect_saved_pages(saved_pages, alternative_path) }
+
+    let(:alternative_path) { "/alternative-path" }
+    let(:content_id) { SecureRandom.uuid }
+    let(:title) { "Hello World" }
+    let(:saved_pages) do
+      [
+        FactoryBot.create(:saved_page, page_path: "/foo"),
+        FactoryBot.create(:saved_page, page_path: "/foo"),
+        FactoryBot.create(:saved_page, page_path: "/foo"),
+      ]
+    end
+
+    before do
+      stub_content_store_has_item(
+        alternative_path,
+        content_item_for_base_path(alternative_path).merge("content_id" => content_id, "title" => title),
+      )
+    end
+
+    it "updates the page paths" do
+      expect(effect).to eq("redirected 3 to #{alternative_path} and destroyed 0 duplicates")
+
+      saved_pages.each do |page|
+        expect(page.reload.content_id).to eq(content_id)
+        expect(page.reload.page_path).to eq(alternative_path)
+        expect(page.reload.title).to eq(title)
+      end
+    end
+
+    context "with duplicate pages" do
+      let(:user) { FactoryBot.create(:oidc_user) }
+      let(:saved_pages) do
+        [
+          FactoryBot.create(:saved_page, page_path: "/foo"),
+          FactoryBot.create(:saved_page, page_path: "/foo", oidc_user: user),
+          FactoryBot.create(:saved_page, page_path: alternative_path, oidc_user: user),
+        ]
+      end
+
+      it "destroys duplicate pages" do
+        expect(effect).to eq("redirected 2 to #{alternative_path} and destroyed 1 duplicates")
+        expect(SavedPage.all.pluck(:page_path)).to eq([alternative_path, alternative_path])
+      end
+    end
+  end
+end


### PR DESCRIPTION
For "gone" notifications, redirect if there is an alternative path or
delete the saved page if not.

For "redirect" notifications, redirect if there is a matching
redirect (including gracefully handling prefix redirects) or delete
the saved page if not.

For "vanish" notifications, delete the saved page.

For other notifications, update the saved information.

See also https://github.com/alphagov/govuk-puppet/pull/11111

---

[Trello card](https://trello.com/c/8EadgviV/772-get-account-api-consuming-publishing-messages-from-rabbitmq)