### PR TITLE
Prepare to move transition checker subscriptions to the normal email endpoints

### DIFF
--- a/app/controllers/email_subscriptions_controller.rb
+++ b/app/controllers/email_subscriptions_controller.rb
@@ -1,9 +1,38 @@
 class EmailSubscriptionsController < ApplicationController
   include AuthenticatedApiConcern
 
+  TRANSITION_CHECKER_SUBSCRIPTION_NAME = "transition-checker-results".freeze
+
   before_action :check_subscription_exists, only: %i[show destroy]
 
+  # the transition checker-specific stuff in here is temporary: after
+  # removing the JWT flow, we will start saving transition checker
+  # data to the local database and only calling the account-manager if
+  # it's not present locally; we'll also need to do a bulk import of
+  # data from users who don't log in for a while.
+  #
+  # the point of adding this logic to the endpoints now, before
+  # implementing the data import, is so that we can update the
+  # transition checker to use the new endpoints sooner rather than
+  # later.
+
   def show
+    if is_transition_checker_subscription?
+      legacy_subscription = @govuk_account_session.get_transition_checker_email_subscription
+      if legacy_subscription
+        render_api_response(email_subscription:
+          {
+            "name" => TRANSITION_CHECKER_SUBSCRIPTION_NAME,
+            "topic_slug" => legacy_subscription["topic_slug"],
+            "email_alert_api_subscription_id" => legacy_subscription["subscription_id"],
+          }.compact)
+      else
+        head :not_found
+      end
+
+      return
+    end
+
     if email_subscription.email_alert_api_subscription_id
       begin
         state = GdsApi.email_alert_api.get_subscription(email_subscription.email_alert_api_subscription_id)
@@ -21,6 +50,18 @@ class EmailSubscriptionsController < ApplicationController
   end
 
   def update
+    if is_transition_checker_subscription?
+      legacy_subscription = @govuk_account_session.set_transition_checker_email_subscription(params.require(:topic_slug))
+      render_api_response(email_subscription:
+        {
+          "name" => TRANSITION_CHECKER_SUBSCRIPTION_NAME,
+          "topic_slug" => legacy_subscription["topic_slug"],
+          "email_alert_api_subscription_id" => legacy_subscription["subscription_id"],
+        }.compact)
+
+      return
+    end
+
     attributes = @govuk_account_session.get_attributes(%w[email email_verified])
 
     email_subscription = EmailSubscription.transaction do
@@ -41,7 +82,7 @@ class EmailSubscriptionsController < ApplicationController
   end
 
   def destroy
-    email_subscription.destroy!
+    email_subscription.destroy! unless is_transition_checker_subscription?
     head :no_content
   end
 
@@ -55,6 +96,12 @@ private
   end
 
   def check_subscription_exists
-    head :not_found and return unless email_subscription
+    return if is_transition_checker_subscription?
+
+    head :not_found unless email_subscription
+  end
+
+  def is_transition_checker_subscription?
+    params.fetch(:subscription_name) == TRANSITION_CHECKER_SUBSCRIPTION_NAME
   end
 end

--- a/app/controllers/transition_checker_email_subscription_controller.rb
+++ b/app/controllers/transition_checker_email_subscription_controller.rb
@@ -4,13 +4,15 @@ class TransitionCheckerEmailSubscriptionController < ApplicationController
   def show
     check_permission! :check
 
-    render_api_response has_subscription: @govuk_account_session.has_email_subscription?
+    subscription = @govuk_account_session.get_transition_checker_email_subscription
+
+    render_api_response has_subscription: subscription.present?
   end
 
   def update
     check_permission! :set
 
-    @govuk_account_session.set_email_subscription(params.require(:slug))
+    @govuk_account_session.set_transition_checker_email_subscription(params.require(:slug))
     render_api_response
   end
 

--- a/app/lib/account_session.rb
+++ b/app/lib/account_session.rb
@@ -86,12 +86,16 @@ class AccountSession
     set_remote_attributes(remote)
   end
 
-  def has_email_subscription?
-    oidc_do :has_email_subscription
+  def get_transition_checker_email_subscription
+    oidc_do :get_transition_checker_email_subscription
   end
 
-  def set_email_subscription(slug)
-    oidc_do :update_email_subscription, { slug: slug }
+  def set_transition_checker_email_subscription(slug)
+    oidc_do :set_transition_checker_email_subscription, { slug: slug }
+  end
+
+  def migrate_transition_checker_email_subscription
+    oidc_do :migrate_transition_checker_email_subscription
   end
 
 private

--- a/app/lib/oidc_client.rb
+++ b/app/lib/oidc_client.rb
@@ -125,24 +125,45 @@ class OidcClient
     end
   end
 
-  def has_email_subscription(access_token:, refresh_token: nil)
+  def get_transition_checker_email_subscription(access_token:, refresh_token: nil)
     response = oauth_request(
       access_token: access_token,
       refresh_token: refresh_token,
       method: :get,
-      uri: email_subscription_uri,
+      uri: transition_checker_email_subscription_uri,
     )
 
-    response.merge(result: (200..299).include?(response[:result].status))
+    body = response[:result].body
+    if response[:result].status != 200 || body.empty?
+      response.merge(result: nil)
+    else
+      response.merge(result: JSON.parse(body))
+    end
   end
 
-  def update_email_subscription(slug:, access_token:, refresh_token: nil)
-    oauth_request(
+  def set_transition_checker_email_subscription(slug:, access_token:, refresh_token: nil)
+    response = oauth_request(
       access_token: access_token,
       refresh_token: refresh_token,
       method: :post,
-      uri: email_subscription_uri,
+      uri: transition_checker_email_subscription_uri,
       arg: { topic_slug: slug },
+    )
+
+    body = response[:result].body
+    if response[:result].status != 200 || body.empty?
+      response.merge(result: nil)
+    else
+      response.merge(result: JSON.parse(body))
+    end
+  end
+
+  def migrate_transition_checker_email_subscription(access_token:, refresh_token: nil)
+    oauth_request(
+      access_token: access_token,
+      refresh_token: refresh_token,
+      method: :delete,
+      uri: transition_checker_email_subscription_uri,
     )
   end
 
@@ -209,7 +230,7 @@ private
     end
   end
 
-  def email_subscription_uri
+  def transition_checker_email_subscription_uri
     URI.parse(provider_uri).tap do |u|
       u.path = "/api/v1/transition-checker/email-subscription"
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
     put "/saved_pages/:page_path", to: "saved_pages#update"
     delete "/saved_pages/:page_path", to: "saved_pages#destroy"
 
+    # delete (+ controller) when gds-api-adapters has been updated
     get "/transition-checker-email-subscription", to: "transition_checker_email_subscription#show"
     post "/transition-checker-email-subscription", to: "transition_checker_email_subscription#update"
   end

--- a/spec/requests/transition_checker_email_subscription_spec.rb
+++ b/spec/requests/transition_checker_email_subscription_spec.rb
@@ -12,13 +12,15 @@ RSpec.describe "Transition Checker email subscriptions" do
 
   describe "GET" do
     before do
-      stub_request(:get, "#{Plek.find('account-manager')}/api/v1/transition-checker/email-subscription").to_return(status: status)
+      stub_request(:get, "#{Plek.find('account-manager')}/api/v1/transition-checker/email-subscription").to_return(status: status, body: body)
     end
 
     let(:status) { 500 }
+    let(:body) { nil }
 
     context "when the user has an email subscription" do
-      let(:status) { 204 }
+      let(:status) { 200 }
+      let(:body) { { topic_slug: "topic", subscription_id: "id" }.to_json }
 
       it "returns 'true'" do
         get transition_checker_email_subscription_path, headers: headers

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -167,7 +167,7 @@ Pact.provider_states_for "GDS API Adapters" do
 
   provider_state "there is a valid user session, with a transition checker email subscription" do
     set_up do
-      stub_request(:get, "#{Plek.find('account-manager')}/api/v1/transition-checker/email-subscription").to_return(status: 204)
+      stub_request(:get, "#{Plek.find('account-manager')}/api/v1/transition-checker/email-subscription").to_return(status: 200, body: { topic_slug: "slug" }.to_json)
     end
   end
 


### PR DESCRIPTION
This PR handles `/api/email-subscriptions/transition-checker-results` as a special case, delegating to the account-manager rather than using the local database like other email subscriptions.

This is because, once the transition checker is no longer a special case, it will use these endpoints.  So we want to update finder-frontend to use them, and delete the old endpoints.

Then, when we have removed the JWT journey from finder-frontend (which we can do as soon as we have the new design for the post-registration confirmation page), we can update these special-cased endpoints to start migrating the subscription data out of account-manager.