### PR TITLE
Add an endpoint to update a user's email by subject identifier

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,7 @@
 class ApplicationController < ActionController::API
   include GDS::SSO::ControllerMethods
 
-  before_action do
-    authorise_user!("internal_app")
-  end
+  before_action :authorise_sso_user!
 
   rescue_from ApiError::Base do |error|
     render status: error.status_code, json: {
@@ -11,5 +9,11 @@ class ApplicationController < ActionController::API
       title: error.title,
       detail: error.detail,
     }.merge(error.extra_detail)
+  end
+
+private
+
+  def authorise_sso_user!
+    authorise_user!("internal_app")
   end
 end

--- a/app/controllers/oidc_users_controller.rb
+++ b/app/controllers/oidc_users_controller.rb
@@ -1,0 +1,15 @@
+class OidcUsersController < ApplicationController
+  OIDC_USER_ATTRIBUTES = %i[email email_verified].freeze
+
+  def update
+    user = OidcUser.find_or_create_by!(sub: params.fetch(:subject_identifier))
+    user.set_local_attributes(params.permit(OIDC_USER_ATTRIBUTES).to_h)
+    render json: user.get_local_attributes(OIDC_USER_ATTRIBUTES).merge(sub: user.sub)
+  end
+
+private
+
+  def authorise_sso_user!
+    authorise_user!("update_protected_attributes")
+  end
+end

--- a/app/models/oidc_user.rb
+++ b/app/models/oidc_user.rb
@@ -1,4 +1,21 @@
 class OidcUser < ApplicationRecord
   has_many :local_attributes, dependent: :destroy
   has_many :saved_pages, dependent: :destroy
+
+  def get_local_attributes(names = [])
+    local_attributes
+      .where(name: names)
+      .map { |attr| [attr.name, attr.value] }
+      .to_h
+  end
+
+  def set_local_attributes(values = {})
+    return if values.empty?
+
+    LocalAttribute.upsert_all(
+      values.map { |name, value| { oidc_user_id: id, name: name, value: value, updated_at: Time.zone.now } },
+      unique_by: :index_local_attributes_on_oidc_user_id_and_name,
+      returning: false,
+    )
+  end
 end

--- a/config/initializers/gds_sso.rb
+++ b/config/initializers/gds_sso.rb
@@ -1,3 +1,3 @@
 GDS::SSO.config do |config|
-  config.additional_mock_permissions_required = %w[internal_app]
+  config.additional_mock_permissions_required = %w[internal_app update_protected_attributes]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
 
     get "/user", to: "user#show"
 
+    resources :oidc_users, only: %i[update], param: :subject_identifier, path: "oidc-users"
+
     get "/attributes", to: "attributes#show"
     patch "/attributes", to: "attributes#update"
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,6 +12,6 @@ gds_organisation_id = "af07d5a5-df63-4ddc-9383-6a666845ebe9"
 
 User.create!(
   name: "Test user",
-  permissions: %w[signin internal_app],
+  permissions: %w[signin internal_app update_protected_attributes],
   organisation_content_id: gds_organisation_id,
 )

--- a/spec/lib/account_session_spec.rb
+++ b/spec/lib/account_session_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe AccountSession do
     end
 
     it "creates a user record if one does not exist" do
-      expect { account_session.user }.to change(OidcUser, :count)
+      expect { account_session.user }.to change(OidcUser, :count).by(1)
     end
 
     it "re-uses a user record if one does exist" do
@@ -122,7 +122,7 @@ RSpec.describe AccountSession do
         let(:attribute_name1) { "test_attribute_cache" }
 
         it "fetches the attribute and stores it locally" do
-          expect { account_session.get_attributes([attribute_name1]) }.to change(LocalAttribute, :count)
+          expect { account_session.get_attributes([attribute_name1]) }.to change(LocalAttribute, :count).by(1)
           expect(account_session.get_attributes([attribute_name1])).to eq({ attribute_name1 => attribute_value1 })
         end
 
@@ -144,7 +144,7 @@ RSpec.describe AccountSession do
 
       it "calls the attribute service for remote attributes, calls the database for local attributes" do
         stub = stub_set_remote_attributes
-        expect { account_session.set_attributes(attributes) }.to change(LocalAttribute, :count)
+        expect { account_session.set_attributes(attributes) }.to change(LocalAttribute, :count).by(1)
         expect(stub).to have_been_made
       end
 
@@ -187,7 +187,7 @@ RSpec.describe AccountSession do
 
         it "sets the attribute both locally and remotely" do
           stub = stub_set_remote_attributes
-          expect { account_session.set_attributes(attributes) }.to change(LocalAttribute, :count)
+          expect { account_session.set_attributes(attributes) }.to change(LocalAttribute, :count).by(1)
           expect(stub).to have_been_made
         end
       end

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Authentication" do
 
   describe "/sign-in" do
     it "creates an AuthRequest to persist the attributes" do
-      expect { get sign_in_path }.to change(AuthRequest, :count)
+      expect { get sign_in_path }.to change(AuthRequest, :count).by(1)
       expect(response).to be_successful
 
       auth_request = AuthRequest.last

--- a/spec/requests/oidc_users_spec.rb
+++ b/spec/requests/oidc_users_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "OIDC Users endpoint" do
 
   describe "PUT" do
     it "creates the user if they do not exist" do
-      expect { put oidc_user_path(subject_identifier: subject_identifier), params: params, headers: headers }.to change(OidcUser, :count)
+      expect { put oidc_user_path(subject_identifier: subject_identifier), params: params, headers: headers }.to change(OidcUser, :count).by(1)
       expect(response).to be_successful
     end
 

--- a/spec/requests/oidc_users_spec.rb
+++ b/spec/requests/oidc_users_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe "OIDC Users endpoint" do
+  let(:headers) { { "Content-Type" => "application/json" } }
+  let(:params) { { email: email, email_verified: email_verified }.compact.to_json }
+  let(:email) { "email@example.com" }
+  let(:email_verified) { true }
+  let(:subject_identifier) { "subject-identifier" }
+
+  describe "PUT" do
+    it "creates the user if they do not exist" do
+      expect { put oidc_user_path(subject_identifier: subject_identifier), params: params, headers: headers }.to change(OidcUser, :count)
+      expect(response).to be_successful
+    end
+
+    it "returns the subject identifier" do
+      put oidc_user_path(subject_identifier: subject_identifier), params: params, headers: headers
+      expect(JSON.parse(response.body)["sub"]).to eq(subject_identifier)
+    end
+
+    it "returns the new attribute values" do
+      put oidc_user_path(subject_identifier: subject_identifier), params: params, headers: headers
+      expect(JSON.parse(response.body)["email"]).to eq(email)
+      expect(JSON.parse(response.body)["email_verified"]).to eq(email_verified)
+    end
+
+    context "when the user already exists" do
+      let!(:user) { OidcUser.create!(sub: subject_identifier) }
+
+      it "does not create a new user" do
+        expect { put oidc_user_path(subject_identifier: subject_identifier), params: params, headers: headers }.not_to change(OidcUser, :count)
+        expect(response).to be_successful
+      end
+
+      it "updates the attribute values" do
+        user.set_local_attributes(email: "old-email@example.com", email_verified: false)
+
+        put oidc_user_path(subject_identifier: subject_identifier), params: params, headers: headers
+
+        expect(user.get_local_attributes(%i[email email_verified])).to eq({ "email" => email, "email_verified" => email_verified })
+      end
+    end
+  end
+end


### PR DESCRIPTION
I've called this `/api/oidc-users`, rather than using the existing
`/api/user`, because this endpoint feels pretty different to
`/api/user`:

- `/api/user` is for the user's profile details as used on GOV.UK
- the new endpoint is for the identity provider to update special
  details (currently email)

They're both about the user, but through different lenses: the user as
seen on GOV.UK, and the user as managed by the OIDC service.  Hence,
`/api/oidc-users`.

You'll need to re-seed your database after pulling this change.

---

[Trello card](https://trello.com/c/UD2IR18h/830-make-account-manager-tell-account-api-about-email-address-changes)
