### PR TITLE
Return cookie consent from auth callback endpoint

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -38,6 +38,7 @@ class AuthenticationController < ApplicationController
       ).serialise,
       redirect_path: redirect_path,
       ga_client_id: oauth_response.fetch(:result)["_ga"],
+      cookie_consent: oauth_response.fetch(:result)["cookie_consent"],
     }
   rescue OidcClient::OAuthFailure
     head :unauthorized

--- a/docs/api.md
+++ b/docs/api.md
@@ -146,6 +146,8 @@ On a `401: Unauthorized` response, the identity provider has rejected the authen
   - the `redirect_path` which was previously passed to `GET /api/oauth2/sign-in`, if given
 - `ga_client_id` *(optional)*
   - the Google Analytics client ID which the identity provider used for analytics
+- `cookie_consent` *(optional)*
+  - whether the user saved a "usage" cookie consent
 
 #### Response codes
 
@@ -169,7 +171,8 @@ Response:
 {
     "govuk_account_session": "YWNjZXNzLXRva2Vu.cmVmcmVzaC10b2tlbg==",
     "redirect_path": "/guidance/keeping-a-pet-pig-or-micropig",
-    "ga_client_id": "ga-123-userid"
+    "ga_client_id": "ga-123-userid",
+    "cookie_consent": false,
 }
 ```
 

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -44,11 +44,11 @@ RSpec.describe "Authentication" do
     it "fetches the tokens & ephemeral state" do
       stub_request(:get, "#{Plek.find('account-manager')}/api/v1/ephemeral-state")
         .with(headers: { "Authorization" => "Bearer access-token" })
-        .to_return(status: 200, body: { _ga: "ga-client-id", level_of_authentication: "level42" }.to_json)
+        .to_return(status: 200, body: { _ga: "ga-client-id", level_of_authentication: "level42", cookie_consent: true }.to_json)
 
       post callback_path, headers: headers, params: { state: auth_request.to_oauth_state, code: "12345" }.to_json
       expect(response).to be_successful
-      expect(JSON.parse(response.body)).to include("govuk_account_session", "redirect_path" => auth_request.redirect_path, "ga_client_id" => "ga-client-id")
+      expect(JSON.parse(response.body)).to include("govuk_account_session", "redirect_path" => auth_request.redirect_path, "ga_client_id" => "ga-client-id", "cookie_consent" => true)
     end
 
     it "returns a 401 if there is no matching AuthRequest" do

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -119,6 +119,15 @@ Pact.provider_states_for "GDS API Adapters" do
     end
   end
 
+  provider_state "there is a valid OAuth response, with cookie consent 'true'" do
+    set_up do
+      auth_request = AuthRequest.generate!(redirect_path: "/some-arbitrary-path")
+      allow(AuthRequest).to receive(:from_oauth_state).and_return(auth_request)
+
+      stub_request(:get, "#{Plek.find('account-manager')}/api/v1/ephemeral-state").to_return(status: 200, body: { _ga: "ga-client-id", level_of_authentication: "level0", cookie_consent: true }.to_json)
+    end
+  end
+
   provider_state "there is a valid user session" do
     set_up do
       stub_email_attribute_requests


### PR DESCRIPTION
We've not actually been doing this since migrating from the
finder-frontend session handling.
