### PR TITLE
Remove `POST /api/oauth2/state` endpoint

### DIFF
--- a/app/lib/oidc_client.rb
+++ b/app/lib/oidc_client.rb
@@ -118,25 +118,6 @@ class OidcClient
     end
   end
 
-  def submit_jwt(jwt:, access_token:, refresh_token: nil)
-    response = time_and_return "submit_jwt" do
-      oauth_request(
-        access_token: access_token,
-        refresh_token: refresh_token,
-        method: :post,
-        uri: jwt_uri,
-        arg: { jwt: jwt },
-      )
-    end
-
-    body = response[:result].body
-    if body.empty?
-      raise OAuthFailure
-    else
-      response.merge(result: JSON.parse(body))
-    end
-  end
-
   def get_transition_checker_email_subscription(access_token:, refresh_token: nil)
     response = time_and_return "get_transition_checker_email_subscription" do
       oauth_request(
@@ -239,12 +220,6 @@ private
   def bulk_attribute_uri
     URI.parse(userinfo_endpoint).tap do |u|
       u.path = "/v1/attributes"
-    end
-  end
-
-  def jwt_uri
-    URI.parse(provider_uri).tap do |u|
-      u.path = "/api/v1/jwt"
     end
   end
 

--- a/app/models/auth_request.rb
+++ b/app/models/auth_request.rb
@@ -6,16 +6,14 @@ class AuthRequest < ApplicationRecord
   validates :oidc_nonce, presence: true
   validates :redirect_path, absolute_path_with_query_string: true
 
-  def self.generate!(options = {})
+  def self.generate!(redirect_path: nil)
     create!(
-      oauth_state: options[:oauth_state] || SecureRandom.hex(16),
+      oauth_state: SecureRandom.hex(16),
       oidc_nonce: SecureRandom.hex(16),
-      redirect_path: options[:redirect_path],
+      redirect_path: redirect_path,
     )
   end
 
-  # This has to be something which the account manager can use to retrieve a JWT, if there is one:
-  # https://github.com/alphagov/govuk-account-manager-prototype/blob/6a68e02055fe3c70083b3899b474b10cc944ffa5/config/initializers/doorkeeper.rb#L14
   def to_oauth_state
     "#{oauth_state}:#{id}"
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,6 @@ Rails.application.routes.draw do
     scope :oauth2 do
       get "/sign-in", to: "authentication#sign_in"
       post "/callback", to: "authentication#callback"
-      post "/state", to: "authentication#create_state"
     end
 
     get "/user", to: "user#show"

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,7 +11,6 @@ management. This API is not for other government services.
 - [API endpoints](#api-endpoints)
   - [`GET /api/oauth2/sign-in`](#get-apioauth2sign-in)
   - [`POST /api/oauth2/callback`](#post-apioauth2callback)
-  - [`POST /api/oauth2/state`](#post-apioauth2state)
   - [`GET /api/user`](#get-apiuser)
   - [`GET /api/attributes`](#get-apiattributes)
   - [`PATCH /api/attributes`](#patch-apiattributes)
@@ -89,8 +88,6 @@ This URL should be served to the user with a 302 response to authenticate the us
 
 - `level_of_authentication` *(optional)*
   - either `level1` (require MFA) or `level0` (do not require MFA, the default)
-- `state_id` *(optional)*
-  - an identifier returned from a previous call to `POST /api/oauth2/state`
 - `redirect_path` *(optional)*
   - a path on GOV.UK to send the user to after authenticating
 
@@ -112,7 +109,6 @@ Request (with gds-api-adapters):
 ```ruby
 GdsApi.account_api.get_sign_in_url(
     redirect_path: "/guidance/keeping-a-pet-pig-or-micropig",
-    state_id: "12345",
 )
 ```
 
@@ -173,42 +169,6 @@ Response:
     "redirect_path": "/guidance/keeping-a-pet-pig-or-micropig",
     "ga_client_id": "ga-123-userid",
     "cookie_consent": false,
-}
-```
-
-### `POST /api/oauth2/state`
-
-Stores some initial attributes which will be persisted if a user creates an account rather than logging in.
-
-#### JSON request parameters
-
-- `attributes`
-  - a JSON object where keys are attribute names and values are attribute values
-
-#### JSON response fields
-
-- `state_id`
-  - an identifier to pass to `GET /api/oauth2/sign-in`
-
-#### Response codes
-
-- 200
-
-#### Example request / response
-
-Request (with gds-api-adapters):
-
-```ruby
-GdsApi.account_api.create_registration_state(
-    attributes: { name1: "value1", name2: "value2" },
-)
-```
-
-Response:
-
-```json
-{
-    "state_id": "5821a9f9-3ba7-4385-a864-80cdb374550a"
 }
 ```
 

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -21,11 +21,6 @@ RSpec.describe "Authentication" do
       expect(auth_uri).to include("state=#{auth_request.to_oauth_state.sub(':', '%3A')}")
     end
 
-    it "uses a provided state_id" do
-      get sign_in_path, params: { state_id: "hello-world" }
-      expect(AuthRequest.last.oauth_state).to eq("hello-world")
-    end
-
     it "uses a provided redirect_path" do
       get sign_in_path, params: { redirect_path: "/transition-check/results?c[]=import-wombats&c[]=practice-wizardry" }
       expect(AuthRequest.last.redirect_path).to eq("/transition-check/results?c[]=import-wombats&c[]=practice-wizardry")
@@ -63,18 +58,6 @@ RSpec.describe "Authentication" do
 
       post callback_path, headers: headers, params: { state: auth_request.to_oauth_state, code: "12345" }.to_json
       expect(response).to have_http_status(:unauthorized)
-    end
-  end
-
-  describe "/state" do
-    it "submits a JWT to the account manager" do
-      stub_request(:post, "#{Plek.find('account-manager')}/api/v1/jwt")
-        .with(headers: { "Authorization" => "Bearer access-token" })
-        .to_return(status: 200, body: { id: "jwt-id" }.to_json)
-
-      post state_path, headers: headers, params: { attributes: { key: "value" } }.to_json
-      expect(response).to be_successful
-      expect(JSON.parse(response.body)).to include("state_id" => "jwt-id")
     end
   end
 end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -88,8 +88,6 @@ Pact.provider_states_for "GDS API Adapters" do
     fixture_file = YAML.safe_load(File.read(Rails.root.join("spec/fixtures/user_attributes.yml"))).with_indifferent_access
     allow(UserAttributes).to receive(:load_config_file).and_return(normal_file.merge(fixture_file))
 
-    stub_request(:post, "#{Plek.find('account-manager')}/api/v1/jwt").to_return(status: 200, body: { id: "jwt-id" }.to_json)
-
     stub_content_store_has_item(
       "/guidance/some-govuk-guidance",
       content_item_for_base_path("/guidance/some-govuk-guidance").merge("content_id" => SecureRandom.uuid),


### PR DESCRIPTION
This has been removed from gds-api-adapters and is now unused.

See also https://github.com/alphagov/gds-api-adapters/pull/1092

---

[Trello card](https://trello.com/c/aEbuS4Tf/884-remove-the-jwt-sign-up-flow)
