### PR TITLE
Reorganise OIDC spec helpers a bit

### DIFF
--- a/spec/requests/attributes/names_spec.rb
+++ b/spec/requests/attributes/names_spec.rb
@@ -20,15 +20,12 @@ RSpec.describe "Attribute names" do
   let(:attribute_value2) { "some_value2" }
   let(:local_attribute_value) { [1, 2, { "buckle" => %w[my shoe] }] }
 
-  let(:status) { 200 }
   let(:response_body) { JSON.parse(response.body) }
 
   describe "GET #show" do
     context "when a single attribute is requested" do
       before do
-        stub_request(:get, "http://openid-provider/v1/attributes/#{attribute_name1}")
-          .to_return(status: status, body: { claim_value: attribute_value1 }.compact.to_json)
-
+        stub_remote_attribute_request(name: attribute_name1, value: attribute_value1)
         get attributes_names_path, headers: headers, params: params
       end
 
@@ -65,11 +62,8 @@ RSpec.describe "Attribute names" do
 
     context "when multiple attributes are requested" do
       before do
-        stub_request(:get, "http://openid-provider/v1/attributes/#{attribute_name1}")
-          .to_return(status: status, body: { claim_value: attribute_value1 }.compact.to_json)
-
-        stub_request(:get, "http://openid-provider/v1/attributes/#{attribute_name2}")
-          .to_return(status: 200, body: { claim_value: attribute_value2 }.compact.to_json)
+        stub_remote_attribute_request(name: attribute_name1, value: attribute_value1)
+        stub_remote_attribute_request(name: attribute_name2, value: attribute_value2)
 
         LocalAttribute.create!(
           oidc_user: OidcUser.find_or_create_by(sub: "user-id"),

--- a/spec/requests/attributes_spec.rb
+++ b/spec/requests/attributes_spec.rb
@@ -20,8 +20,7 @@ RSpec.describe "Attributes" do
 
   describe "GET" do
     before do
-      stub_request(:get, "http://openid-provider/v1/attributes/#{attribute_name1}")
-        .to_return(status: status, body: { claim_value: attribute_value1 }.compact.to_json)
+      stub_remote_attribute_request(name: attribute_name1, value: attribute_value1, status: status)
     end
 
     let(:params) { { attributes: [attribute_name1] } }
@@ -84,8 +83,7 @@ RSpec.describe "Attributes" do
 
     context "when multiple attributes are requested" do
       before do
-        stub_request(:get, "http://openid-provider/v1/attributes/#{attribute_name2}")
-          .to_return(status: 200, body: { claim_value: attribute_value2 }.compact.to_json)
+        stub_remote_attribute_request(name: attribute_name2, value: attribute_value2)
 
         LocalAttribute.create!(
           oidc_user: OidcUser.find_or_create_by(sub: "user-id"),

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "User information endpoint" do
 
   before do
     stub_oidc_discovery
-    stub_requests_for_attributes(attributes)
+    stub_remote_attribute_requests(attributes)
   end
 
   let(:session_identifier) { placeholder_govuk_account_session_object(level_of_authentication: level_of_authentication) }
@@ -91,16 +91,6 @@ RSpec.describe "User information endpoint" do
     it "returns a 401" do
       get "/api/user", headers: headers
       expect(response).to have_http_status(:unauthorized)
-    end
-  end
-
-  def stub_requests_for_attributes(attributes)
-    attributes.each do |name, value|
-      if value.nil?
-        stub_request(:get, "http://openid-provider/v1/attributes/#{name}").to_return(status: 404)
-      else
-        stub_request(:get, "http://openid-provider/v1/attributes/#{name}").to_return(body: { claim_value: value }.to_json)
-      end
     end
   end
 

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -92,11 +92,13 @@ Pact.provider_states_for "GDS API Adapters" do
     set_up do
       stub_request(:get, "#{Plek.find('account-manager')}/api/v1/transition-checker/email-subscription").to_return(status: 404)
       stub_request(:post, "#{Plek.find('account-manager')}/api/v1/transition-checker/email-subscription").to_return(status: 200)
-      stub_request(:get, "http://openid-provider/v1/attributes/email").to_return(status: 200, body: { claim_value: "user@example.com" }.to_json)
-      stub_request(:get, "http://openid-provider/v1/attributes/email_verified").to_return(status: 200, body: { claim_value: true }.to_json)
-      stub_request(:get, "http://openid-provider/v1/attributes/transition_checker_state").to_return(status: 404)
-      stub_request(:get, "http://openid-provider/v1/attributes/foo").to_return(status: 404)
-      stub_request(:get, "http://openid-provider/v1/attributes/test_attribute_1").to_return(status: 404)
+      stub_remote_attribute_requests(
+        email: "user@example.com",
+        email_verified: true,
+        transition_checker_state: nil,
+        foo: nil,
+        test_attribute_1: nil,
+      )
       stub_request(:post, "http://openid-provider/v1/attributes").to_return(status: 200)
     end
   end
@@ -109,9 +111,11 @@ Pact.provider_states_for "GDS API Adapters" do
 
   provider_state "there is a valid user session, with /guidance/some-govuk-guidance saved" do
     set_up do
-      stub_request(:get, "http://openid-provider/v1/attributes/email").to_return(status: 200, body: { claim_value: "user@example.com" }.to_json)
-      stub_request(:get, "http://openid-provider/v1/attributes/email_verified").to_return(status: 200, body: { claim_value: true }.to_json)
-      stub_request(:get, "http://openid-provider/v1/attributes/transition_checker_state").to_return(status: 404)
+      stub_remote_attribute_requests(
+        email: "user@example.com",
+        email_verified: true,
+        transition_checker_state: nil,
+      )
       FactoryBot.create(:saved_page, page_path: "/guidance/some-govuk-guidance", oidc_user_id: oidc_user.id)
     end
   end
@@ -124,13 +128,13 @@ Pact.provider_states_for "GDS API Adapters" do
 
   provider_state "there is a valid user session, with an attribute called 'foo'" do
     set_up do
-      stub_request(:get, "http://openid-provider/v1/attributes/foo").to_return(status: 200, body: { claim_value: { bar: "baz" } }.to_json)
+      stub_remote_attribute_request(name: "foo", value: { bar: "baz" })
     end
   end
 
   provider_state "there is a valid user session, with an attribute called 'test_attribute_1'" do
     set_up do
-      stub_request(:get, "http://openid-provider/v1/attributes/test_attribute_1").to_return(status: 200, body: { claim_value: { bar: "baz" } }.to_json)
+      stub_remote_attribute_request(name: "test_attribute_1", value: { bar: "baz" })
     end
   end
 end

--- a/spec/support/helpers/oidc_client_helper.rb
+++ b/spec/support/helpers/oidc_client_helper.rb
@@ -30,6 +30,18 @@ module OidcClientHelper
     allow_any_instance_of(OidcClient).to receive(:tokens!).and_return(token_response)
     # rubocop:enable RSpec/AnyInstance
   end
+
+  def stub_remote_attribute_request(name:, value: nil, status: nil)
+    status ||= value.nil? ? 404 : 200
+    stub_request(:get, "http://openid-provider/v1/attributes/#{name}")
+      .to_return(status: status, body: { claim_value: value }.compact.to_json)
+  end
+
+  def stub_remote_attribute_requests(names_and_values = {})
+    names_and_values.each do |name, value|
+      stub_remote_attribute_request(name: name, value: value)
+    end
+  end
 end
 
 RSpec.configuration.send :include, OidcClientHelper

--- a/spec/support/helpers/oidc_client_helper.rb
+++ b/spec/support/helpers/oidc_client_helper.rb
@@ -30,30 +30,6 @@ module OidcClientHelper
     allow_any_instance_of(OidcClient).to receive(:tokens!).and_return(token_response)
     # rubocop:enable RSpec/AnyInstance
   end
-
-  def stub_oidc_client(client = nil)
-    oidc_client = instance_double("OpenIDConnect::Client")
-
-    if client
-      allow(client).to receive(:client).and_return(oidc_client)
-    else
-      # rubocop:disable RSpec/AnyInstance
-      allow_any_instance_of(OidcClient).to receive(:client).and_return(oidc_client)
-      # rubocop:enable RSpec/AnyInstance
-    end
-
-    oidc_client
-  end
-
-  def allow_token_refresh(client)
-    new_access_token = Rack::OAuth2::AccessToken::Bearer.new(
-      access_token: "new-access-token",
-      refresh_token: "new-refresh-token",
-    )
-
-    allow(client).to receive(:"refresh_token=").with("refresh-token")
-    allow(client).to receive(:access_token!).and_return(new_access_token)
-  end
 end
 
 RSpec.configuration.send :include, OidcClientHelper


### PR DESCRIPTION
Our API coverage looks pretty good, it's really only the `redirect_path` of the auth controller and the `page_path` of the saved pages controller where we're passing something which could directly come from user input.  And those have good coverage now.

I shuffled around the OIDC helpers a bit, merging two single-use methods into the file which needed them and adding a couple of new methods for stubbing remote attribute requests.

---

[Trello card](https://trello.com/c/siLdMmuu/848-review-api-tests-for-missing-coverage)