### PR TITLE
Add rake task to migrate Transition Checker data

### DIFF
--- a/app/lib/migrations/transition_checker.rb
+++ b/app/lib/migrations/transition_checker.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Migrations
+  class TransitionChecker
+    LOCAL_ATTRIBUTE_NAME = "transition_checker_state"
+    EMAIL_SUBSCRIPTION_NAME = "transition-checker-results"
+
+    def self.call(token)
+      new(token).migrate!
+    end
+
+    def initialize(token)
+      @token = token
+      @uri = "#{Plek.find('account-manager')}/api/v1/migrate-users-to-account-api"
+    end
+
+    def migrate!
+      page = 0
+      is_last_page = false
+      until is_last_page
+        response = HTTParty.get("#{uri}?page=#{page}", headers: { "Accept" => "application/json", "Authorization" => "Bearer #{token}" })
+        response["users"].each { |user| migrate_user! user }
+        is_last_page = response["is_last_page"]
+        page += 1
+      end
+    end
+
+  private
+
+    attr_reader :uri, :token
+
+    def migrate_user!(user_record)
+      User.transaction do
+        oidc_user = OidcUser.find_or_create_by!(sub: user_record["subject_identifier"])
+
+        LocalAttribute
+          .create_with(
+            value: user_record["transition_checker_state"],
+          )
+          .find_or_create_by!(
+            oidc_user_id: oidc_user.id,
+            name: LOCAL_ATTRIBUTE_NAME,
+          )
+
+        EmailSubscription
+          .create_with(
+            topic_slug: user_record["topic_slug"],
+            email_alert_api_subscription_id: user_record["email_alert_api_subscription_id"],
+          )
+          .find_or_create_by!(
+            oidc_user_id: oidc_user.id,
+            name: EMAIL_SUBSCRIPTION_NAME,
+          )
+      end
+    end
+  end
+end

--- a/lib/tasks/migrations.rake
+++ b/lib/tasks/migrations.rake
@@ -1,0 +1,7 @@
+namespace :migrations do
+  desc "Migrate Transition Checker state & email subscriptions from the Account Manager"
+  task :transition_checker, %i[token] => [:environment] do
+    token = args.token
+    Migrations::TransitionChecker.call(token)
+  end
+end

--- a/spec/lib/migrations/transition_checker_spec.rb
+++ b/spec/lib/migrations/transition_checker_spec.rb
@@ -1,0 +1,97 @@
+RSpec.describe Migrations::TransitionChecker do
+  let(:subject_identifier) { SecureRandom.uuid }
+  let(:transition_checker_state) { { foo: "bar" } }
+  let(:topic_slug) { "topic-slug" }
+  let(:subscription_id) { "subscription-id" }
+
+  before do
+    user = {
+      subject_identifier: subject_identifier,
+      transition_checker_state: transition_checker_state,
+      topic_slug: topic_slug,
+      email_alert_api_subscription_id: subscription_id,
+    }
+
+    stub_page(0, users: [user], is_last_page: true)
+  end
+
+  it "pages through the results" do
+    stub_page0 = stub_page(0)
+    stub_page1 = stub_page(1)
+    stub_page2 = stub_page(2, is_last_page: true)
+
+    described_class.call("dummy-token")
+
+    expect(stub_page0).to have_been_made
+    expect(stub_page1).to have_been_made
+    expect(stub_page2).to have_been_made
+  end
+
+  shared_examples "imports the attribute" do
+    it "imports the attribute" do
+      expect { described_class.call("dummy-token") }.to change(LocalAttribute, :count).by(1)
+      expect(LocalAttribute.where(oidc_user_id: oidc_user.id, name: "transition_checker_state", value: transition_checker_state).exists?).to be(true)
+    end
+  end
+
+  shared_examples "imports the email subscription" do
+    it "imports the email subscription" do
+      expect { described_class.call("dummy-token") }.to change(EmailSubscription, :count).by(1)
+      expect(EmailSubscription.where(oidc_user_id: oidc_user.id, name: "transition-checker-results", topic_slug: topic_slug, email_alert_api_subscription_id: subscription_id).exists?).to be(true)
+    end
+  end
+
+  context "when the user is new" do
+    let(:oidc_user) { OidcUser.find_by(sub: subject_identifier) }
+
+    it "creates the user" do
+      expect { described_class.call("dummy-token") }.to change(OidcUser, :count).by(1)
+      expect(oidc_user).not_to be_nil
+    end
+
+    include_examples "imports the attribute"
+    include_examples "imports the email subscription"
+  end
+
+  context "when the user already exists in the database" do
+    let!(:oidc_user) { FactoryBot.create(:oidc_user, sub: subject_identifier) }
+
+    it "does not create the user" do
+      expect { described_class.call("dummy-token") }.not_to change(OidcUser, :count)
+    end
+
+    include_examples "imports the attribute"
+    include_examples "imports the email subscription"
+
+    context "when the user already has the attribute" do
+      let!(:local_attribute) { FactoryBot.create(:local_attribute, oidc_user: oidc_user, name: "transition_checker_state", value: "old-value") }
+
+      it "does not import the attribute" do
+        old_value = local_attribute.value
+        expect { described_class.call("dummy-token") }.not_to change(LocalAttribute, :count)
+        expect(local_attribute.reload.value).to eq(old_value)
+      end
+
+      include_examples "imports the email subscription"
+    end
+
+    context "when the user already has the email subscription" do
+      let!(:email_subscription) { FactoryBot.create(:email_subscription, oidc_user: oidc_user, name: "transition-checker-results", topic_slug: "old-slug") }
+
+      it "does not import the email subscription" do
+        old_topic_slug = email_subscription.topic_slug
+        old_subscription_id = email_subscription.email_alert_api_subscription_id
+        expect { described_class.call("dummy-token") }.not_to change(EmailSubscription, :count)
+        expect(email_subscription.reload.topic_slug).to eq(old_topic_slug)
+        expect(email_subscription.reload.email_alert_api_subscription_id).to eq(old_subscription_id)
+      end
+
+      include_examples "imports the attribute"
+    end
+  end
+
+  def stub_page(page, users: [], is_last_page: false)
+    stub_request(:get, "http://account-manager.dev.gov.uk/api/v1/migrate-users-to-account-api?page=#{page}")
+      .to_return(body: { users: users, is_last_page: is_last_page }.to_json, headers: { content_type: "application/json" })
+  end
+end


### PR DESCRIPTION
After being run once we can delete this task and the account-manager
endpoint.

See also https://github.com/alphagov/govuk-account-manager-prototype/pull/893

---

[Trello card](https://trello.com/c/4ulBaTFk/887-bulk-migrate-older-transition-checker-state-from-account-manager-to-account-api)
