### PR TITLE
Use strings for attribute names everywhere

### DIFF
--- a/app/controllers/oidc_users_controller.rb
+++ b/app/controllers/oidc_users_controller.rb
@@ -1,5 +1,5 @@
 class OidcUsersController < ApplicationController
-  OIDC_USER_ATTRIBUTES = %i[email email_verified has_unconfirmed_email].freeze
+  OIDC_USER_ATTRIBUTES = %w[email email_verified has_unconfirmed_email].freeze
 
   def update
     user = OidcUser.find_or_create_by!(sub: params.fetch(:subject_identifier))

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -1,7 +1,7 @@
 class UserController < ApplicationController
   include AuthenticatedApiConcern
 
-  HOMEPAGE_ATTRIBUTES = %i[email email_verified has_unconfirmed_email transition_checker_state].freeze
+  HOMEPAGE_ATTRIBUTES = %w[email email_verified has_unconfirmed_email transition_checker_state].freeze
 
   def show
     has_unconfirmed_email = attributes.dig(:has_unconfirmed_email, :value)
@@ -11,11 +11,11 @@ class UserController < ApplicationController
       {
         id: @govuk_account_session.user.id.to_s,
         level_of_authentication: @govuk_account_session.level_of_authentication,
-        email: attributes.dig(:email, :value),
-        email_verified: attributes.dig(:email_verified, :value),
+        email: attributes.dig("email", :value),
+        email_verified: attributes.dig("email_verified", :value),
         has_unconfirmed_email: has_unconfirmed_email,
         services: {
-          transition_checker: attribute_service(:transition_checker_state),
+          transition_checker: attribute_service("transition_checker_state"),
           saved_pages: saved_pages_service,
         }.compact,
       },
@@ -39,7 +39,7 @@ private
   def attributes
     @attributes ||=
       begin
-        attribute_values = @govuk_account_session.get_attributes(HOMEPAGE_ATTRIBUTES.select { |name| has_permission_for name, :check }).symbolize_keys
+        attribute_values = @govuk_account_session.get_attributes(HOMEPAGE_ATTRIBUTES.select { |name| has_permission_for name, :check })
 
         HOMEPAGE_ATTRIBUTES.index_with do |name|
           if attribute_values.key? name

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe "User information endpoint" do
 
   before do
     stub_oidc_discovery
-    stub_userinfo
-    stub_remote_attribute_requests(attributes)
+    stub_userinfo(attributes)
   end
 
   let(:session_identifier) { placeholder_govuk_account_session_object(level_of_authentication: level_of_authentication) }


### PR DESCRIPTION
A JSON response gets parsed to a hash with string keys, not symbols.
So if we use symbols for attribute names, they don't match the
userinfo hash.

I considered making the userinfo a HashWithIndifferentAccess, but that
would encourage mixing strings and symbols for attribute names
throughout the code, which could be confusing.  So instead, use
strings for attribute names everywhere.

This change will make the optimisation in 26c945a apply to the
/account/home page.

---

[Trello card](https://trello.com/c/RYLdsABd/906-fetch-remote-attributes-from-userinfo-if-present-there)
