### PR TITLE
Put OAuth env vars in secrets.yml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ gem "pg"
 group :development, :test do
   gem "awesome_print"
   gem "bullet"
-  gem "climate_control"
   gem "database_cleaner-active_record"
   gem "factory_bot_rails"
   gem "govuk_schemas"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,6 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (3.0.0)
-    climate_control (1.0.1)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
     crack (0.4.5)
@@ -454,7 +453,6 @@ DEPENDENCIES
   awesome_print
   bootsnap
   bullet
-  climate_control
   dalli
   database_cleaner-active_record
   factory_bot_rails

--- a/app/lib/oidc_client.rb
+++ b/app/lib/oidc_client.rb
@@ -14,10 +14,10 @@ class OidcClient
            :end_session_endpoint,
            to: :discover
 
-  def initialize(provider_uri: nil, client_id: nil, secret: nil)
-    @provider_uri = provider_uri || Plek.find("account-manager")
-    @client_id = client_id || ENV.fetch("GOVUK_ACCOUNT_OAUTH_CLIENT_ID")
-    @secret = secret || ENV.fetch("GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET")
+  def initialize
+    @provider_uri = Plek.find("account-manager")
+    @client_id = Rails.application.secrets.oauth_client_id
+    @secret = Rails.application.secrets.oauth_client_secret
   end
 
   def auth_uri(auth_request, level_of_authentication)
@@ -146,7 +146,7 @@ class OidcClient
     )
   end
 
-protected
+private
 
   OK_STATUSES = [200, 204, 404, 410].freeze
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,8 +1,14 @@
 test:
   session_signing_key: secret
+  oauth_client_id: client-id
+  oauth_client_secret: client-secret
 
 development:
   session_signing_key: secret
+  oauth_client_id: <%= ENV.fetch('GOVUK_ACCOUNT_OAUTH_CLIENT_ID', 'client-id') %>
+  oauth_client_secret: <%= ENV.fetch('GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET', 'client-secret') %>
 
 production:
   session_signing_key: <%= ENV['SESSION_SIGNING_KEY'] %>
+  oauth_client_id: <%= ENV['GOVUK_ACCOUNT_OAUTH_CLIENT_ID'] %>
+  oauth_client_secret: <%= ENV['GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET'] %>

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -37,9 +37,6 @@ end
 
 Pact.provider_states_for "GDS API Adapters" do
   set_up do
-    ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_ID"] = "client-id"
-    ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET"] = "client-secret"
-
     DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.allow_remote_database_url = true
     DatabaseCleaner.start

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,12 +28,6 @@ RSpec.configure do |config|
 
   config.before { Rails.application.load_seed }
 
-  config.around do |example|
-    ClimateControl.modify(GOVUK_ACCOUNT_OAUTH_CLIENT_ID: "client-id", GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET: "client-secret") do
-      example.run
-    end
-  end
-
   config.expose_dsl_globally = false
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
These aren't passed as parameters anywhere, and by putting these in
secrets.yml we can give them default values in dev and test, meaning
we don't need to set them with ClimateControl in our tests.

Also remove the `provider_uri` parameter from `OidcClient` because we
don't set that anywhere.
