### PR TITLE
Return the user ID in the `GET /api/user` response

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -9,6 +9,7 @@ class UserController < ApplicationController
 
     render_api_response(
       {
+        id: @govuk_account_session.user.id,
         level_of_authentication: @govuk_account_session.level_of_authentication,
         email: attributes.dig(:email, :value),
         email_verified: attributes.dig(:email_verified, :value),

--- a/docs/api.md
+++ b/docs/api.md
@@ -220,6 +220,8 @@ Retrieves the information needed to render the `/account/home` page.
 
 #### JSON response fields
 
+- `id`
+  - the user identifier
 - `level_of_authentication`
   - the user's current level of authentication (`level0` or `level1`)
 - `email`

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -30,6 +30,11 @@ RSpec.describe "User information endpoint" do
     expect(response).to be_successful
   end
 
+  it "returns the user's ID" do
+    get "/api/user", headers: headers
+    expect(response_body["id"]).to eq(session_identifier.user.id)
+  end
+
   it "returns the user's level of authentication" do
     get "/api/user", headers: headers
     expect(response_body["level_of_authentication"]).to eq(session_identifier.level_of_authentication)


### PR DESCRIPTION
We'll need this in email-alert-api so we can record which GOV.UK
Account a Subscriber belongs to.  I thought about adding this to the
`GET /api/attributes` endpoint, but it feels like more of a user
concern to me.

We might want to retire the attributes endpoints at some point anyway
and consolidate stuff under `/api/user`.

---

[Trello card](https://trello.com/c/Vzd8so2T/874-implement-designs-for-managing-your-email-notifications-via-the-account)
