### PR TITLE
Return user ID as a string

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -9,7 +9,7 @@ class UserController < ApplicationController
 
     render_api_response(
       {
-        id: @govuk_account_session.user.id,
+        id: @govuk_account_session.user.id.to_s,
         level_of_authentication: @govuk_account_session.level_of_authentication,
         email: attributes.dig(:email, :value),
         email_verified: attributes.dig(:email_verified, :value),

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "User information endpoint" do
 
   it "returns the user's ID" do
     get "/api/user", headers: headers
-    expect(response_body["id"]).to eq(session_identifier.user.id)
+    expect(response_body["id"]).to eq(session_identifier.user.id.to_s)
   end
 
   it "returns the user's level of authentication" do


### PR DESCRIPTION
This is a small future-proofing change: user IDs are integers now, but
we don't want consuming apps to treat them as such (eg, we might start
propagating subject identifiers at some point, and so they'll turn
into strings).  So let's return it as a string from the get-go.
