### PR TITLE
Allow "false" as an attribute value

### DIFF
--- a/app/models/local_attribute.rb
+++ b/app/models/local_attribute.rb
@@ -2,5 +2,5 @@ class LocalAttribute < ApplicationRecord
   belongs_to :oidc_user
 
   validates :name, presence: true, uniqueness: { scope: :oidc_user_id }
-  validates :value, presence: true
+  validates :value, exclusion: [nil]
 end

--- a/spec/models/local_attribute_spec.rb
+++ b/spec/models/local_attribute_spec.rb
@@ -10,6 +10,6 @@ RSpec.describe LocalAttribute do
 
     it { is_expected.to validate_uniqueness_of(:name).scoped_to(:oidc_user_id) }
 
-    it { is_expected.to validate_presence_of(:value) }
+    it { is_expected.to validate_exclusion_of(:value).in_array([nil]) }
   end
 end


### PR DESCRIPTION
We want to forbid nils, but false is a totally acceptable value to
have.  In particular, this forbids an `email_verified` value of
`false`.

---

[Trello card](https://trello.com/c/yzVmdrzw/829-add-rest-api-for-email-subscriptions-to-account-api)
