### PR TITLE
Cache the OIDC discovery response

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ ruby File.read(".ruby-version").strip
 gem "rails", "6.1.3.2"
 
 gem "bootsnap"
+gem "dalli"
 gem "gds-sso"
 gem "govuk_app_config"
 gem "openid_connect"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    dalli (2.7.11)
     diff-lcs (1.4.4)
     dig_rb (1.0.1)
     docile (1.3.5)
@@ -416,6 +417,7 @@ DEPENDENCIES
   bootsnap
   bullet
   climate_control
+  dalli
   factory_bot_rails
   gds-sso
   govuk_app_config

--- a/app/lib/oidc_client.rb
+++ b/app/lib/oidc_client.rb
@@ -227,6 +227,10 @@ protected
   end
 
   def discover
-    @discover ||= OpenIDConnect::Discovery::Provider::Config.discover! provider_uri
+    @discover ||= OpenIDConnect::Discovery::Provider::Config::Response.new cached_discover_response
+  end
+
+  def cached_discover_response
+    Rails.cache.fetch("oidc/discover/#{provider_uri}") { OpenIDConnect::Discovery::Provider::Config.discover!(provider_uri).raw }
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
   config.log_tags = [:request_id]
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :mem_cache_store, nil, { namespace: :account_api, compress: true }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
     GovukHealthcheck::ActiveRecord,
+    GovukHealthcheck::RailsCache,
   )
 
   scope :api do

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -37,13 +37,12 @@ Pact.provider_states_for "GDS API Adapters" do
     WebMock.enable!
     WebMock.reset!
 
-    discovery_response = instance_double(
-      "OpenIDConnect::Discovery::Provider::Config::Response",
+    discovery_response = {
       authorization_endpoint: "http://openid-provider/authorization-endpoint",
       token_endpoint: "http://openid-provider/token-endpoint",
       userinfo_endpoint: "http://openid-provider/userinfo-endpoint",
       end_session_endpoint: "http://openid-provider/end-session-endpoint",
-    )
+    }
 
     token_response = {
       access_token: "access-token",
@@ -59,7 +58,7 @@ Pact.provider_states_for "GDS API Adapters" do
     }
 
     # rubocop:disable RSpec/AnyInstance
-    allow_any_instance_of(OidcClient).to receive(:discover).and_return(discovery_response)
+    allow_any_instance_of(OidcClient).to receive(:cached_discover_response).and_return(discovery_response)
     allow_any_instance_of(OidcClient).to receive(:tokens!).and_return(token_response)
     # rubocop:enable RSpec/AnyInstance
 

--- a/spec/support/helpers/oidc_client_helper.rb
+++ b/spec/support/helpers/oidc_client_helper.rb
@@ -1,15 +1,14 @@
 module OidcClientHelper
   def stub_oidc_discovery
-    discovery_response = instance_double(
-      "OpenIDConnect::Discovery::Provider::Config::Response",
+    discovery_response = {
       authorization_endpoint: "http://openid-provider/authorization-endpoint",
       token_endpoint: "http://openid-provider/token-endpoint",
       userinfo_endpoint: "http://openid-provider/userinfo-endpoint",
       end_session_endpoint: "http://openid-provider/end-session-endpoint",
-    )
+    }
 
     # rubocop:disable RSpec/AnyInstance
-    allow_any_instance_of(OidcClient).to receive(:discover).and_return(discovery_response)
+    allow_any_instance_of(OidcClient).to receive(:cached_discover_response).and_return(discovery_response)
     # rubocop:enable RSpec/AnyInstance
   end
 


### PR DESCRIPTION
We use OIDC discovery to avoid hard-coding things like URLs or keys in
this app.  This method makes an HTTP request to the Identity
Provider (govuk-account-manager-prototype) and then validates the
response.  But this response changes very infrequently, so this is
adding an unnecessary (and slow) network hop to almost every
account-api response.

This is most visible in the auth endpoint which, despite only
generating a URL, commonly takes 150ms because it's got this extra
request and validation going on, but it impacts the attribute and
Transition Checker email endpoints too.

---

[Trello card](https://trello.com/c/F4q6raJf/785-cache-oidc-discovery-response)