### PR TITLE
Add missing ActiveRecord validations & specs from DB constraints

### DIFF
--- a/app/models/auth_request.rb
+++ b/app/models/auth_request.rb
@@ -2,7 +2,7 @@ class AuthRequest < ApplicationRecord
   EXPIRATION_AGE = 2.hours
   scope :expired, -> { where("created_at < ?", EXPIRATION_AGE.ago) }
 
-  validate :redirect_path_is_safe
+  validates :redirect_path, absolute_path_with_query_string: true
 
   def self.generate!(options = {})
     create!(
@@ -23,20 +23,5 @@ class AuthRequest < ApplicationRecord
     return nil unless bits.length == 2
 
     find_by(id: bits[1], oauth_state: bits[0])
-  end
-
-  def redirect_path_is_safe
-    return if redirect_path.nil?
-    return if redirect_path.empty?
-
-    if redirect_path.starts_with? "//"
-      errors.add(:redirect_path, "can't be protocol-relative")
-      return
-    end
-
-    return if redirect_path.starts_with? "/"
-    return if redirect_path.starts_with?("http://") && Rails.env.development?
-
-    errors.add(:redirect_path, "can't be absolute")
   end
 end

--- a/app/models/auth_request.rb
+++ b/app/models/auth_request.rb
@@ -2,6 +2,8 @@ class AuthRequest < ApplicationRecord
   EXPIRATION_AGE = 2.hours
   scope :expired, -> { where("created_at < ?", EXPIRATION_AGE.ago) }
 
+  validates :oauth_state, presence: true
+  validates :oidc_nonce, presence: true
   validates :redirect_path, absolute_path_with_query_string: true
 
   def self.generate!(options = {})

--- a/app/models/oidc_user.rb
+++ b/app/models/oidc_user.rb
@@ -2,6 +2,8 @@ class OidcUser < ApplicationRecord
   has_many :local_attributes, dependent: :destroy
   has_many :saved_pages, dependent: :destroy
 
+  validates :sub, presence: true
+
   def get_local_attributes(names = [])
     local_attributes
       .where(name: names)

--- a/app/models/saved_page.rb
+++ b/app/models/saved_page.rb
@@ -1,6 +1,7 @@
 class SavedPage < ApplicationRecord
   belongs_to :oidc_user
 
+  validates :content_id, presence: true
   validates :page_path, uniqueness: { scope: :oidc_user_id }, presence: true, absolute_path: true
 
   def to_hash

--- a/app/models/saved_page.rb
+++ b/app/models/saved_page.rb
@@ -1,9 +1,7 @@
 class SavedPage < ApplicationRecord
   belongs_to :oidc_user
 
-  validates :page_path, uniqueness: { scope: :oidc_user_id }, presence: true
-
-  validate :page_path_is_valid_path
+  validates :page_path, uniqueness: { scope: :oidc_user_id }, presence: true, absolute_path: true
 
   def to_hash
     {
@@ -20,17 +18,5 @@ class SavedPage < ApplicationRecord
       title: content_item["title"],
       public_updated_at: content_item["public_updated_at"] ? Time.zone.parse(content_item["public_updated_at"]) : nil,
     }
-  end
-
-private
-
-  def page_path_is_valid_path
-    errors.add(:page_path, :invalid_path, message: "must only include URL path") unless is_valid_path?
-  end
-
-  def is_valid_path?
-    page_path&.starts_with?("/") && URI(page_path).path == page_path
-  rescue StandardError
-    false
   end
 end

--- a/app/validators/absolute_path_validator.rb
+++ b/app/validators/absolute_path_validator.rb
@@ -1,0 +1,15 @@
+class AbsolutePathValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    record.errors.add(attribute, "must only include URL path") unless valid_absolute_url_path? value
+  end
+
+private
+
+  def valid_absolute_url_path?(value)
+    value.starts_with?("/") && URI.parse(value).path == value
+  rescue URI::InvalidURIError
+    false
+  end
+end

--- a/app/validators/absolute_path_with_query_string_validator.rb
+++ b/app/validators/absolute_path_with_query_string_validator.rb
@@ -1,0 +1,15 @@
+class AbsolutePathWithQueryStringValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    if value.starts_with? "//"
+      record.errors.add(attribute, "can't be protocol-relative")
+      return
+    end
+
+    return if value.starts_with? "/"
+    return if value.starts_with?("http://") && Rails.env.development?
+
+    record.errors.add(attribute, "can't be absolute")
+  end
+end

--- a/spec/factories/auth_request_factory.rb
+++ b/spec/factories/auth_request_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :auth_request do
+    oauth_state { SecureRandom.uuid }
+    oidc_nonce { SecureRandom.uuid }
+  end
+end

--- a/spec/models/auth_request_spec.rb
+++ b/spec/models/auth_request_spec.rb
@@ -1,39 +1,37 @@
 RSpec.describe AuthRequest do
   it "can be found from the OAuth state param" do
-    request1 = described_class.create!(
-      oauth_state: SecureRandom.alphanumeric(10),
-      oidc_nonce: SecureRandom.alphanumeric(10),
-      redirect_path: "/#{SecureRandom.alphanumeric(10)}",
-    )
-    request2 = described_class.create!(
-      oauth_state: request1.oauth_state,
-      oidc_nonce: request1.oidc_nonce,
-      redirect_path: request1.redirect_path,
-    )
+    request1 = FactoryBot.create(:auth_request, redirect_path: "/#{SecureRandom.alphanumeric(10)}")
+    request2 = FactoryBot.create(:auth_request, redirect_path: request1.redirect_path)
 
     expect(described_class.from_oauth_state(request1.to_oauth_state).id).to eq(request1.id)
     expect(described_class.from_oauth_state(request2.to_oauth_state).id).to eq(request2.id)
   end
 
-  it "allows an empty redirect" do
-    expect(described_class.new(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "")).to be_valid
-    expect(described_class.new(oauth_state: "foo", oidc_nonce: "bar", redirect_path: nil)).to be_valid
-  end
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:oauth_state) }
 
-  it "allows path-relative redirects" do
-    expect(described_class.new(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "/good-page")).to be_valid
-  end
+    it { is_expected.to validate_presence_of(:oidc_nonce) }
 
-  it "allows querystrings" do
-    expect(described_class.new(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "/page/with/a?query=string")).to be_valid
-  end
+    it "allows an empty redirect" do
+      expect(described_class.new(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "")).to be_valid
+      expect(described_class.new(oauth_state: "foo", oidc_nonce: "bar", redirect_path: nil)).to be_valid
+    end
 
-  it "forbids protocol-relative redirects" do
-    expect(described_class.new(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "//malicious-site.com")).not_to be_valid
-  end
+    it "allows path-relative redirects" do
+      expect(described_class.new(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "/good-page")).to be_valid
+    end
 
-  it "forbids absolute redirects" do
-    expect(described_class.new(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "http://malicious-site.com")).not_to be_valid
-    expect(described_class.new(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "https://malicious-site.com")).not_to be_valid
+    it "allows querystrings" do
+      expect(described_class.new(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "/page/with/a?query=string")).to be_valid
+    end
+
+    it "forbids protocol-relative redirects" do
+      expect(described_class.new(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "//malicious-site.com")).not_to be_valid
+    end
+
+    it "forbids absolute redirects" do
+      expect(described_class.new(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "http://malicious-site.com")).not_to be_valid
+      expect(described_class.new(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "https://malicious-site.com")).not_to be_valid
+    end
   end
 end

--- a/spec/models/oidc_user_spec.rb
+++ b/spec/models/oidc_user_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe OidcUser do
+  describe "associations" do
+    it { is_expected.to have_many(:local_attributes) }
+
+    it { is_expected.to have_many(:saved_pages) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:sub) }
+  end
+end

--- a/spec/models/saved_page_spec.rb
+++ b/spec/models/saved_page_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe SavedPage do
   end
 
   describe "validations" do
+    it { is_expected.to validate_presence_of(:content_id) }
+
     it { is_expected.to validate_presence_of(:page_path) }
 
     it { is_expected.to validate_uniqueness_of(:page_path).scoped_to(:oidc_user_id) }

--- a/spec/requests/attributes/names_spec.rb
+++ b/spec/requests/attributes/names_spec.rb
@@ -20,15 +20,12 @@ RSpec.describe "Attribute names" do
   let(:attribute_value2) { "some_value2" }
   let(:local_attribute_value) { [1, 2, { "buckle" => %w[my shoe] }] }
 
-  let(:status) { 200 }
   let(:response_body) { JSON.parse(response.body) }
 
   describe "GET #show" do
     context "when a single attribute is requested" do
       before do
-        stub_request(:get, "http://openid-provider/v1/attributes/#{attribute_name1}")
-          .to_return(status: status, body: { claim_value: attribute_value1 }.compact.to_json)
-
+        stub_remote_attribute_request(name: attribute_name1, value: attribute_value1)
         get attributes_names_path, headers: headers, params: params
       end
 
@@ -65,11 +62,8 @@ RSpec.describe "Attribute names" do
 
     context "when multiple attributes are requested" do
       before do
-        stub_request(:get, "http://openid-provider/v1/attributes/#{attribute_name1}")
-          .to_return(status: status, body: { claim_value: attribute_value1 }.compact.to_json)
-
-        stub_request(:get, "http://openid-provider/v1/attributes/#{attribute_name2}")
-          .to_return(status: 200, body: { claim_value: attribute_value2 }.compact.to_json)
+        stub_remote_attribute_request(name: attribute_name1, value: attribute_value1)
+        stub_remote_attribute_request(name: attribute_name2, value: attribute_value2)
 
         LocalAttribute.create!(
           oidc_user: OidcUser.find_or_create_by(sub: "user-id"),

--- a/spec/requests/attributes_spec.rb
+++ b/spec/requests/attributes_spec.rb
@@ -20,8 +20,7 @@ RSpec.describe "Attributes" do
 
   describe "GET" do
     before do
-      stub_request(:get, "http://openid-provider/v1/attributes/#{attribute_name1}")
-        .to_return(status: status, body: { claim_value: attribute_value1 }.compact.to_json)
+      stub_remote_attribute_request(name: attribute_name1, value: attribute_value1, status: status)
     end
 
     let(:params) { { attributes: [attribute_name1] } }
@@ -84,8 +83,7 @@ RSpec.describe "Attributes" do
 
     context "when multiple attributes are requested" do
       before do
-        stub_request(:get, "http://openid-provider/v1/attributes/#{attribute_name2}")
-          .to_return(status: 200, body: { claim_value: attribute_value2 }.compact.to_json)
+        stub_remote_attribute_request(name: attribute_name2, value: attribute_value2)
 
         LocalAttribute.create!(
           oidc_user: OidcUser.find_or_create_by(sub: "user-id"),

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "User information endpoint" do
 
   before do
     stub_oidc_discovery
-    stub_requests_for_attributes(attributes)
+    stub_remote_attribute_requests(attributes)
   end
 
   let(:session_identifier) { placeholder_govuk_account_session_object(level_of_authentication: level_of_authentication) }
@@ -91,16 +91,6 @@ RSpec.describe "User information endpoint" do
     it "returns a 401" do
       get "/api/user", headers: headers
       expect(response).to have_http_status(:unauthorized)
-    end
-  end
-
-  def stub_requests_for_attributes(attributes)
-    attributes.each do |name, value|
-      if value.nil?
-        stub_request(:get, "http://openid-provider/v1/attributes/#{name}").to_return(status: 404)
-      else
-        stub_request(:get, "http://openid-provider/v1/attributes/#{name}").to_return(body: { claim_value: value }.to_json)
-      end
     end
   end
 

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -92,11 +92,13 @@ Pact.provider_states_for "GDS API Adapters" do
     set_up do
       stub_request(:get, "#{Plek.find('account-manager')}/api/v1/transition-checker/email-subscription").to_return(status: 404)
       stub_request(:post, "#{Plek.find('account-manager')}/api/v1/transition-checker/email-subscription").to_return(status: 200)
-      stub_request(:get, "http://openid-provider/v1/attributes/email").to_return(status: 200, body: { claim_value: "user@example.com" }.to_json)
-      stub_request(:get, "http://openid-provider/v1/attributes/email_verified").to_return(status: 200, body: { claim_value: true }.to_json)
-      stub_request(:get, "http://openid-provider/v1/attributes/transition_checker_state").to_return(status: 404)
-      stub_request(:get, "http://openid-provider/v1/attributes/foo").to_return(status: 404)
-      stub_request(:get, "http://openid-provider/v1/attributes/test_attribute_1").to_return(status: 404)
+      stub_remote_attribute_requests(
+        email: "user@example.com",
+        email_verified: true,
+        transition_checker_state: nil,
+        foo: nil,
+        test_attribute_1: nil,
+      )
       stub_request(:post, "http://openid-provider/v1/attributes").to_return(status: 200)
     end
   end
@@ -109,9 +111,11 @@ Pact.provider_states_for "GDS API Adapters" do
 
   provider_state "there is a valid user session, with /guidance/some-govuk-guidance saved" do
     set_up do
-      stub_request(:get, "http://openid-provider/v1/attributes/email").to_return(status: 200, body: { claim_value: "user@example.com" }.to_json)
-      stub_request(:get, "http://openid-provider/v1/attributes/email_verified").to_return(status: 200, body: { claim_value: true }.to_json)
-      stub_request(:get, "http://openid-provider/v1/attributes/transition_checker_state").to_return(status: 404)
+      stub_remote_attribute_requests(
+        email: "user@example.com",
+        email_verified: true,
+        transition_checker_state: nil,
+      )
       FactoryBot.create(:saved_page, page_path: "/guidance/some-govuk-guidance", oidc_user_id: oidc_user.id)
     end
   end
@@ -124,13 +128,13 @@ Pact.provider_states_for "GDS API Adapters" do
 
   provider_state "there is a valid user session, with an attribute called 'foo'" do
     set_up do
-      stub_request(:get, "http://openid-provider/v1/attributes/foo").to_return(status: 200, body: { claim_value: { bar: "baz" } }.to_json)
+      stub_remote_attribute_request(name: "foo", value: { bar: "baz" })
     end
   end
 
   provider_state "there is a valid user session, with an attribute called 'test_attribute_1'" do
     set_up do
-      stub_request(:get, "http://openid-provider/v1/attributes/test_attribute_1").to_return(status: 200, body: { claim_value: { bar: "baz" } }.to_json)
+      stub_remote_attribute_request(name: "test_attribute_1", value: { bar: "baz" })
     end
   end
 end

--- a/spec/support/helpers/oidc_client_helper.rb
+++ b/spec/support/helpers/oidc_client_helper.rb
@@ -30,6 +30,18 @@ module OidcClientHelper
     allow_any_instance_of(OidcClient).to receive(:tokens!).and_return(token_response)
     # rubocop:enable RSpec/AnyInstance
   end
+
+  def stub_remote_attribute_request(name:, value: nil, status: nil)
+    status ||= value.nil? ? 404 : 200
+    stub_request(:get, "http://openid-provider/v1/attributes/#{name}")
+      .to_return(status: status, body: { claim_value: value }.compact.to_json)
+  end
+
+  def stub_remote_attribute_requests(names_and_values = {})
+    names_and_values.each do |name, value|
+      stub_remote_attribute_request(name: name, value: value)
+    end
+  end
 end
 
 RSpec.configuration.send :include, OidcClientHelper


### PR DESCRIPTION
DB constraints are needed, because application code isn't infallible,
but Rails validations give nicer error messages than just a generic
"postgres constraint failed" exception, and mean that methods like
`valid?` will work.

I also moved the two path validators into their own named classes, to
make it clearer what the difference between the two is.

---

[Trello card](https://trello.com/c/J7Aba0jq/850-review-database-constraints-and-make-sure-we-have-rails-validations)
