### PR TITLE
Re-use RSpec helpers in Pact helper

### DIFF
--- a/spec/support/helpers/govuk_account_session_helper.rb
+++ b/spec/support/helpers/govuk_account_session_helper.rb
@@ -1,5 +1,9 @@
 module GovukAccountSessionHelper
   def placeholder_govuk_account_session(options = {})
+    placeholder_govuk_account_session_object(options).serialise
+  end
+
+  def placeholder_govuk_account_session_object(options = {})
     AccountSession.new(
       **{
         session_signing_key: Rails.application.secrets.session_signing_key,
@@ -8,7 +12,7 @@ module GovukAccountSessionHelper
         refresh_token: "refresh-token",
         level_of_authentication: AccountSession::LOWEST_LEVEL_OF_AUTHENTICATION,
       }.merge(options),
-    ).serialise
+    )
   end
 end
 


### PR DESCRIPTION
This reduces a little code duplication between Pact and RSpec.