### PR TITLE
Implement email subscriptions

### DIFF
--- a/app/controllers/email_subscriptions_controller.rb
+++ b/app/controllers/email_subscriptions_controller.rb
@@ -1,0 +1,60 @@
+class EmailSubscriptionsController < ApplicationController
+  include AuthenticatedApiConcern
+
+  before_action :check_subscription_exists, only: %i[show destroy]
+
+  def show
+    if email_subscription.email_alert_api_subscription_id
+      begin
+        state = GdsApi.email_alert_api.get_subscription(email_subscription.email_alert_api_subscription_id)
+        if state.to_hash.dig("subscription", "ended_reason")
+          email_subscription.destroy!
+          head :not_found and return
+        end
+      rescue GdsApi::HTTPGone, GdsApi::HTTPNotFound
+        email_subscription.destroy!
+        head :not_found and return
+      end
+    end
+
+    render_api_response(email_subscription: email_subscription.to_hash)
+  end
+
+  def update
+    attributes = @govuk_account_session.get_attributes(%w[email email_verified])
+
+    email_subscription = EmailSubscription.transaction do
+      EmailSubscription
+        .create_with(topic_slug: params.fetch(:topic_slug))
+        .find_or_create_by!(
+          oidc_user_id: @govuk_account_session.user.id,
+          name: params.fetch(:subscription_name),
+        ).tap { |subscription| subscription.update!(topic_slug: params.fetch(:topic_slug)) }
+    end
+
+    email_subscription.reactivate_if_confirmed!(
+      attributes["email"],
+      attributes["email_verified"],
+    )
+
+    render_api_response(email_subscription: email_subscription.to_hash)
+  end
+
+  def destroy
+    email_subscription.destroy!
+    head :no_content
+  end
+
+private
+
+  def email_subscription
+    @email_subscription ||= EmailSubscription.find_by(
+      oidc_user: @govuk_account_session.user,
+      name: params.fetch(:subscription_name),
+    )
+  end
+
+  def check_subscription_exists
+    head :not_found and return unless email_subscription
+  end
+end

--- a/app/controllers/oidc_users_controller.rb
+++ b/app/controllers/oidc_users_controller.rb
@@ -4,7 +4,18 @@ class OidcUsersController < ApplicationController
   def update
     user = OidcUser.find_or_create_by!(sub: params.fetch(:subject_identifier))
     user.set_local_attributes(params.permit(OIDC_USER_ATTRIBUTES).to_h)
-    render json: user.get_local_attributes(OIDC_USER_ATTRIBUTES).merge(sub: user.sub)
+    attributes = user.get_local_attributes(OIDC_USER_ATTRIBUTES)
+
+    if attributes["email"] && !attributes["email_verified"].nil?
+      user.email_subscriptions.each do |email_subscription|
+        email_subscription.reactivate_if_confirmed!(
+          attributes["email"],
+          attributes["email_verified"],
+        )
+      end
+    end
+
+    render json: attributes.merge(sub: user.sub)
   end
 
 private

--- a/app/models/email_subscription.rb
+++ b/app/models/email_subscription.rb
@@ -1,0 +1,14 @@
+class EmailSubscription < ApplicationRecord
+  belongs_to :oidc_user
+
+  validates :name, presence: true
+  validates :topic_slug, presence: true
+
+  def to_hash
+    {
+      "name" => name,
+      "topic_slug" => topic_slug,
+      "email_alert_api_subscription_id" => email_alert_api_subscription_id,
+    }.compact
+  end
+end

--- a/app/models/email_subscription.rb
+++ b/app/models/email_subscription.rb
@@ -4,11 +4,43 @@ class EmailSubscription < ApplicationRecord
   validates :name, presence: true
   validates :topic_slug, presence: true
 
+  before_destroy :deactivate!
+
   def to_hash
     {
       "name" => name,
       "topic_slug" => topic_slug,
       "email_alert_api_subscription_id" => email_alert_api_subscription_id,
     }.compact
+  end
+
+  def reactivate_if_confirmed!(email, email_verified)
+    deactivate!
+
+    return unless email_verified
+
+    subscriber_list = GdsApi.email_alert_api.get_subscriber_list(
+      slug: topic_slug,
+    )
+
+    subscription = GdsApi.email_alert_api.subscribe(
+      subscriber_list_id: subscriber_list.to_hash.dig("subscriber_list", "id"),
+      address: email,
+      frequency: "daily",
+      skip_confirmation_email: true,
+    )
+
+    update!(email_alert_api_subscription_id: subscription.to_hash.dig("subscription", "id"))
+  end
+
+  def deactivate!
+    return unless email_alert_api_subscription_id
+
+    GdsApi.email_alert_api.unsubscribe(email_alert_api_subscription_id)
+    update!(email_alert_api_subscription_id: nil)
+  rescue GdsApi::HTTPGone, GdsApi::HTTPNotFound
+    # this can happen if the subscription has been deactivated by the
+    # user through email-alert-frontend
+    update!(email_alert_api_subscription_id: nil)
   end
 end

--- a/app/models/oidc_user.rb
+++ b/app/models/oidc_user.rb
@@ -1,4 +1,5 @@
 class OidcUser < ApplicationRecord
+  has_many :email_subscriptions, dependent: :destroy
   has_many :local_attributes, dependent: :destroy
   has_many :saved_pages, dependent: :destroy
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ Rails.application.routes.draw do
       get "/names", to: "names#show"
     end
 
+    resources :email_subscriptions, only: %i[show update destroy], param: :subscription_name, path: "email-subscriptions"
+
     resources :saved_pages, only: %i[index show update destroy], param: :page_path, path: "saved-pages"
 
     # delete when gds-api-adapters has been updated

--- a/db/migrate/20210611093439_create_email_subscriptions.rb
+++ b/db/migrate/20210611093439_create_email_subscriptions.rb
@@ -1,0 +1,14 @@
+class CreateEmailSubscriptions < ActiveRecord::Migration[6.1]
+  def change
+    create_table :email_subscriptions do |t|
+      t.references :oidc_user,  null: false
+      t.string     :name,       null: false
+      t.string     :topic_slug, null: false
+      t.string     :email_alert_api_subscription_id
+
+      t.timestamps
+    end
+
+    add_index :email_subscriptions, %i[oidc_user_id name], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_01_152044) do
+ActiveRecord::Schema.define(version: 2021_06_11_093439) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,17 @@ ActiveRecord::Schema.define(version: 2021_06_01_152044) do
     t.string "redirect_path"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "email_subscriptions", force: :cascade do |t|
+    t.bigint "oidc_user_id", null: false
+    t.string "name", null: false
+    t.string "topic_slug", null: false
+    t.string "email_alert_api_subscription_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["oidc_user_id", "name"], name: "index_email_subscriptions_on_oidc_user_id_and_name", unique: true
+    t.index ["oidc_user_id"], name: "index_email_subscriptions_on_oidc_user_id"
   end
 
   create_table "local_attributes", force: :cascade do |t|

--- a/docs/api.md
+++ b/docs/api.md
@@ -18,6 +18,9 @@ management. This API is not for other government services.
   - [`GET /api/attributes/names`](#get-apiattributesnames)
   - [`GET /api/transition-checker-email-subscription`](#get-apitransition-checker-email-subscription)
   - [`POST /api/transition-checker-email-subscription`](#post-apitransition-checker-email-subscription)
+  - [`GET /api/email-subscriptions/:subscription_name`](#get-apiemail-subscriptionssubscription_name)
+  - [`PUT /api/email-subscriptions/:subscription_name`](#put-apiemail-subscriptionssubscription_name)
+  - [`DELETE /api/email-subscriptions/:subscription_name`](#delete-apiemail-subscriptionssubscription_name)
   - [`GET /api/saved-pages`](#get-apisaved-pages)
   - [`GET /api/saved-pages/:page_path`](#get-apisaved-pagespage_path)
   - [`PUT /api/saved-pages/:page_path`](#put-apisaved-pagespage_path)
@@ -489,6 +492,143 @@ Response:
     "govuk_account_session": "YWNjZXNzLXRva2Vu.cmVmcmVzaC10b2tlbg=="
 }
 ```
+
+### `GET /api/email-subscriptions/:subscription_name`
+
+Get the details of a named email subscription
+
+#### Request headers
+
+- `GOVUK-Account-Session`
+  - the user's session identifier
+
+#### Request parameters
+
+- `subscription_name`
+  - the name of the subscription
+
+#### JSON response fields
+
+- `govuk_account_session` *(optional)*
+  - a new session identifier
+- `email_subscription`
+  - details of the subscription
+
+#### Response codes
+
+- 404 if there is no such subscription (or if it has been deleted)
+- 401 if the session identifier is invalid
+- 200 otherwise
+
+#### Example request / response
+
+Request (with gds-api-adapters):
+
+```ruby
+GdsApi.account_api.get_email_subscription(
+    name: "transition-checker",
+    govuk_account_session: "session-identifier",
+)
+```
+
+```json
+{
+    "govuk_account_session": "YWNjZXNzLXRva2Vu.cmVmcmVzaC10b2tlbg==",
+    "email_subscription": {
+      "name": "transition-checker",
+      "topic_slug": "brexit-results-12345",
+      "email_alert_api_subscription_id": "cd5f6972-faf3-4f1c-bb76-3774b0a389f0"
+    },
+}
+```
+
+### `PUT /api/email-subscriptions/:subscription_name`
+
+Create or update a named email subscription
+
+#### Request headers
+
+- `GOVUK-Account-Session`
+  - the user's session identifier
+
+#### Request parameters
+
+- `subscription_name`
+  - the name of the subscription
+
+#### JSON request parameters
+
+- `topic_slug`
+  - the email-alert-api topic slug
+
+#### JSON response fields
+
+- `govuk_account_session` *(optional)*
+  - a new session identifier
+- `email_subscription`
+  - details of the subscription
+
+#### Response codes
+
+- 422 if the `topic_slug` parameter is missing
+- 401 if the session identifier is invalid
+- 200 otherwise
+
+#### Example request / response
+
+Request (with gds-api-adapters):
+
+```ruby
+GdsApi.account_api.put_email_subscription(
+    name: "transition-checker",
+    topic_slug: "brexit-results-12345",
+    govuk_account_session: "session-identifier",
+)
+```
+
+```json
+{
+    "govuk_account_session": "YWNjZXNzLXRva2Vu.cmVmcmVzaC10b2tlbg==",
+    "email_subscription": {
+      "name": "transition-checker",
+      "topic_slug": "brexit-results-12345",
+      "email_alert_api_subscription_id": "96ae61d6-c2a1-48cb-8e67-da9d105ae381"
+    },
+}
+```
+
+### `DELETE /api/email-subscriptions/:subscription_name`
+
+Cancel and remove a named email subscription
+
+#### Request headers
+
+- `GOVUK-Account-Session`
+  - the user's session identifier
+
+#### Request parameters
+
+- `subscription_name`
+  - the name of the subscription
+
+#### Response codes
+
+- 404 if there is no such subscription (or if it has been deleted)
+- 401 if the session identifier is invalid
+- 204 otherwise
+
+#### Example request / response
+
+Request (with gds-api-adapters):
+
+```ruby
+GdsApi.account_api.delete_email_subscription(
+    name: "transition-checker",
+    govuk_account_session: "session-identifier",
+)
+```
+
+Response is status code only.
 
 ### `GET /api/saved-pages`
 

--- a/spec/factories/email_subscription_factory.rb
+++ b/spec/factories/email_subscription_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :email_subscription do
+    oidc_user
+    sequence(:name) { |n| "subscription-#{n}" }
+    sequence(:topic_slug) { |n| "topic-#{n}" }
+  end
+end

--- a/spec/models/email_subscription_spec.rb
+++ b/spec/models/email_subscription_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe EmailSubscription do
+  subject(:email_subscription) { FactoryBot.build(:email_subscription) }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:oidc_user) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:topic_slug) }
+  end
+end

--- a/spec/models/email_subscription_spec.rb
+++ b/spec/models/email_subscription_spec.rb
@@ -1,4 +1,8 @@
+require "gds_api/test_helpers/email_alert_api"
+
 RSpec.describe EmailSubscription do
+  include GdsApi::TestHelpers::EmailAlertApi
+
   subject(:email_subscription) { FactoryBot.build(:email_subscription) }
 
   describe "associations" do
@@ -8,5 +12,95 @@ RSpec.describe EmailSubscription do
   describe "validations" do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:topic_slug) }
+  end
+
+  describe "reactivate_if_confirmed!" do
+    let(:email) { "email@example.com" }
+    let(:email_verified) { false }
+
+    it "doesn't call email-alert-api if the user is not confirmed" do
+      stub = stub_subscriber_list
+
+      email_subscription.reactivate_if_confirmed!(email, email_verified)
+
+      expect(stub).not_to have_been_made
+    end
+
+    context "when the user is confirmed" do
+      let(:email_verified) { true }
+
+      it "calls email-alert-api to create the subscription" do
+        stub1 = stub_subscriber_list
+        stub2 = stub_create_subscription
+
+        email_subscription.reactivate_if_confirmed!(email, email_verified)
+
+        expect(stub1).to have_been_made
+        expect(stub2).to have_been_made
+        expect(email_subscription.email_alert_api_subscription_id).to eq("new-subscription-id")
+      end
+
+      context "when the user has a prior subscription" do
+        subject(:email_subscription) { FactoryBot.build(:email_subscription, email_alert_api_subscription_id: "prior-subscription-id") }
+
+        it "calls email-alert-api to remove the prior subscription" do
+          stub = stub_email_alert_api_unsubscribes_a_subscription("prior-subscription-id")
+          stub_subscriber_list
+          stub_create_subscription
+
+          email_subscription.reactivate_if_confirmed!(email, email_verified)
+
+          expect(stub).to have_been_made
+        end
+      end
+
+      def stub_create_subscription
+        stub_email_alert_api_creates_a_subscription(
+          subscriber_list_id: "list-id",
+          address: email,
+          frequency: "daily",
+          returned_subscription_id: "new-subscription-id",
+          skip_confirmation_email: true,
+        )
+      end
+    end
+  end
+
+  describe "deactivate!" do
+    subject(:email_subscription) { FactoryBot.build(:email_subscription, email_alert_api_subscription_id: "prior-subscription-id") }
+
+    it "calls email-alert-api to remove the prior subscription and forgets the subscription id" do
+      stub = stub_email_alert_api_unsubscribes_a_subscription("prior-subscription-id")
+
+      email_subscription.deactivate!
+
+      expect(email_subscription.reload.email_alert_api_subscription_id).to be_nil
+      expect(stub).to have_been_made
+    end
+
+    context "when the subscription has been ended in email-alert-api" do
+      before { stub_email_alert_api_has_no_subscription_for_uuid("prior-subscription-id") }
+
+      it "sets the email_alert_api_subscription_id to nil" do
+        email_subscription.deactivate!
+
+        expect(email_subscription.reload.email_alert_api_subscription_id).to be_nil
+      end
+    end
+
+    it "calls deactivate! on destroy" do
+      stub = stub_email_alert_api_unsubscribes_a_subscription("prior-subscription-id")
+
+      email_subscription.destroy!
+
+      expect(stub).to have_been_made
+    end
+  end
+
+  def stub_subscriber_list
+    stub_email_alert_api_has_subscriber_list_by_slug(
+      slug: email_subscription.topic_slug,
+      returned_attributes: { id: "list-id" },
+    )
   end
 end

--- a/spec/requests/email_subscriptions_spec.rb
+++ b/spec/requests/email_subscriptions_spec.rb
@@ -1,0 +1,171 @@
+require "gds_api/test_helpers/email_alert_api"
+
+RSpec.describe "Email subscriptions" do
+  include GdsApi::TestHelpers::EmailAlertApi
+
+  let(:headers) { { "Content-Type" => "application/json", "GOVUK-Account-Session" => session_identifier.serialise } }
+  let(:session_identifier) { placeholder_govuk_account_session_object }
+
+  describe "GET /api/email-subscriptions/:subscription_name" do
+    it "returns a 404" do
+      get email_subscription_path(subscription_name: "foo"), headers: headers
+      expect(response).to have_http_status(:not_found)
+    end
+
+    context "when the subscription exists" do
+      before do
+        stub_email_alert_api_has_subscription(
+          email_subscription.email_alert_api_subscription_id,
+          "daily",
+          ended: subscription_ended,
+        )
+      end
+
+      let(:email_subscription) do
+        FactoryBot.create(:email_subscription, oidc_user: session_identifier.user, email_alert_api_subscription_id: "prior-subscription-id")
+      end
+
+      let(:subscription_ended) { false }
+
+      it "returns the subscription details" do
+        get email_subscription_path(subscription_name: email_subscription.name), headers: headers
+        expect(response).to be_successful
+        expect(JSON.parse(response.body)["email_subscription"]).to eq(email_subscription.to_hash)
+      end
+
+      context "when the subscription has been ended in email-alert-api" do
+        let(:subscription_ended) { true }
+
+        it "deletes the subscription here and returns a 404" do
+          stub_email_alert_api_unsubscribes_a_subscription(email_subscription.email_alert_api_subscription_id)
+          expect { get email_subscription_path(subscription_name: email_subscription.name), headers: headers }.to change(EmailSubscription, :count).by(-1)
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+  end
+
+  describe "PUT /api/email-subscriptions/:subscription_name" do
+    let(:params) { { topic_slug: "slug" } }
+    let(:email) { "email@example.com" }
+    let(:email_verified) { false }
+
+    it "creates a new subscription record if one doesn't already exist" do
+      stub_local_attributes
+
+      expect { put email_subscription_path(subscription_name: "name"), params: params.to_json, headers: headers }.to change(EmailSubscription, :count).by(1)
+
+      expect(response).to be_successful
+      expect(JSON.parse(response.body)["email_subscription"]).to eq(EmailSubscription.last.to_hash)
+    end
+
+    it "fetches the email & email_verified attributes if they aren't cached locally" do
+      stub_oidc_discovery
+      stub_email = stub_request(:get, "http://openid-provider/v1/attributes/email").to_return(body: { claim_value: "email@example.com" }.to_json)
+      stub_email_verified = stub_request(:get, "http://openid-provider/v1/attributes/email_verified").to_return(body: { claim_value: false }.to_json)
+
+      expect { put email_subscription_path(subscription_name: "name"), params: params.to_json, headers: headers }.to change(EmailSubscription, :count).by(1)
+
+      expect(response).to be_successful
+      expect(JSON.parse(response.body)["email_subscription"]).to eq(EmailSubscription.last.to_hash)
+
+      expect(stub_email).to have_been_made
+      expect(stub_email_verified).to have_been_made
+    end
+
+    context "when the user has verified their email address" do
+      let(:email_verified) { true }
+
+      it "calls email-alert-api to create the subscription" do
+        expect_activate_email_subscription do
+          stub_local_attributes
+
+          expect { put email_subscription_path(subscription_name: "name"), params: params.to_json, headers: headers }.to change(EmailSubscription, :count).by(1)
+
+          expect(response).to be_successful
+          expect(JSON.parse(response.body)["email_subscription"]).to eq(EmailSubscription.last.to_hash)
+        end
+      end
+    end
+
+    context "when the subscription already exists" do
+      let!(:email_subscription) do
+        FactoryBot.create(:email_subscription, oidc_user: session_identifier.user, email_alert_api_subscription_id: "prior-subscription-id")
+      end
+
+      before { stub_local_attributes }
+
+      it "calls email-alert-api to deactivate the old subscription" do
+        stub_cancel_old = stub_email_alert_api_unsubscribes_a_subscription(email_subscription.email_alert_api_subscription_id)
+
+        put email_subscription_path(subscription_name: email_subscription.name), params: params.to_json, headers: headers
+
+        expect(response).to be_successful
+        expect(JSON.parse(response.body)["email_subscription"]).to eq(EmailSubscription.last.to_hash)
+        expect(stub_cancel_old).to have_been_made
+      end
+
+      context "when the user has verified their email address" do
+        let(:email_verified) { true }
+
+        it "calls email-alert-api to create the new subscription" do
+          expect_activate_email_subscription do
+            stub_email_alert_api_unsubscribes_a_subscription(email_subscription.email_alert_api_subscription_id)
+
+            put email_subscription_path(subscription_name: email_subscription.name), params: params.to_json, headers: headers
+
+            expect(response).to be_successful
+            expect(JSON.parse(response.body)["email_subscription"]).to eq(EmailSubscription.last.to_hash)
+          end
+        end
+      end
+    end
+
+    def stub_local_attributes
+      LocalAttribute.create!(oidc_user: session_identifier.user, name: "email", value: email)
+      LocalAttribute.create!(oidc_user: session_identifier.user, name: "email_verified", value: email_verified)
+    end
+
+    def expect_activate_email_subscription
+      stub_fetch_topic = stub_email_alert_api_has_subscriber_list_by_slug(
+        slug: params[:topic_slug],
+        returned_attributes: { id: "list-id" },
+      )
+
+      stub_create_new = stub_email_alert_api_creates_a_subscription(
+        subscriber_list_id: "list-id",
+        address: "email@example.com",
+        frequency: "daily",
+        returned_subscription_id: "new-subscription-id",
+        skip_confirmation_email: true,
+      )
+
+      yield
+
+      expect(stub_fetch_topic).to have_been_made
+      expect(stub_create_new).to have_been_made
+    end
+  end
+
+  describe "DELETE /api/email-subscriptions/:subscription_name" do
+    it "returns a 404" do
+      delete email_subscription_path(subscription_name: "foo"), headers: headers
+      expect(response).to have_http_status(:not_found)
+    end
+
+    context "when the subscription exists" do
+      let!(:email_subscription) do
+        FactoryBot.create(:email_subscription, oidc_user: session_identifier.user, email_alert_api_subscription_id: "prior-subscription-id")
+      end
+
+      it "deletes it, calls email-alert-api to cancel the old subscription, and returns a 204" do
+        stub_cancel_old = stub_email_alert_api_unsubscribes_a_subscription(email_subscription.email_alert_api_subscription_id)
+
+        expect { delete email_subscription_path(subscription_name: email_subscription.name), headers: headers }.to change(EmailSubscription, :count).by(-1)
+
+        expect(response).to have_http_status(:no_content)
+        expect(stub_cancel_old).to have_been_made
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds an API for email subscription management, and makes it so that when the Identity Provider tells us that a user has a new email address, we update the subscriptions.

**Why not just use email-alert-api?**

Updating the subscriptions when the account updates needs a change in account-api, but couldn't we just use email-alert-api for the rest of this?  Why do we need an `email_subscriptions` table?  Well, there are two reasons:

1. Since consuming apps work with "names" rather than email topic slugs, they don't need to implement logic like:
    1. Call email-alert-api with the old topic slug and the current email address to cancel the old subscription (this would be a new endpoint in email-alert-api)
    2. Call email-alert-api with the new topic slug and current email address to create the new subscription
2. We're intentionally *not* fully integrating accounts with notifications yet, so when a user's email address is updates we *only* want to update those subscriptions associated with the account (we could do this by adding a flag to the email-alert-api model)

So we can keep all the changes in account-api, or we can make some in account-api and some in email-alert-api.  Probably best to keep them all in account-api for now.  We might revisit this after integrating accounts and notifications more tightly.

---

[Trello card](https://trello.com/c/yzVmdrzw/829-add-rest-api-for-email-subscriptions-to-account-api)