### PR TITLE
Remove duplication of absolute path validation

### DIFF
--- a/app/models/auth_request.rb
+++ b/app/models/auth_request.rb
@@ -2,7 +2,7 @@ class AuthRequest < ApplicationRecord
   EXPIRATION_AGE = 2.hours
   scope :expired, -> { where("created_at < ?", EXPIRATION_AGE.ago) }
 
-  validate :redirect_path_is_safe
+  validates :redirect_path, absolute_path: true
 
   def self.generate!(options = {})
     create!(
@@ -23,20 +23,5 @@ class AuthRequest < ApplicationRecord
     return nil unless bits.length == 2
 
     find_by(id: bits[1], oauth_state: bits[0])
-  end
-
-  def redirect_path_is_safe
-    return if redirect_path.nil?
-    return if redirect_path.empty?
-
-    if redirect_path.starts_with? "//"
-      errors.add(:redirect_path, "can't be protocol-relative")
-      return
-    end
-
-    return if redirect_path.starts_with? "/"
-    return if redirect_path.starts_with?("http://") && Rails.env.development?
-
-    errors.add(:redirect_path, "can't be absolute")
   end
 end

--- a/app/models/saved_page.rb
+++ b/app/models/saved_page.rb
@@ -1,9 +1,7 @@
 class SavedPage < ApplicationRecord
   belongs_to :oidc_user
 
-  validates :page_path, uniqueness: { scope: :oidc_user_id }, presence: true
-
-  validate :page_path_is_valid_path
+  validates :page_path, uniqueness: { scope: :oidc_user_id }, presence: true, absolute_path: true
 
   def to_hash
     {
@@ -20,17 +18,5 @@ class SavedPage < ApplicationRecord
       title: content_item["title"],
       public_updated_at: content_item["public_updated_at"] ? Time.zone.parse(content_item["public_updated_at"]) : nil,
     }
-  end
-
-private
-
-  def page_path_is_valid_path
-    errors.add(:page_path, :invalid_path, message: "must only include URL path") unless is_valid_path?
-  end
-
-  def is_valid_path?
-    page_path&.starts_with?("/") && URI(page_path).path == page_path
-  rescue StandardError
-    false
   end
 end

--- a/app/validators/absolute_path_validator.rb
+++ b/app/validators/absolute_path_validator.rb
@@ -1,0 +1,15 @@
+class AbsolutePathValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    record.errors.add(attribute, "must only include URL path") unless valid_absolute_url_path? value
+  end
+
+private
+
+  def valid_absolute_url_path?(value)
+    value.starts_with?("/") && URI.parse(value).path == value
+  rescue URI::InvalidURIError
+    false
+  end
+end


### PR DESCRIPTION
We had the same logic implemented differently in two places.  This commit adds a validator which both models use.