### PR TITLE
Mark transition_checker_state attribute as local

### DIFF
--- a/config/user_attributes.yml
+++ b/config/user_attributes.yml
@@ -21,7 +21,7 @@ has_unconfirmed_email:
     get: 0
 
 transition_checker_state:
-  type: cached
+  type: local
   permissions:
     check: 0
     get: 1

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -17,11 +17,8 @@ RSpec.describe "User information endpoint" do
       email: "email@example.com",
       email_verified: true,
       has_unconfirmed_email: false,
-      transition_checker_state: transition_checker_state,
     }
   end
-
-  let(:transition_checker_state) { nil }
 
   let(:response_body) { JSON.parse(response.body) }
 
@@ -55,7 +52,7 @@ RSpec.describe "User information endpoint" do
     end
 
     context "when the user has used the checker" do
-      let(:transition_checker_state) { "state" }
+      before { FactoryBot.create(:local_attribute, oidc_user: session_identifier.user, name: "transition_checker_state", value: "state") }
 
       it "returns 'yes_but_must_reauthenticate'" do
         get "/api/user", headers: headers


### PR DESCRIPTION
We have now migrated this attribute fully into the account-api.

---

[Trello card](https://trello.com/c/4ulBaTFk/887-bulk-migrate-older-transition-checker-state-from-account-manager-to-account-api)
