### PR TITLE
Incrementally migrate Transition Checker subscriptions

### DIFF
--- a/app/controllers/email_subscriptions_controller.rb
+++ b/app/controllers/email_subscriptions_controller.rb
@@ -3,36 +3,10 @@ class EmailSubscriptionsController < ApplicationController
 
   TRANSITION_CHECKER_SUBSCRIPTION_NAME = "transition-checker-results".freeze
 
+  before_action :migrate_transition_checker_subscription
   before_action :check_subscription_exists, only: %i[show destroy]
 
-  # the transition checker-specific stuff in here is temporary: after
-  # removing the JWT flow, we will start saving transition checker
-  # data to the local database and only calling the account-manager if
-  # it's not present locally; we'll also need to do a bulk import of
-  # data from users who don't log in for a while.
-  #
-  # the point of adding this logic to the endpoints now, before
-  # implementing the data import, is so that we can update the
-  # transition checker to use the new endpoints sooner rather than
-  # later.
-
   def show
-    if is_transition_checker_subscription?
-      legacy_subscription = @govuk_account_session.get_transition_checker_email_subscription
-      if legacy_subscription
-        render_api_response(email_subscription:
-          {
-            "name" => TRANSITION_CHECKER_SUBSCRIPTION_NAME,
-            "topic_slug" => legacy_subscription["topic_slug"],
-            "email_alert_api_subscription_id" => legacy_subscription["subscription_id"],
-          }.compact)
-      else
-        head :not_found
-      end
-
-      return
-    end
-
     if email_subscription.email_alert_api_subscription_id
       begin
         state = GdsApi.email_alert_api.get_subscription(email_subscription.email_alert_api_subscription_id)
@@ -50,18 +24,6 @@ class EmailSubscriptionsController < ApplicationController
   end
 
   def update
-    if is_transition_checker_subscription?
-      legacy_subscription = @govuk_account_session.set_transition_checker_email_subscription(params.require(:topic_slug))
-      render_api_response(email_subscription:
-        {
-          "name" => TRANSITION_CHECKER_SUBSCRIPTION_NAME,
-          "topic_slug" => legacy_subscription["topic_slug"],
-          "email_alert_api_subscription_id" => legacy_subscription["subscription_id"],
-        }.compact)
-
-      return
-    end
-
     attributes = @govuk_account_session.get_attributes(%w[email email_verified])
 
     email_subscription = EmailSubscription.transaction do
@@ -82,11 +44,29 @@ class EmailSubscriptionsController < ApplicationController
   end
 
   def destroy
-    email_subscription.destroy! unless is_transition_checker_subscription?
+    email_subscription.destroy!
     head :no_content
   end
 
 private
+
+  # remove this after we've done a bulk import of older subscriptions
+  def migrate_transition_checker_subscription
+    return unless params.fetch(:subscription_name) == TRANSITION_CHECKER_SUBSCRIPTION_NAME
+    return if email_subscription
+
+    legacy_subscription = @govuk_account_session.get_transition_checker_email_subscription
+    return unless legacy_subscription
+
+    @email_subscription = EmailSubscription.create!(
+      oidc_user: @govuk_account_session.user,
+      name: TRANSITION_CHECKER_SUBSCRIPTION_NAME,
+      topic_slug: legacy_subscription["topic_slug"],
+      email_alert_api_subscription_id: legacy_subscription["subscription_id"],
+    )
+
+    @govuk_account_session.migrate_transition_checker_email_subscription
+  end
 
   def email_subscription
     @email_subscription ||= EmailSubscription.find_by(
@@ -96,12 +76,6 @@ private
   end
 
   def check_subscription_exists
-    return if is_transition_checker_subscription?
-
     head :not_found unless email_subscription
-  end
-
-  def is_transition_checker_subscription?
-    params.fetch(:subscription_name) == TRANSITION_CHECKER_SUBSCRIPTION_NAME
   end
 end


### PR DESCRIPTION
All Transition Checker email subscription interactions are now going
through this controller, and the JWT method of creating subscriptions
is gone.

So now we can begin to migrate the state into account-api.

---

[Trello card](https://trello.com/c/5rNWhML7/885-begin-incremental-migration-of-transition-checker-email-subscriptions-from-account-manager-to-account-api)
