### PR TITLE
Do not try to cache unset remote attributes

### DIFF
--- a/app/lib/account_session.rb
+++ b/app/lib/account_session.rb
@@ -132,7 +132,7 @@ private
   end
 
   def get_remote_attributes(remote_attributes)
-    remote_attributes.index_with { |name| oidc_do :get_attribute, { attribute: name } }
+    remote_attributes.index_with { |name| oidc_do :get_attribute, { attribute: name } }.compact
   end
 
   def set_remote_attributes(remote_attributes)

--- a/spec/lib/account_session_spec.rb
+++ b/spec/lib/account_session_spec.rb
@@ -143,6 +143,15 @@ RSpec.describe AccountSession do
           expect { account_session.get_attributes([attribute_name1]) }.to change(LocalAttribute, :count)
           expect(account_session.get_attributes([attribute_name1])).to eq({ attribute_name1 => attribute_value1 })
         end
+
+        context "when the attribute is unset" do
+          let(:attribute_value1) { nil }
+
+          it "does not try to cache locally" do
+            expect { account_session.get_attributes([attribute_name1]) }.not_to change(LocalAttribute, :count)
+            expect(account_session.get_attributes([attribute_name1])).to eq({})
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Attributes are non-nil: getting a nil from the remote means that the
attribute is unset, and so we shouldn't try to store it.

---

[Sentry error](https://sentry.io/organizations/govuk/issues/2430637572/)
