### PR TITLE
Update linked subscribers on email address change

### DIFF
--- a/app/controllers/oidc_users_controller.rb
+++ b/app/controllers/oidc_users_controller.rb
@@ -6,12 +6,35 @@ class OidcUsersController < ApplicationController
     user.set_local_attributes(params.permit(OIDC_USER_ATTRIBUTES).to_h)
     attributes = user.get_local_attributes(OIDC_USER_ATTRIBUTES)
 
-    if attributes["email"] && !attributes["email_verified"].nil?
-      user.email_subscriptions.each do |email_subscription|
-        email_subscription.reactivate_if_confirmed!(
-          attributes["email"],
-          attributes["email_verified"],
+    if attributes["email"] && attributes["email_verified"]
+      begin
+        # if the user has linked their notifications account to their
+        # GOV.UK account we don't need to update their
+        # `user.email_subscriptions`, because we can update the
+        # subscriber directly.
+        subscriber_id = GdsApi.email_alert_api
+          .find_subscriber_by_govuk_account(govuk_account_id: user.id)
+          .dig("subscriber", "id")
+        GdsApi.email_alert_api.change_subscriber(
+          id: subscriber_id,
+          new_address: attributes["email"],
         )
+      rescue GdsApi::HTTPNotFound
+        # but for users who haven't linked their notifications account
+        # to their GOV.UK account, we do need to update any
+        # account-linked subscriptions they have (eg, brexit checker
+        # users who haven't touched notifications since registering
+        # through the checker).
+        #
+        # this branch can be removed once we have no GOV.UK accounts
+        # which have subscriptions but are *not* linked to the
+        # corresponding notifications account.
+        user.email_subscriptions.each do |email_subscription|
+          email_subscription.reactivate_if_confirmed!(
+            attributes["email"],
+            attributes["email_verified"],
+          )
+        end
       end
     end
 


### PR DESCRIPTION
Currently, if a user updates their email address, any subscriptions
which account-api knows about will also be updated.  But any other
subscriptions for the same email address won't.  This isn't great.

To address this problem, we've added a concept of "linking" a
subscriber to a GOV.UK Account in email-alert-api.

So now the logic for updating email subscriptions is:

- Check if there is a linked subscriber:
  - If so, update the address for that subscriber
  - If not, update each subscription we know about

We're going to make some frontend changes to nudge people towards
linking their accounts.

---

[Trello card](https://trello.com/c/Vzd8so2T/874-implement-designs-for-managing-your-email-notifications-via-the-account)
