### PR TITLE
Move attribute definitions to OpenStruct / ActiveRecord

### DIFF
--- a/app/lib/user_attributes.rb
+++ b/app/lib/user_attributes.rb
@@ -1,14 +1,17 @@
 class UserAttributes
-  CONFIG_KEYS = %w[type writable permissions].freeze
-  PERMISSION_KEYS = %w[check get set].freeze
-
   attr_reader :attributes
+
+  class UnknownPermission < StandardError; end
 
   def initialize(attributes = nil)
     @attributes = (attributes || UserAttributes.load_config_file).transform_values do |config|
-      config ||= {}
-      config["writable"] = true unless config.key? "writable"
-      config
+      AttributeDefinition.new(
+        type: config["type"],
+        writable: config.fetch("writable", true),
+        level_of_auth_check: config.dig("permissions", "check") || 0,
+        level_of_auth_get: config.dig("permissions", "get") || 0,
+        level_of_auth_set: config.dig("permissions", "set") || 0,
+      )
     end
   end
 
@@ -29,48 +32,15 @@ class UserAttributes
   end
 
   def level_of_authentication_for(name, permission_level)
-    attributes.fetch(name)[:permissions].fetch(permission_level)
-  end
-
-  def self.validate(attributes)
-    new(attributes).errors
-  end
-
-  def errors
-    attributes.each_with_object({}) do |(name, config), errors|
-      missing_keys = CONFIG_KEYS - config.keys
-      unknown_keys = config.keys - CONFIG_KEYS
-      invalid_keys = []
-
-      invalid_keys << "type" if config["type"] && !config["type"].in?(%w[local remote cached])
-
-      permissions = config["permissions"]
-      if permissions
-        permissions_keys = config["writable"] ? PERMISSION_KEYS : PERMISSION_KEYS - %w[set]
-
-        missing_keys.concat((permissions_keys - permissions.keys).map { |key| "permissions.#{key}" })
-        unknown_keys.concat((permissions.keys - permissions_keys).map { |key| "permissions.#{key}" })
-
-        non_integer_values = permissions.keys.reject { |key| permissions[key].is_a? Integer }.map { |key| "permissions.#{key}" }
-        if non_integer_values.any?
-          invalid_keys.concat non_integer_values
-        else
-          if permissions["check"] && permissions["get"] && permissions["check"] > permissions["get"]
-            invalid_keys << "permissions.check"
-          end
-          if permissions["get"] && permissions["set"] && permissions["get"] > permissions["set"]
-            invalid_keys << "permissions.get"
-          end
-        end
-      end
-
-      this_errors = {
-        missing_keys: missing_keys.any? ? missing_keys : nil,
-        unknown_keys: unknown_keys.any? ? unknown_keys : nil,
-        invalid_keys: invalid_keys.any? ? invalid_keys : nil,
-      }.compact
-
-      errors[name] = this_errors if this_errors.any?
+    case permission_level
+    when :check
+      attributes.fetch(name).level_of_auth_check
+    when :get
+      attributes.fetch(name).level_of_auth_get
+    when :set
+      attributes.fetch(name).level_of_auth_set
+    else
+      raise UnknownPermission, permission_level
     end
   end
 

--- a/app/models/attribute_definition.rb
+++ b/app/models/attribute_definition.rb
@@ -1,0 +1,22 @@
+class AttributeDefinition < OpenStruct
+  include ActiveModel::Validations
+
+  validates :type, :level_of_auth_check, :level_of_auth_get, :level_of_auth_set, presence: true
+  validates :type, inclusion: %w[local remote cached]
+  validates :writable, exclusion: [nil]
+  validate :auth_ordering
+
+  def initialize(type:, writable: true, level_of_auth_check: 0, level_of_auth_get: 0, level_of_auth_set: 0)
+    super
+  end
+
+  def auth_ordering
+    if level_of_auth_get && level_of_auth_check && level_of_auth_get < level_of_auth_check
+      errors.add(:level_of_auth_check, "must be <= :level_of_auth_get")
+    end
+
+    if writable && level_of_auth_get && level_of_auth_set && level_of_auth_set < level_of_auth_get
+      errors.add(:level_of_auth_get, "must be <= :level_of_auth_set")
+    end
+  end
+end

--- a/spec/lib/user_attributes_spec.rb
+++ b/spec/lib/user_attributes_spec.rb
@@ -1,95 +1,17 @@
 RSpec.describe UserAttributes do
-  it "validates the config file" do
-    expect(described_class.new.errors).to be_empty
+  subject(:user_attributes) { described_class.new }
+
+  describe "attribute definitions" do
+    described_class.new.attributes.each do |name, attribute|
+      it "#{name} is valid" do
+        expect(attribute.valid?).to be(true)
+      end
+    end
   end
 
-  describe "validation" do
-    let(:attributes) { { "foo" => foo_properties, "bar" => bar_properties } }
-    let(:foo_properties) { { "type" => "local", "permissions" => foo_permissions } }
-    let(:foo_permissions) { { "check" => 0, "get" => 0, "set" => 1 } }
-    let(:bar_properties) { { "type" => "remote", "permissions" => bar_permissions } }
-    let(:bar_permissions) { { "check" => 1, "get" => 1, "set" => 1 } }
-
-    let(:errors) { described_class.validate(attributes) }
-
-    it "accepts valid configuration" do
-      expect(errors).to eq({})
-    end
-
-    describe "errors with top-level keys" do
-      context "when a key is missing" do
-        let(:foo_properties) { {} }
-
-        it "rejects" do
-          expect(errors).to eq({ "foo" => { missing_keys: %w[type permissions] } })
-        end
-      end
-
-      context "when an unexpected top-level key is present" do
-        let(:bar_properties) { { "tye" => "local", "permissions" => bar_permissions } }
-
-        it "rejects" do
-          expect(errors).to eq({ "bar" => { missing_keys: %w[type], unknown_keys: %w[tye] } })
-        end
-      end
-
-      context "when a key has an unexpected value" do
-        let(:foo_properties) { { "type" => "banana", "permissions" => foo_permissions } }
-
-        it "rejects" do
-          expect(errors).to eq({ "foo" => { invalid_keys: %w[type] } })
-        end
-      end
-    end
-
-    describe "errors with permission keys" do
-      context "when a key is missing" do
-        let(:foo_permissions) { { "get" => 1 } }
-
-        it "rejects" do
-          expect(errors).to eq({ "foo" => { missing_keys: %w[permissions.check permissions.set] } })
-        end
-      end
-
-      context "when an unexpected key is present" do
-        let(:foo_permissions) { { "check" => 1, "get" => 1, "sett" => 1 } }
-
-        it "rejects" do
-          expect(errors).to eq({ "foo" => { missing_keys: %w[permissions.set], unknown_keys: %w[permissions.sett] } })
-        end
-      end
-
-      context "when a key has an non-integral value" do
-        let(:foo_permissions) { { "check" => "apple", "get" => 1, "set" => 1 } }
-
-        it "rejects" do
-          expect(errors).to eq({ "foo" => { invalid_keys: %w[permissions.check] } })
-        end
-      end
-
-      context "when the attribute is not writable, but there is a set permission" do
-        let(:foo_properties) { { "type" => "local", "writable" => false, "permissions" => foo_permissions } }
-
-        it "rejects" do
-          expect(errors).to eq({ "foo" => { unknown_keys: %w[permissions.set] } })
-        end
-      end
-
-      context "when check requires a higher permission than get" do
-        let(:foo_permissions) { { "check" => 1, "get" => 0, "set" => 0 } }
-
-        it "rejects" do
-          expect(errors).to eq({ "foo" => { invalid_keys: %w[permissions.check] } })
-        end
-      end
-
-      context "when get requires a higher permission than set" do
-        let(:foo_permissions) { { "check" => 0, "get" => 1, "set" => 0 } }
-
-        it "rejects" do
-          expect(errors).to eq({ "foo" => { invalid_keys: %w[permissions.get] } })
-        end
-      end
+  describe "#level_of_authentication_for" do
+    it "raises an error for an unknown permission level" do
+      expect { user_attributes.level_of_authentication_for("attribute", :wizardry) }.to raise_error(UserAttributes::UnknownPermission)
     end
   end
 end

--- a/spec/models/attribute_definition_spec.rb
+++ b/spec/models/attribute_definition_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe AttributeDefinition do
+  subject(:attribute) { described_class.new(type: :local) }
+
+  it { is_expected.to validate_presence_of(:type) }
+  it { is_expected.to validate_presence_of(:level_of_auth_check) }
+  it { is_expected.to validate_presence_of(:level_of_auth_get) }
+  it { is_expected.to validate_presence_of(:level_of_auth_set) }
+
+  it { is_expected.to validate_inclusion_of(:type).in_array(%w[local remote cached]) }
+  it { is_expected.to validate_exclusion_of(:writable).in_array([nil]) }
+
+  it "validates that :level_of_auth_check <= :level_of_auth_get" do
+    attribute = described_class.new(type: :local, level_of_auth_check: 9, level_of_auth_get: 0, level_of_auth_set: 0)
+    attribute.valid?
+    expect(attribute.errors[:level_of_auth_check]).not_to be_empty
+  end
+
+  it "validates that :level_of_auth_get <= :level_of_auth_set" do
+    attribute = described_class.new(type: :local, level_of_auth_check: 0, level_of_auth_get: 9, level_of_auth_set: 0)
+    attribute.valid?
+    expect(attribute.errors[:level_of_auth_get]).not_to be_empty
+  end
+
+  context "when the attribute is not writable" do
+    it "does not validate that :level_of_auth_get <= :level_of_auth_set" do
+      attribute = described_class.new(type: :local, level_of_auth_check: 0, level_of_auth_get: 9, level_of_auth_set: 0, writable: false)
+      attribute.valid?
+      expect(attribute.errors[:level_of_auth_get]).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
In the UserAttributes class there's a bunch of validation logic to
make sure that the config file is correct, and then in the specs
there's a bunch of test logic to make sure that the validation logic
works, and THEN we get to the real spec: a short one which validates
the config file.

There's already a way to define validations and test them:
ActiveRecord and shoulda-matchers.  And this sort of code is much more
familiar, so it's easier to read at a glance.

So, switch to using an OpenStruct including ActiveRecord::Validations
for attribute definitions, write some (short!) specs around the
validations, just to make sure nobody in the future accidentally
removes one, and then remove all the hand-written validation logic
from UserAttributes.