### PR TITLE
Add `has_unconfirmed_email` attribute, to be used in the account home page

### DIFF
--- a/app/controllers/oidc_users_controller.rb
+++ b/app/controllers/oidc_users_controller.rb
@@ -1,5 +1,5 @@
 class OidcUsersController < ApplicationController
-  OIDC_USER_ATTRIBUTES = %i[email email_verified].freeze
+  OIDC_USER_ATTRIBUTES = %i[email email_verified has_unconfirmed_email].freeze
 
   def update
     user = OidcUser.find_or_create_by!(sub: params.fetch(:subject_identifier))

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -1,14 +1,18 @@
 class UserController < ApplicationController
   include AuthenticatedApiConcern
 
-  HOMEPAGE_ATTRIBUTES = %i[email email_verified transition_checker_state].freeze
+  HOMEPAGE_ATTRIBUTES = %i[email email_verified has_unconfirmed_email transition_checker_state].freeze
 
   def show
+    has_unconfirmed_email = attributes.dig(:has_unconfirmed_email, :value)
+    has_unconfirmed_email = false if has_unconfirmed_email.nil?
+
     render_api_response(
       {
         level_of_authentication: @govuk_account_session.level_of_authentication,
         email: attributes.dig(:email, :value),
         email_verified: attributes.dig(:email_verified, :value),
+        has_unconfirmed_email: has_unconfirmed_email,
         services: {
           transition_checker: attribute_service(:transition_checker_state),
           saved_pages: saved_pages_service,

--- a/config/user_attributes.yml
+++ b/config/user_attributes.yml
@@ -14,7 +14,7 @@ email_verified:
     get: 0
 
 has_unconfirmed_email:
-  type: remote
+  type: cached
   writable: false
   permissions:
     check: 0

--- a/config/user_attributes.yml
+++ b/config/user_attributes.yml
@@ -13,6 +13,13 @@ email_verified:
     check: 0
     get: 0
 
+has_unconfirmed_email:
+  type: remote
+  writable: false
+  permissions:
+    check: 0
+    get: 0
+
 transition_checker_state:
   type: cached
   permissions:

--- a/spec/requests/oidc_users_spec.rb
+++ b/spec/requests/oidc_users_spec.rb
@@ -4,9 +4,10 @@ RSpec.describe "OIDC Users endpoint" do
   include GdsApi::TestHelpers::EmailAlertApi
 
   let(:headers) { { "Content-Type" => "application/json" } }
-  let(:params) { { email: email, email_verified: email_verified }.compact.to_json }
+  let(:params) { { email: email, email_verified: email_verified, has_unconfirmed_email: has_unconfirmed_email }.compact.to_json }
   let(:email) { "email@example.com" }
   let(:email_verified) { true }
+  let(:has_unconfirmed_email) { false }
   let(:subject_identifier) { "subject-identifier" }
 
   describe "PUT" do
@@ -24,6 +25,7 @@ RSpec.describe "OIDC Users endpoint" do
       put oidc_user_path(subject_identifier: subject_identifier), params: params, headers: headers
       expect(JSON.parse(response.body)["email"]).to eq(email)
       expect(JSON.parse(response.body)["email_verified"]).to eq(email_verified)
+      expect(JSON.parse(response.body)["has_unconfirmed_email"]).to eq(has_unconfirmed_email)
     end
 
     context "when the user already exists" do
@@ -39,7 +41,7 @@ RSpec.describe "OIDC Users endpoint" do
 
         put oidc_user_path(subject_identifier: subject_identifier), params: params, headers: headers
 
-        expect(user.get_local_attributes(%i[email email_verified])).to eq({ "email" => email, "email_verified" => email_verified })
+        expect(user.get_local_attributes(%i[email email_verified has_unconfirmed_email])).to eq({ "email" => email, "email_verified" => email_verified, "has_unconfirmed_email" => has_unconfirmed_email })
       end
 
       context "when the user has email subscriptions" do

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "User information endpoint" do
     {
       email: "email@example.com",
       email_verified: true,
+      has_unconfirmed_email: false,
       transition_checker_state: transition_checker_state,
     }
   end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -9,10 +9,11 @@ Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
 module PactStubHelpers
   EMAIL_ADDRESS = "user@example.com".freeze
 
-  def stub_email_attribute_requests(email_verified: true)
+  def stub_email_attribute_requests(email_verified: true, has_unconfirmed_email: false)
     stub_remote_attribute_requests(
       email: EMAIL_ADDRESS,
       email_verified: email_verified,
+      has_unconfirmed_email: has_unconfirmed_email,
     )
   end
 


### PR DESCRIPTION
This is not just `!email_verified`:

- `email` - this is the email address the user registered with, or a
  new email address they have confirmed.

- `email_verified` - the user needs to verify the email address they
  registered with, this starts `false`, becomes `true`, and then never
  returns to `false`

- `has_unconfirmed_email` - this is `true` if `email_verified` is
  `false` OR the user has a pending email change to confirm

So,

    if has_unconfirmed_email
      if email_verified
        show "finish changing your email address" banner
      else
        show "confirm your account" banner
      end
    end

And set the attribute through `PATCH /api/oidc-users/:sub`.

We want to have the as many of the attributes needed to return the
`GET /api/user` response stored locally as possible, so the homepage
is nice and fast.

---

[Trello card](https://trello.com/c/nvi8bZct/856-add-hasunconfirmedemail-attribute)