### PR TITLE
Add an API endpoint for getting batch user information

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -1,0 +1,62 @@
+class UserController < ApplicationController
+  include AuthenticatedApiConcern
+
+  HOMEPAGE_ATTRIBUTES = %i[email email_verified transition_checker_state].freeze
+
+  def show
+    render_api_response(
+      {
+        level_of_authentication: @govuk_account_session.level_of_authentication,
+        email: attributes.dig(:email, :value),
+        email_verified: attributes.dig(:email_verified, :value),
+        services: {
+          transition_checker: attribute_service(:transition_checker_state),
+          saved_pages: saved_pages_service,
+        }.compact,
+      },
+    )
+  end
+
+private
+
+  def attribute_service(attribute_name)
+    attributes[attribute_name][:state]
+  end
+
+  def saved_pages_service
+    if @govuk_account_session.user.saved_pages.exists?
+      :yes
+    else
+      :no
+    end
+  end
+
+  def attributes
+    @attributes ||=
+      begin
+        attribute_values = @govuk_account_session.get_attributes(HOMEPAGE_ATTRIBUTES.select { |name| has_permission_for name, :check }).symbolize_keys
+
+        HOMEPAGE_ATTRIBUTES.index_with do |name|
+          if attribute_values.key? name
+            if has_permission_for name, :get
+              { state: :yes, value: attribute_values[name] }
+            else
+              { state: :yes_but_must_reauthenticate }
+            end
+          elsif has_permission_for name, :check
+            { state: :no }
+          else
+            { state: :unknown }
+          end
+        end
+      end
+  end
+
+  def has_permission_for(attribute_name, permission_level)
+    user_attributes.has_permission_for? attribute_name, permission_level, @govuk_account_session
+  end
+
+  def user_attributes
+    @user_attributes ||= UserAttributes.new
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Rails.application.routes.draw do
       post "/state", to: "authentication#create_state"
     end
 
+    get "/user", to: "user#show"
+
     get "/attributes", to: "attributes#show"
     patch "/attributes", to: "attributes#update"
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -18,6 +18,7 @@ management. This API is not for other government services.
   - [`GET /api/oauth2/sign-in`](#get-apioauth2sign-in)
   - [`POST /api/oauth2/callback`](#post-apioauth2callback)
   - [`POST /api/oauth2/state`](#post-apioauth2state)
+  - [`GET /api/user`](#get-apiuser)
   - [`GET /api/attributes`](#get-apiattributes)
   - [`PATCH /api/attributes`](#patch-apiattributes)
   - [`GET /api/attributes/names`](#get-apiattributesnames)
@@ -333,6 +334,59 @@ Response:
 ```json
 {
     "state_id": "5821a9f9-3ba7-4385-a864-80cdb374550a"
+}
+```
+
+### `GET /api/user`
+
+Retrieves the information needed to render the `/account/home` page.
+
+#### Request headers
+
+- `GOVUK-Account-Session`
+  - the user's session identifier
+
+#### JSON response fields
+
+- `level_of_authentication`
+  - the user's current level of authentication (`level0` or `level1`)
+- `email`
+  - the user's current email address
+- `email_verified`
+  - whether the user has confirmed their email address or not
+- `services`
+  - object of known services, keys are service names and values are one of:
+    - `yes`: the user has used the service and can use it now
+    - `yes_but_must_reauthenticate`: the user has used the service but must reauthenticate at a higher level to use it now
+    - `no`: the user has not used the service
+    - `unknown`: the user is not authenticated at a high enough level to check whether they have used the service or not
+
+#### Response codes
+
+- 401 if the session identifier is invalid
+- 200 otherwise
+
+#### Example request / response
+
+Request (with gds-api-adapters):
+
+```ruby
+GdsApi.account_api.get_user(
+    govuk_account_session: "session-identifier",
+)
+```
+
+Response:
+
+```json
+{
+    "level_of_authentication": "level0",
+    "email": "email@example.com",
+    "email_verified": false,
+    "services": {
+        "transition_checker": "yes_but_must_reauthenticate",
+        "saved_pages": "yes"
+    }
 }
 ```
 

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -1,0 +1,112 @@
+require "gds_api/test_helpers/content_store"
+
+RSpec.describe "User information endpoint" do
+  include GdsApi::TestHelpers::ContentStore
+
+  before do
+    stub_oidc_discovery
+    stub_requests_for_attributes(attributes)
+  end
+
+  let(:session_identifier) { placeholder_govuk_account_session_object(level_of_authentication: level_of_authentication) }
+  let(:headers) { { "Content-Type" => "application/json", "GOVUK-Account-Session" => session_identifier&.serialise }.compact }
+  let(:level_of_authentication) { "level0" }
+
+  let(:attributes) do
+    {
+      email: "email@example.com",
+      email_verified: true,
+      transition_checker_state: transition_checker_state,
+    }
+  end
+
+  let(:transition_checker_state) { nil }
+
+  let(:response_body) { JSON.parse(response.body) }
+
+  it "returns 200 OK" do
+    get "/api/user", headers: headers
+    expect(response).to be_successful
+  end
+
+  it "returns the user's level of authentication" do
+    get "/api/user", headers: headers
+    expect(response_body["level_of_authentication"]).to eq(session_identifier.level_of_authentication)
+  end
+
+  it "returns the user's email attributes" do
+    get "/api/user", headers: headers
+    expect(response_body["email"]).to eq(attributes[:email])
+    expect(response_body["email_verified"]).to eq(attributes[:email_verified])
+  end
+
+  describe "services.transition_checker" do
+    let(:service_state) { response_body.dig("services", "transition_checker") }
+
+    it "returns 'no'" do
+      get "/api/user", headers: headers
+      expect(service_state).to eq("no")
+    end
+
+    context "when the user has used the checker" do
+      let(:transition_checker_state) { "state" }
+
+      it "returns 'yes_but_must_reauthenticate'" do
+        get "/api/user", headers: headers
+        expect(service_state).to eq("yes_but_must_reauthenticate")
+      end
+
+      context "when the user is logged in at level1" do
+        let(:level_of_authentication) { "level1" }
+
+        it "returns 'yes'" do
+          get "/api/user", headers: headers
+          expect(service_state).to eq("yes")
+        end
+      end
+    end
+  end
+
+  describe "services.saved_pages" do
+    let(:service_state) { response_body.dig("services", "saved_pages") }
+
+    it "returns 'no'" do
+      get "/api/user", headers: headers
+      expect(service_state).to eq("no")
+    end
+
+    context "when the user has saved pages" do
+      before { stub_user_has_saved_pages }
+
+      it "returns 'yes'" do
+        get "/api/user", headers: headers
+        expect(service_state).to eq("yes")
+      end
+    end
+  end
+
+  context "when the user is not logged in" do
+    let(:session_identifier) { nil }
+
+    it "returns a 401" do
+      get "/api/user", headers: headers
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  def stub_requests_for_attributes(attributes)
+    attributes.each do |name, value|
+      if value.nil?
+        stub_request(:get, "http://openid-provider/v1/attributes/#{name}").to_return(status: 404)
+      else
+        stub_request(:get, "http://openid-provider/v1/attributes/#{name}").to_return(body: { claim_value: value }.to_json)
+      end
+    end
+  end
+
+  def stub_user_has_saved_pages
+    page_path = "/page-path"
+    stub_content_store_has_item(page_path, content_item_for_base_path(page_path).merge("content_id" => SecureRandom.uuid))
+    put saved_page_path(page_path: page_path), headers: headers
+  end
+end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -92,6 +92,9 @@ Pact.provider_states_for "GDS API Adapters" do
     set_up do
       stub_request(:get, "#{Plek.find('account-manager')}/api/v1/transition-checker/email-subscription").to_return(status: 404)
       stub_request(:post, "#{Plek.find('account-manager')}/api/v1/transition-checker/email-subscription").to_return(status: 200)
+      stub_request(:get, "http://openid-provider/v1/attributes/email").to_return(status: 200, body: { claim_value: "user@example.com" }.to_json)
+      stub_request(:get, "http://openid-provider/v1/attributes/email_verified").to_return(status: 200, body: { claim_value: true }.to_json)
+      stub_request(:get, "http://openid-provider/v1/attributes/transition_checker_state").to_return(status: 404)
       stub_request(:get, "http://openid-provider/v1/attributes/foo").to_return(status: 404)
       stub_request(:get, "http://openid-provider/v1/attributes/test_attribute_1").to_return(status: 404)
       stub_request(:post, "http://openid-provider/v1/attributes").to_return(status: 200)
@@ -106,6 +109,9 @@ Pact.provider_states_for "GDS API Adapters" do
 
   provider_state "there is a valid user session, with /guidance/some-govuk-guidance saved" do
     set_up do
+      stub_request(:get, "http://openid-provider/v1/attributes/email").to_return(status: 200, body: { claim_value: "user@example.com" }.to_json)
+      stub_request(:get, "http://openid-provider/v1/attributes/email_verified").to_return(status: 200, body: { claim_value: true }.to_json)
+      stub_request(:get, "http://openid-provider/v1/attributes/transition_checker_state").to_return(status: 404)
       FactoryBot.create(:saved_page, page_path: "/guidance/some-govuk-guidance", oidc_user_id: oidc_user.id)
     end
   end


### PR DESCRIPTION
This provides all the data needed for the new `/account/home` page, so
we can render that with a single request to account-api rather than
needing to make at least three separate requests to: get some
attributes, check other attributes, and check saved pages.

---

[Trello card](https://trello.com/c/lIDQNATi/813-implement-the-govuk-account-home-page)
