### PR TITLE
Refactor config code a little, add a notion of unwritable attributes, and make `email` and `email_verified` available

### DIFF
--- a/app/controllers/attributes_controller.rb
+++ b/app/controllers/attributes_controller.rb
@@ -25,6 +25,11 @@ private
     unknown_attributes = attribute_names.reject { |name| user_attributes.defined? name }
     raise ApiError::UnknownAttributeNames, { attributes: unknown_attributes } if unknown_attributes.any?
 
+    if permission_level == :set
+      unwritable_attributes = attribute_names.reject { |name| user_attributes.is_writable? name }
+      raise ApiError::UnwritableAttributes, { attributes: unwritable_attributes } if unwritable_attributes.any?
+    end
+
     if Rails.application.config.feature_flag_enforce_levels_of_authentication
       forbidden_attributes = attribute_names.reject { |name| user_attributes.has_permission_for? name, permission_level, @govuk_account_session }
       if forbidden_attributes.any?

--- a/app/lib/account_session.rb
+++ b/app/lib/account_session.rb
@@ -75,9 +75,9 @@ class AccountSession
   end
 
   def get_attributes(attribute_names)
-    local = attribute_names.select { |name| user_attributes.stored_locally? name }
-    remote = attribute_names.select { |name| !user_attributes.stored_locally?(name) && !user_attributes.cached_locally?(name) }
-    cached = attribute_names.select { |name| user_attributes.cached_locally? name }
+    local = attribute_names.select { |name| user_attributes.type(name) == "local" }
+    remote = attribute_names.select { |name| user_attributes.type(name) == "remote" }
+    cached = attribute_names.select { |name| user_attributes.type(name) == "cached" }
 
     if cached
       values_already_cached = get_local_attributes(cached)
@@ -92,9 +92,9 @@ class AccountSession
   end
 
   def set_attributes(attributes)
-    local = attributes.select { |name| user_attributes.stored_locally? name }
-    remote = attributes.select { |name| !user_attributes.stored_locally?(name) && !user_attributes.cached_locally?(name) }
-    cached = attributes.select { |name| user_attributes.cached_locally? name }
+    local = attributes.select { |name| user_attributes.type(name) == "local" }
+    remote = attributes.select { |name| user_attributes.type(name) == "remote" }
+    cached = attributes.select { |name| user_attributes.type(name) == "cached" }
 
     if cached
       set_local_attributes(cached)

--- a/app/lib/api_error/unwritable_attributes.rb
+++ b/app/lib/api_error/unwritable_attributes.rb
@@ -1,0 +1,25 @@
+module ApiError
+  class UnwritableAttributes < ApiError::Base
+    def initialize(attributes:)
+      super
+      @attributes = attributes
+    end
+
+    def status_code
+      :forbidden
+    end
+
+    def detail
+      I18n.t(
+        "errors.unwritable_attributes.detail",
+        attributes: @attributes.join(", "),
+      )
+    end
+
+    def extra_detail
+      {
+        attributes: @attributes,
+      }
+    end
+  end
+end

--- a/app/lib/oidc_client.rb
+++ b/app/lib/oidc_client.rb
@@ -3,7 +3,7 @@ require "openid_connect"
 class OidcClient
   class OAuthFailure < RuntimeError; end
 
-  DEFAULT_SCOPES = %i[transition_checker openid].freeze
+  DEFAULT_SCOPES = %i[email transition_checker openid].freeze
 
   attr_reader :client_id,
               :provider_uri

--- a/app/lib/user_attributes.rb
+++ b/app/lib/user_attributes.rb
@@ -1,5 +1,5 @@
 class UserAttributes
-  CONFIG_KEYS = %w[is_stored_locally is_cached_locally permissions].freeze
+  CONFIG_KEYS = %w[type permissions].freeze
   PERMISSION_KEYS = %w[check get set].freeze
 
   attr_reader :attributes
@@ -12,12 +12,8 @@ class UserAttributes
     attributes.key? name
   end
 
-  def stored_locally?(name)
-    attributes.fetch(name)[:is_stored_locally]
-  end
-
-  def cached_locally?(name)
-    attributes.fetch(name)[:is_cached_locally]
+  def type(name)
+    attributes.fetch(name)[:type]
   end
 
   def has_permission_for?(name, permission_level, user_session)
@@ -38,15 +34,9 @@ class UserAttributes
 
       missing_keys = CONFIG_KEYS - config.keys
       unknown_keys = config.keys - CONFIG_KEYS
-
       invalid_keys = []
-      %w[is_stored_locally is_cached_locally].each do |key|
-        invalid_keys << key unless config[key].in?([nil, false, true])
-      end
 
-      if config["is_stored_locally"] == true && config["is_cached_locally"] == true
-        invalid_keys << "is_cached_locally"
-      end
+      invalid_keys << "type" if config["type"] && !config["type"].in?(%w[local remote cached])
 
       permissions = config["permissions"]
       if permissions

--- a/config/locales/errors.en.yml
+++ b/config/locales/errors.en.yml
@@ -9,6 +9,10 @@ en:
       type: https://github.com/alphagov/account-api/blob/main/docs/api.md#unknown-attribute-names
       title: Unknown attribute names
       detail: Attribute names %{attributes} are unknown, have they been added to config/user_attributes.yml?
+    unwritable_attributes:
+      type: https://github.com/alphagov/account-api/blob/main/docs/api.md#unwritable-attributes
+      title: Unwritable attributes
+      detail: Attributes %{attributes} cannot be updated through the account-api.
     cannot_save_page:
       type: https://github.com/alphagov/account-api/blob/main/docs/api.md#cannot-save-page
       title: Cannot save page

--- a/config/user_attributes.yml
+++ b/config/user_attributes.yml
@@ -1,4 +1,18 @@
 ---
+email:
+  type: remote
+  writable: false
+  permissions:
+    check: 0
+    get: 0
+
+email_verified:
+  type: remote
+  writable: false
+  permissions:
+    check: 0
+    get: 0
+
 transition_checker_state:
   type: cached
   permissions:

--- a/config/user_attributes.yml
+++ b/config/user_attributes.yml
@@ -1,7 +1,6 @@
 ---
 transition_checker_state:
-  is_stored_locally: false
-  is_cached_locally: true
+  type: cached
   permissions:
     check: 0
     get: 1

--- a/docs/api.md
+++ b/docs/api.md
@@ -30,6 +30,7 @@ management. This API is not for other government services.
 - [API errors](#api-errors)
   - [Level of authentication too low](#level-of-authentication-too-low)
   - [Unknown attribute names](#unknown-attribute-names)
+  - [Unwritable attributes](#unwritable-attributes)
   - [Page cannot be saved](#page-cannot-be-saved)
 
 ## Nomenclature
@@ -408,6 +409,7 @@ Updates the attributes of the current user.
 #### Response codes
 
 - 422 if any attributes are unknown (see [error: unknown attribute names](#unknown-attribute-names))
+- 403 if any attributes are unwritable (see [error: unwritable attributes](#unwritable-attributes))
 - 403 if the session's level of authentication is too low (see [error: level of authentication too low](#level-of-authentication-too-low))
 - 401 if the session identifier is invalid
 - 200 otherwise
@@ -789,6 +791,13 @@ level to access.
 
 One or more of the attribute names you have specified are not known.
 The `attributes` response field lists these.
+
+### Unwritable attributes
+
+One or more of the attributes you have specified cannot be updated
+through account-api.  The `attributes` response field lists these.
+
+Do not just reauthenticate the user and try again.
 
 ### Page cannot be saved
 

--- a/spec/fixtures/user_attributes.yml
+++ b/spec/fixtures/user_attributes.yml
@@ -1,46 +1,40 @@
 test_attribute_1:
-  is_stored_locally: false
-  is_cached_locally: false
+  type: remote
   permissions:
     check: 0
     get: 0
     set: 0
 
 test_attribute_2:
-  is_stored_locally: false
-  is_cached_locally: false
+  type: remote
   permissions:
     check: 0
     get: 0
     set: 0
 
 test_attribute_cache:
-  is_stored_locally: false
-  is_cached_locally: true
+  type: cached
   permissions:
     check: 0
     get: 0
     set: 0
 
 test_local_attribute:
-  is_stored_locally: true
-  is_cached_locally: false
+  type: local
   permissions:
     check: 0
     get: 0
     set: 0
 
 foo:
-  is_stored_locally: false
-  is_cached_locally: false
+  type: remote
   permissions:
     check: 0
     get: 0
     set: 0
 
 bar:
-  is_stored_locally: false
-  is_cached_locally: false
+  type: remote
   permissions:
     check: 0
     get: 0

--- a/spec/fixtures/user_attributes.yml
+++ b/spec/fixtures/user_attributes.yml
@@ -26,6 +26,13 @@ test_local_attribute:
     get: 0
     set: 0
 
+test_unwritable_attribute:
+  type: local
+  writable: false
+  permissions:
+    check: 0
+    get: 0
+
 foo:
   type: remote
   permissions:

--- a/spec/lib/oidc_client_spec.rb
+++ b/spec/lib/oidc_client_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe OidcClient do
 
   describe "auth_uri" do
     it "includes the requested level of authentication in the scopes" do
-      expect(client.auth_uri(AuthRequest.generate!, "level1234567890")).to include("scope=transition_checker%20openid%20level1234567890")
+      expect(client.auth_uri(AuthRequest.generate!, "level1234567890")).to include("scope=email%20transition_checker%20openid%20level1234567890")
     end
   end
 

--- a/spec/lib/user_attributes_spec.rb
+++ b/spec/lib/user_attributes_spec.rb
@@ -67,6 +67,14 @@ RSpec.describe UserAttributes do
         end
       end
 
+      context "when the attribute is not writable, but there is a set permission" do
+        let(:foo_properties) { { "type" => "local", "writable" => false, "permissions" => foo_permissions } }
+
+        it "rejects" do
+          expect(errors).to eq({ "foo" => { unknown_keys: %w[permissions.set] } })
+        end
+      end
+
       context "when check requires a higher permission than get" do
         let(:foo_permissions) { { "check" => 1, "get" => 0, "set" => 0 } }
 

--- a/spec/lib/user_attributes_spec.rb
+++ b/spec/lib/user_attributes_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe UserAttributes do
 
   describe "validation" do
     let(:attributes) { { "foo" => foo_properties, "bar" => bar_properties } }
-    let(:foo_properties) { { "is_stored_locally" => true, "is_cached_locally" => false, "permissions" => foo_permissions } }
+    let(:foo_properties) { { "type" => "local", "permissions" => foo_permissions } }
     let(:foo_permissions) { { "check" => 0, "get" => 0, "set" => 1 } }
-    let(:bar_properties) { { "is_stored_locally" => false, "is_cached_locally" => false, "permissions" => bar_permissions } }
+    let(:bar_properties) { { "type" => "remote", "permissions" => bar_permissions } }
     let(:bar_permissions) { { "check" => 1, "get" => 1, "set" => 1 } }
 
     let(:errors) { described_class.validate(attributes) }
@@ -21,31 +21,23 @@ RSpec.describe UserAttributes do
         let(:foo_properties) { {} }
 
         it "rejects" do
-          expect(errors).to eq({ "foo" => { missing_keys: %w[is_stored_locally is_cached_locally permissions] } })
+          expect(errors).to eq({ "foo" => { missing_keys: %w[type permissions] } })
         end
       end
 
       context "when an unexpected top-level key is present" do
-        let(:bar_properties) { { "is_stored_loally" => true, "is_cached_locally" => false, "permissions" => bar_permissions } }
+        let(:bar_properties) { { "tye" => "local", "permissions" => bar_permissions } }
 
         it "rejects" do
-          expect(errors).to eq({ "bar" => { missing_keys: %w[is_stored_locally], unknown_keys: %w[is_stored_loally] } })
+          expect(errors).to eq({ "bar" => { missing_keys: %w[type], unknown_keys: %w[tye] } })
         end
       end
 
       context "when a key has an unexpected value" do
-        let(:foo_properties) { { "is_stored_locally" => "banana", "is_cached_locally" => true, "permissions" => foo_permissions } }
+        let(:foo_properties) { { "type" => "banana", "permissions" => foo_permissions } }
 
         it "rejects" do
-          expect(errors).to eq({ "foo" => { invalid_keys: %w[is_stored_locally] } })
-        end
-      end
-
-      context "when a key is both stored and cached locally" do
-        let(:foo_properties) { { "is_stored_locally" => true, "is_cached_locally" => true, "permissions" => foo_permissions } }
-
-        it "rejects" do
-          expect(errors).to eq({ "foo" => { invalid_keys: %w[is_cached_locally] } })
+          expect(errors).to eq({ "foo" => { invalid_keys: %w[type] } })
         end
       end
     end

--- a/spec/requests/attributes_spec.rb
+++ b/spec/requests/attributes_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "Attributes" do
   let(:attribute_name1) { "test_attribute_1" }
   let(:attribute_name2) { "test_attribute_2" }
   let(:local_attribute_name) { "test_local_attribute" }
+  let(:unwritable_attribute_name) { "test_unwritable_attribute" }
   let(:attribute_value1) { { "some" => "complex", "value" => 42 } }
   let(:attribute_value2) { [1, 2, 3, 4, 5] }
   let(:local_attribute_value) { [1, 2, { "buckle" => %w[my shoe] }] }
@@ -224,6 +225,19 @@ RSpec.describe "Attributes" do
       it "returns a 401" do
         patch attributes_path, headers: { "Content-Type" => "application/json" }, params: params.to_json
         expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "when the attribute is unwritable" do
+      let(:attributes) { { unwritable_attribute_name => attribute_value1 } }
+
+      it "returns a 403" do
+        patch attributes_path, headers: headers, params: params.to_json
+        expect(response).to have_http_status(:forbidden)
+
+        error = JSON.parse(response.body)
+        expect(error["type"]).to eq(I18n.t("errors.unwritable_attributes.type"))
+        expect(error["attributes"]).to eq([unwritable_attribute_name])
       end
     end
 


### PR DESCRIPTION
This is so we can show the user's email address & prompt them to verify it on the account home page, which is going to move from the account manager to GOV.UK.

See commit messages for details.

---

[Trello card](https://trello.com/c/lIDQNATi/813-implement-the-govuk-account-home-page)