### PR TITLE
Fetch remote attributes from userinfo, if present there

### DIFF
--- a/spec/lib/account_session_spec.rb
+++ b/spec/lib/account_session_spec.rb
@@ -91,6 +91,7 @@ RSpec.describe AccountSession do
 
     describe "get_attributes" do
       before do
+        stub_userinfo
         stub_request(:get, "http://openid-provider/v1/attributes/#{attribute_name1}")
           .to_return(status: status, body: { claim_value: attribute_value1 }.compact.to_json)
         stub_request(:get, "http://openid-provider/v1/attributes/#{attribute_name2}")
@@ -108,6 +109,18 @@ RSpec.describe AccountSession do
 
         values = account_session.get_attributes([attribute_name1, attribute_name2, local_attribute_name])
         expect(values).to eq({ attribute_name1 => attribute_value1, attribute_name2 => attribute_value2, local_attribute_name => local_attribute_value })
+      end
+
+      context "when the attribute value is in the userinfo response" do
+        before do
+          stub_userinfo(attribute_name1 => value_from_userinfo)
+        end
+
+        let(:value_from_userinfo) { "value-from-userinfo" }
+
+        it "uses the value from the userinfo response" do
+          expect(account_session.get_attributes([attribute_name1])).to eq({ attribute_name1 => value_from_userinfo })
+        end
       end
 
       context "when some attributes are not found" do

--- a/spec/requests/attributes/names_spec.rb
+++ b/spec/requests/attributes/names_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe "Attribute names" do
   before do
     stub_oidc_discovery
+    stub_userinfo
 
     fixture_file = YAML.safe_load(File.read(Rails.root.join("spec/fixtures/user_attributes.yml"))).with_indifferent_access
     allow(UserAttributes).to receive(:load_config_file).and_return(fixture_file)

--- a/spec/requests/attributes_spec.rb
+++ b/spec/requests/attributes_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe "Attributes" do
   before do
     stub_oidc_discovery
+    stub_userinfo
 
     fixture_file = YAML.safe_load(File.read(Rails.root.join("spec/fixtures/user_attributes.yml"))).with_indifferent_access
     allow(UserAttributes).to receive(:load_config_file).and_return(fixture_file)

--- a/spec/requests/email_subscriptions_spec.rb
+++ b/spec/requests/email_subscriptions_spec.rb
@@ -125,16 +125,14 @@ RSpec.describe "Email subscriptions" do
 
     it "fetches the email & email_verified attributes if they aren't cached locally" do
       stub_oidc_discovery
-      stub_email = stub_request(:get, "http://openid-provider/v1/attributes/email").to_return(body: { claim_value: "email@example.com" }.to_json)
-      stub_email_verified = stub_request(:get, "http://openid-provider/v1/attributes/email_verified").to_return(body: { claim_value: false }.to_json)
+      stub = stub_userinfo(email: "email@example.com", email_verified: false)
 
       expect { put email_subscription_path(subscription_name: "name"), params: params.to_json, headers: headers }.to change(EmailSubscription, :count).by(1)
 
       expect(response).to be_successful
       expect(JSON.parse(response.body)["email_subscription"]).to eq(EmailSubscription.last.to_hash)
 
-      expect(stub_email).to have_been_made
-      expect(stub_email_verified).to have_been_made
+      expect(stub).to have_been_made
     end
 
     context "when the user has verified their email address" do

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "User information endpoint" do
 
   before do
     stub_oidc_discovery
+    stub_userinfo
     stub_remote_attribute_requests(attributes)
   end
 

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -77,6 +77,7 @@ Pact.provider_states_for "GDS API Adapters" do
 
     stub_oidc_discovery
     stub_token_response
+    stub_userinfo
 
     account_session = placeholder_govuk_account_session_object(
       user_id: oidc_user.sub,

--- a/spec/support/helpers/oidc_client_helper.rb
+++ b/spec/support/helpers/oidc_client_helper.rb
@@ -31,6 +31,11 @@ module OidcClientHelper
     # rubocop:enable RSpec/AnyInstance
   end
 
+  def stub_userinfo(attributes = {})
+    stub_request(:get, "http://openid-provider/userinfo-endpoint")
+      .to_return(status: 200, body: attributes.to_json)
+  end
+
   def stub_remote_attribute_request(name:, value: nil, status: nil)
     status ||= value.nil? ? 404 : 200
     stub_request(:get, "http://openid-provider/v1/attributes/#{name}")


### PR DESCRIPTION
The userinfo response MUST have at least one attribute, "sub", the
user's "subject identifier", and MAY also have additional attributes.

In contrast, the `get_attribute` endpoint in our attribute-service
prototype only returns one attribute at a time.  So an account-api
request which needs to fetch multiple attributes (like `GET /api/user`)
will make multiple requests, in sequence, to fetch them.
Which is slow.

If we can get even one attribute from the userinfo response (and in
practice we can currently get *all* of them from the userinfo
response), then this change is worthwhile.

---

[Trello card](https://trello.com/c/RYLdsABd/906-fetch-remote-attributes-from-userinfo-if-present-there)
