### PR TITLE
Mark email attributes "cached"

### DIFF
--- a/config/user_attributes.yml
+++ b/config/user_attributes.yml
@@ -1,13 +1,13 @@
 ---
 email:
-  type: remote
+  type: cached
   writable: false
   permissions:
     check: 0
     get: 0
 
 email_verified:
-  type: remote
+  type: cached
   writable: false
   permissions:
     check: 0


### PR DESCRIPTION
Now that account-manager is telling account-api when a user updates
their email address, we know that the value in the account-api
database is up to date, so we don't need to fetch it from the remote.

---

[Trello card](https://trello.com/c/UD2IR18h/830-make-account-manager-tell-account-api-about-email-address-changes)
