### PR TITLE
Handle redirects where the target content item does not exist

### DIFF
--- a/lib/message_queue_processor.rb
+++ b/lib/message_queue_processor.rb
@@ -73,6 +73,8 @@ class MessageQueueProcessor
     else
       destroy_saved_pages(saved_pages)
     end
+  rescue GdsApi::ContentStore::ItemNotFound
+    destroy_saved_pages(saved_pages)
   end
 
   def destroy_saved_pages(saved_pages)


### PR DESCRIPTION
There is a small list (somewhere) of other government websites which
our content items can redirect to (e.g., www.justice.gov.uk).
Ultimately how to handle this is a design question but for now, for
the sake of getting a rough version of saved-page updating up and
running, just delete pages where the redirect target is not a genuine
GOV.UK content item.
