### PR TITLE
Enforce levels of authentication & remove support for legacy base64 sessions

### DIFF
--- a/app/controllers/attributes_controller.rb
+++ b/app/controllers/attributes_controller.rb
@@ -30,12 +30,10 @@ private
       raise ApiError::UnwritableAttributes, { attributes: unwritable_attributes } if unwritable_attributes.any?
     end
 
-    if Rails.application.config.feature_flag_enforce_levels_of_authentication
-      forbidden_attributes = attribute_names.reject { |name| user_attributes.has_permission_for? name, permission_level, @govuk_account_session }
-      if forbidden_attributes.any?
-        needed_level_of_authentication = forbidden_attributes.map { |name| user_attributes.level_of_authentication_for name, permission_level }.max
-        raise ApiError::LevelOfAuthenticationTooLow, { attributes: forbidden_attributes, needed_level_of_authentication: needed_level_of_authentication }
-      end
+    forbidden_attributes = attribute_names.reject { |name| user_attributes.has_permission_for? name, permission_level, @govuk_account_session }
+    if forbidden_attributes.any?
+      needed_level_of_authentication = forbidden_attributes.map { |name| user_attributes.level_of_authentication_for name, permission_level }.max
+      raise ApiError::LevelOfAuthenticationTooLow, { attributes: forbidden_attributes, needed_level_of_authentication: needed_level_of_authentication }
     end
   end
 

--- a/app/controllers/transition_checker_email_subscription_controller.rb
+++ b/app/controllers/transition_checker_email_subscription_controller.rb
@@ -17,12 +17,10 @@ class TransitionCheckerEmailSubscriptionController < ApplicationController
 private
 
   def check_permission!(permission_level)
-    return unless Rails.application.config.feature_flag_enforce_levels_of_authentication
+    return if user_attributes.has_permission_for? "transition_checker_state", permission_level, @govuk_account_session
 
-    unless user_attributes.has_permission_for? "transition_checker_state", permission_level, @govuk_account_session
-      needed_level_of_authentication = user_attributes.level_of_authentication_for "transition_checker_state", permission_level
-      raise ApiError::LevelOfAuthenticationTooLow, { attributes: %w[transition_checker_state], needed_level_of_authentication: needed_level_of_authentication }
-    end
+    needed_level_of_authentication = user_attributes.level_of_authentication_for "transition_checker_state", permission_level
+    raise ApiError::LevelOfAuthenticationTooLow, { attributes: %w[transition_checker_state], needed_level_of_authentication: needed_level_of_authentication }
   end
 
   def user_attributes

--- a/app/lib/account_session.rb
+++ b/app/lib/account_session.rb
@@ -28,27 +28,8 @@ class AccountSession
           level_of_authentication: LOWEST_LEVEL_OF_AUTHENTICATION,
         }.merge(JSON.parse(serialised_session).symbolize_keys),
       )
-    else
-      deserialise_legacy_base64_session(
-        encoded_session: encoded_session,
-        session_signing_key: session_signing_key,
-      )
     end
   rescue OidcClient::OAuthFailure
-    nil
-  end
-
-  def self.deserialise_legacy_base64_session(encoded_session:, session_signing_key:)
-    bits = (encoded_session || "").split(".")
-    if bits.length == 2
-      new(
-        session_signing_key: session_signing_key,
-        access_token: Base64.urlsafe_decode64(bits[0]),
-        refresh_token: Base64.urlsafe_decode64(bits[1]),
-        level_of_authentication: LOWEST_LEVEL_OF_AUTHENTICATION,
-      )
-    end
-  rescue ArgumentError
     nil
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,7 +36,5 @@ module AccountApi
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
-
-    config.feature_flag_enforce_levels_of_authentication = ENV["FEATURE_FLAG_ENFORCE_LEVELS_OF_AUTHENTICATION"] == "enabled"
   end
 end

--- a/docs/api.md
+++ b/docs/api.md
@@ -499,6 +499,7 @@ Checks if the user has an active Transition Checker email subscription.
 
 #### Response codes
 
+- 403 if the session's level of authentication is too low (see [error: level of authentication too low](#level-of-authentication-too-low))
 - 401 if the session identifier is invalid
 - 200 otherwise
 
@@ -543,6 +544,7 @@ Updates the user's Transition Checker email subscription, cancelling any previou
 
 #### Response codes
 
+- 403 if the session's level of authentication is too low (see [error: level of authentication too low](#level-of-authentication-too-low))
 - 401 if the session identifier is invalid
 - 200 otherwise
 

--- a/spec/lib/account_session_spec.rb
+++ b/spec/lib/account_session_spec.rb
@@ -52,13 +52,6 @@ RSpec.describe AccountSession do
         expect(described_class.new(session_signing_key: "secret", **params).to_hash).to eq(params.merge(user_id: user_id_from_userinfo))
       end
 
-      it "accepts a legacy unsigned session header, and queries userinfo for the user ID" do
-        encoded = "#{Base64.urlsafe_encode64(access_token)}.#{Base64.urlsafe_encode64(refresh_token)}"
-        decoded = described_class.deserialise(encoded_session: encoded, session_signing_key: "secret").to_hash
-
-        expect(decoded).to eq(params.merge(user_id: user_id_from_userinfo))
-      end
-
       context "when the userinfo request fails" do
         let(:userinfo_status) { 401 }
 
@@ -68,17 +61,6 @@ RSpec.describe AccountSession do
           encoded = "#{Base64.urlsafe_encode64(access_token)}.#{Base64.urlsafe_encode64(refresh_token)}"
           expect(described_class.deserialise(encoded_session: encoded, session_signing_key: "secret")).to be_nil
         end
-      end
-    end
-
-    describe "deserialise_legacy_base64_session" do
-      it "returns nil on invalid base64" do
-        expect(described_class.deserialise_legacy_base64_session(encoded_session: "?.?", session_signing_key: "secret")).to be_nil
-      end
-
-      it "returns nil if there are the wrong number of fragments" do
-        expect(described_class.deserialise_legacy_base64_session(encoded_session: Base64.urlsafe_encode64("1"), session_signing_key: "secret")).to be_nil
-        expect(described_class.deserialise_legacy_base64_session(encoded_session: "#{Base64.urlsafe_encode64('1')}.#{Base64.urlsafe_encode64('2')}.#{Base64.urlsafe_encode64('3')}", session_signing_key: "secret")).to be_nil
       end
     end
   end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -56,8 +56,9 @@ Pact.provider_states_for "GDS API Adapters" do
     )
     allow(AccountSession).to receive(:deserialise).and_return(account_session)
 
+    normal_file = YAML.safe_load(File.read(Rails.root.join("config/user_attributes.yml"))).with_indifferent_access
     fixture_file = YAML.safe_load(File.read(Rails.root.join("spec/fixtures/user_attributes.yml"))).with_indifferent_access
-    allow(UserAttributes).to receive(:load_config_file).and_return(fixture_file)
+    allow(UserAttributes).to receive(:load_config_file).and_return(normal_file.merge(fixture_file))
 
     stub_request(:post, "#{Plek.find('account-manager')}/api/v1/jwt").to_return(status: 200, body: { id: "jwt-id" }.to_json)
 


### PR DESCRIPTION
We've not yet enabled the ability to log in or register at level0 in
the account manager, so this won't impose any visible changes for
users who have logged in since late April.  Users who logged in before
then and still have a live session will be prompted to reauthenticate
when they next use the Transition Checker.

---

[Trello card](https://trello.com/c/6C8UdVFG/815-enforce-levels-of-authentication-in-production)