### PR TITLE
Cache transition_checker_state locally

### DIFF
--- a/app/lib/user_attributes.rb
+++ b/app/lib/user_attributes.rb
@@ -1,5 +1,5 @@
 class UserAttributes
-  CONFIG_KEYS = %w[is_stored_locally permissions].freeze
+  CONFIG_KEYS = %w[is_stored_locally is_cached_locally permissions].freeze
   PERMISSION_KEYS = %w[check get set].freeze
 
   attr_reader :attributes
@@ -14,6 +14,10 @@ class UserAttributes
 
   def stored_locally?(name)
     attributes.fetch(name)[:is_stored_locally]
+  end
+
+  def cached_locally?(name)
+    attributes.fetch(name)[:is_cached_locally]
   end
 
   def has_permission_for?(name, permission_level, user_session)
@@ -36,8 +40,12 @@ class UserAttributes
       unknown_keys = config.keys - CONFIG_KEYS
 
       invalid_keys = []
-      unless config["is_stored_locally"].in?([nil, false, true])
-        invalid_keys << "is_stored_locally"
+      %w[is_stored_locally is_cached_locally].each do |key|
+        invalid_keys << key unless config[key].in?([nil, false, true])
+      end
+
+      if config["is_stored_locally"] == true && config["is_cached_locally"] == true
+        invalid_keys << "is_cached_locally"
       end
 
       permissions = config["permissions"]

--- a/config/user_attributes.yml
+++ b/config/user_attributes.yml
@@ -1,6 +1,7 @@
 ---
 transition_checker_state:
   is_stored_locally: false
+  is_cached_locally: true
   permissions:
     check: 0
     get: 1

--- a/spec/fixtures/user_attributes.yml
+++ b/spec/fixtures/user_attributes.yml
@@ -1,5 +1,6 @@
 test_attribute_1:
   is_stored_locally: false
+  is_cached_locally: false
   permissions:
     check: 0
     get: 0
@@ -7,6 +8,15 @@ test_attribute_1:
 
 test_attribute_2:
   is_stored_locally: false
+  is_cached_locally: false
+  permissions:
+    check: 0
+    get: 0
+    set: 0
+
+test_attribute_cache:
+  is_stored_locally: false
+  is_cached_locally: true
   permissions:
     check: 0
     get: 0
@@ -14,6 +24,7 @@ test_attribute_2:
 
 test_local_attribute:
   is_stored_locally: true
+  is_cached_locally: false
   permissions:
     check: 0
     get: 0
@@ -21,6 +32,7 @@ test_local_attribute:
 
 foo:
   is_stored_locally: false
+  is_cached_locally: false
   permissions:
     check: 0
     get: 0
@@ -28,6 +40,7 @@ foo:
 
 bar:
   is_stored_locally: false
+  is_cached_locally: false
   permissions:
     check: 0
     get: 0

--- a/spec/lib/account_session_spec.rb
+++ b/spec/lib/account_session_spec.rb
@@ -135,6 +135,15 @@ RSpec.describe AccountSession do
           expect(account_session.get_attributes([attribute_name1, attribute_name2])).to eq({ attribute_name2 => attribute_value2 })
         end
       end
+
+      context "when an attribute is cached_locally" do
+        let(:attribute_name1) { "test_attribute_cache" }
+
+        it "fetches the attribute and stores it locally" do
+          expect { account_session.get_attributes([attribute_name1]) }.to change(LocalAttribute, :count)
+          expect(account_session.get_attributes([attribute_name1])).to eq({ attribute_name1 => attribute_value1 })
+        end
+      end
     end
 
     describe "set_attributes" do
@@ -177,6 +186,18 @@ RSpec.describe AccountSession do
           stub = stub_set_remote_attributes
           account_session.set_attributes(attributes)
           expect(stub).not_to have_been_made
+        end
+      end
+
+      context "when an attribute is cached_locally" do
+        let(:attribute_name1) { "test_attribute_cache" }
+        let(:remote_attributes) { { attribute_name1 => attribute_value1 } }
+        let(:local_attributes) { {} }
+
+        it "sets the attribute both locally and remotely" do
+          stub = stub_set_remote_attributes
+          expect { account_session.set_attributes(attributes) }.to change(LocalAttribute, :count)
+          expect(stub).to have_been_made
         end
       end
 

--- a/spec/lib/user_attributes_spec.rb
+++ b/spec/lib/user_attributes_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe UserAttributes do
 
   describe "validation" do
     let(:attributes) { { "foo" => foo_properties, "bar" => bar_properties } }
-    let(:foo_properties) { { "is_stored_locally" => true, "permissions" => foo_permissions } }
+    let(:foo_properties) { { "is_stored_locally" => true, "is_cached_locally" => false, "permissions" => foo_permissions } }
     let(:foo_permissions) { { "check" => 0, "get" => 0, "set" => 1 } }
-    let(:bar_properties) { { "is_stored_locally" => false, "permissions" => bar_permissions } }
+    let(:bar_properties) { { "is_stored_locally" => false, "is_cached_locally" => false, "permissions" => bar_permissions } }
     let(:bar_permissions) { { "check" => 1, "get" => 1, "set" => 1 } }
 
     let(:errors) { described_class.validate(attributes) }
@@ -21,12 +21,12 @@ RSpec.describe UserAttributes do
         let(:foo_properties) { {} }
 
         it "rejects" do
-          expect(errors).to eq({ "foo" => { missing_keys: %w[is_stored_locally permissions] } })
+          expect(errors).to eq({ "foo" => { missing_keys: %w[is_stored_locally is_cached_locally permissions] } })
         end
       end
 
       context "when an unexpected top-level key is present" do
-        let(:bar_properties) { { "is_stored_loally" => true, "permissions" => bar_permissions } }
+        let(:bar_properties) { { "is_stored_loally" => true, "is_cached_locally" => false, "permissions" => bar_permissions } }
 
         it "rejects" do
           expect(errors).to eq({ "bar" => { missing_keys: %w[is_stored_locally], unknown_keys: %w[is_stored_loally] } })
@@ -34,10 +34,18 @@ RSpec.describe UserAttributes do
       end
 
       context "when a key has an unexpected value" do
-        let(:foo_properties) { { "is_stored_locally" => "banana", "permissions" => foo_permissions } }
+        let(:foo_properties) { { "is_stored_locally" => "banana", "is_cached_locally" => true, "permissions" => foo_permissions } }
 
         it "rejects" do
           expect(errors).to eq({ "foo" => { invalid_keys: %w[is_stored_locally] } })
+        end
+      end
+
+      context "when a key is both stored and cached locally" do
+        let(:foo_properties) { { "is_stored_locally" => true, "is_cached_locally" => true, "permissions" => foo_permissions } }
+
+        it "rejects" do
+          expect(errors).to eq({ "foo" => { invalid_keys: %w[is_cached_locally] } })
         end
       end
     end


### PR DESCRIPTION
At some point, we'll move the "Your Account" page from the
account-manager and onto GOV.UK proper (www.gov.uk/account ?).  When
that happens, this account-api will the only user of the
transition_checker_state attribute.

So to improve performance, we'd like to migrate the attribute from the
attribute-service into this app's database.  But we don't want to have
any downtime, so we can't go for the simple approach of:

1. Block updates to the attribute
2. Dump the attribute-service database
3. Import the attribute-service database into the account-api
4. Unblock updates to the attribute

As while the dump&import happens users won't be able to make changes.
Instead we want an online approach, which this commit enables:

1. Get account-api persisting transition_checker_state both
locally *and* remotely.

This is safe because account-api is the only *writer* of this
attribute value.  We don't need to keep anything else in sync.

Then later, we can do this:

2. Add an endpoint to attribute-service to expose the attribute values
3. Run a background task in account-api to fetch values which haven't
already been copied across by (1)
4. Stop account-api persisting the values remotely

This commit by itself is only the first step of the migration.  For
now, it will improve performance for users returning to their saved
results because, as values get cached locally, we won't have to query
the attribute-service to retrieve someone's saved results.

---

[Trello caerd](https://trello.com/c/gLfDdRtf/807-cache-transition-checker-answers-in-account-api)