### PR TITLE
Add tests for using a querystring in the auth redirect_path

### DIFF
--- a/spec/models/auth_request_spec.rb
+++ b/spec/models/auth_request_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe AuthRequest do
     expect(described_class.new(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "/good-page")).to be_valid
   end
 
+  it "allows querystrings" do
+    expect(described_class.new(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "/page/with/a?query=string")).to be_valid
+  end
+
   it "forbids protocol-relative redirects" do
     expect(described_class.new(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "//malicious-site.com")).not_to be_valid
   end

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe "Authentication" do
     end
 
     it "uses a provided redirect_path" do
-      get sign_in_path, params: { redirect_path: "/hello-world" }
-      expect(AuthRequest.last.redirect_path).to eq("/hello-world")
+      get sign_in_path, params: { redirect_path: "/transition-check/results?c[]=import-wombats&c[]=practice-wizardry" }
+      expect(AuthRequest.last.redirect_path).to eq("/transition-check/results?c[]=import-wombats&c[]=practice-wizardry")
     end
 
     it "deletes old expired AuthRequests" do


### PR DESCRIPTION
Querystrings are needed when clicking the sign-in link from the header
on transition checker pages, as the current answers are in the
querystring.

This test would have prevented the bug introduced by #97.
