### PR TITLE
Fix migrations:transition_checker task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "gds-api-adapters"
 gem "gds-sso"
 gem "govuk_app_config"
 gem "govuk_message_queue_consumer"
+gem "httparty"
 gem "openid_connect"
 gem "pg"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -469,6 +469,7 @@ DEPENDENCIES
   govuk_message_queue_consumer
   govuk_schemas
   govuk_test
+  httparty
   listen
   openid_connect
   pact

--- a/lib/tasks/migrations.rake
+++ b/lib/tasks/migrations.rake
@@ -1,6 +1,6 @@
 namespace :migrations do
   desc "Migrate Transition Checker state & email subscriptions from the Account Manager"
-  task :transition_checker, %i[token] => [:environment] do
+  task :transition_checker, %i[token] => [:environment] do |_, args|
     token = args.token
     Migrations::TransitionChecker.call(token)
   end


### PR DESCRIPTION
`httparty` wasn't in the Gemfile (but it was in the Gemfile.lock) but,
confusingly, it worked in the tests despite `bundle exec rake` giving
an uninitialized constant error when I tried to run it in staging.

Also add the missing `args` parameter to the task.

---

[Trello card](https://trello.com/c/4ulBaTFk/887-bulk-migrate-older-transition-checker-state-from-account-manager-to-account-api)
