### PR TITLE
Move the deletion of expired AuthRequests to a sidekiq worker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,9 +13,11 @@ gem "gds-api-adapters"
 gem "gds-sso"
 gem "govuk_app_config"
 gem "govuk_message_queue_consumer"
+gem "govuk_sidekiq"
 gem "httparty"
 gem "openid_connect"
 gem "pg"
+gem "sidekiq-scheduler"
 
 group :development, :test do
   gem "awesome_print"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
     childprocess (3.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
+    connection_pool (2.2.5)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -102,7 +103,10 @@ GEM
     docile (1.3.5)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    e2mmap (0.1.0)
     erubi (1.10.0)
+    et-orbi (1.2.4)
+      tzinfo
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -124,6 +128,9 @@ GEM
     ffi (1.15.0)
     filelock (1.1.1)
     find_a_port (1.0.1)
+    fugit (1.5.0)
+      et-orbi (~> 1.1, >= 1.1.8)
+      raabro (~> 1.4)
     gds-api-adapters (71.9.0)
       addressable
       link_header
@@ -150,6 +157,13 @@ GEM
       bunny (~> 2.11)
     govuk_schemas (4.3.0)
       json-schema (~> 2.8.0)
+    govuk_sidekiq (5.0.0)
+      gds-api-adapters (>= 19.1.0)
+      govuk_app_config (>= 1.1)
+      redis-namespace (~> 1.6)
+      sidekiq (>= 5, < 6)
+      sidekiq-logging-json (~> 0.0)
+      sidekiq-statsd (>= 2.1)
     govuk_test (2.3.0)
       brakeman (>= 5.0.2)
       capybara
@@ -278,6 +292,7 @@ GEM
     public_suffix (4.0.6)
     puma (5.3.2)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.5.2)
     rack (2.2.3)
     rack-oauth2 (1.16.0)
@@ -323,6 +338,9 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redis (4.1.4)
+    redis-namespace (1.8.1)
+      redis (>= 3.0.4)
     regexp_parser (2.1.1)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -382,6 +400,8 @@ GEM
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.4)
     rubyzip (2.3.0)
+    rufus-scheduler (3.8.0)
+      fugit (~> 1.1, >= 1.1.6)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -389,6 +409,23 @@ GEM
       faraday (>= 1.0)
     shoulda-matchers (5.0.0)
       activesupport (>= 5.2.0)
+    sidekiq (5.2.9)
+      connection_pool (~> 2.2, >= 2.2.2)
+      rack (~> 2.0)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 4.2)
+    sidekiq-logging-json (0.0.19)
+      sidekiq (>= 3)
+    sidekiq-scheduler (3.1.0)
+      e2mmap
+      redis (>= 3, < 5)
+      rufus-scheduler (~> 3.2)
+      sidekiq (>= 3)
+      thwait
+      tilt (>= 1.4.0)
+    sidekiq-statsd (2.1.0)
+      activesupport
+      sidekiq (>= 3.3.1)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -412,6 +449,9 @@ GEM
     term-ansicolor (1.7.1)
       tins (~> 1.0)
     thor (1.1.0)
+    thwait (0.2.0)
+      e2mmap
+    tilt (2.0.10)
     tins (1.29.1)
       sync
     tzinfo (2.0.4)
@@ -468,6 +508,7 @@ DEPENDENCIES
   govuk_app_config
   govuk_message_queue_consumer
   govuk_schemas
+  govuk_sidekiq
   govuk_test
   httparty
   listen
@@ -481,6 +522,7 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   shoulda-matchers
+  sidekiq-scheduler
   simplecov
   webmock
 

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bundle exec unicorn -c ./config/unicorn.rb -p ${PORT:-3000}
+worker: bundle exec sidekiq -C ./config/sidekiq.yml
 publishing-queue-listener: bundle exec rake message_queue:consumer

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -1,7 +1,5 @@
 class AuthenticationController < ApplicationController
   def sign_in
-    AuthRequest.expired.delete_all
-
     auth_request = AuthRequest.generate!(redirect_path: params[:redirect_path])
 
     render json: {

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,7 +1,0 @@
-class ApplicationJob < ActiveJob::Base
-  # Automatically retry jobs that encountered a deadlock
-  # retry_on ActiveRecord::Deadlocked
-
-  # Most jobs are safe to ignore if the underlying records are no longer available
-  # discard_on ActiveJob::DeserializationError
-end

--- a/app/workers/application_worker.rb
+++ b/app/workers/application_worker.rb
@@ -1,0 +1,3 @@
+class ApplicationWorker
+  include Sidekiq::Worker
+end

--- a/app/workers/expired_auth_request_worker.rb
+++ b/app/workers/expired_auth_request_worker.rb
@@ -1,0 +1,5 @@
+class ExpiredAuthRequestWorker < ApplicationWorker
+  def perform
+    AuthRequest.expired.delete_all
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -3,7 +3,7 @@ require_relative "boot"
 require "rails"
 # Pick the frameworks you want:
 require "active_model/railtie"
-require "active_job/railtie"
+# require "active_job/railtie"
 require "active_record/railtie"
 # require "active_storage/engine"
 require "action_controller/railtie"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
     GovukHealthcheck::ActiveRecord,
     GovukHealthcheck::RailsCache,
+    GovukHealthcheck::SidekiqRedis,
   )
 
   scope :api do

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,3 +3,8 @@
 
 :queues:
   - default
+
+:schedule:
+  expired_auth_request_worker:
+    every: '1h'
+    class: ExpiredAuthRequestWorker

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,5 @@
+---
+:logfile: ./log/sidekiq.json.log
+
+:queues:
+  - default

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -25,12 +25,6 @@ RSpec.describe "Authentication" do
       get sign_in_path, params: { redirect_path: "/transition-check/results?c[]=import-wombats&c[]=practice-wizardry" }
       expect(AuthRequest.last.redirect_path).to eq("/transition-check/results?c[]=import-wombats&c[]=practice-wizardry")
     end
-
-    it "deletes old expired AuthRequests" do
-      auth_request_id = AuthRequest.create!(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "/some-path", created_at: 1.day.ago).id
-      get sign_in_path
-      expect(AuthRequest.exists?(auth_request_id)).to be(false)
-    end
   end
 
   describe "/callback" do

--- a/spec/workers/expired_auth_request_worker_spec.rb
+++ b/spec/workers/expired_auth_request_worker_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe ExpiredAuthRequestWorker do
+  include ActiveSupport::Testing::TimeHelpers
+
+  before { freeze_time }
+
+  it "deletes old state" do
+    AuthRequest.create!(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "/some-path", created_at: (AuthRequest::EXPIRATION_AGE + 1.second).ago)
+    expect { described_class.new.perform }.to change(AuthRequest, :count).to(0)
+  end
+
+  it "doesn't delete recent state" do
+    AuthRequest.create!(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "/some-path", created_at: AuthRequest::EXPIRATION_AGE.ago)
+    expect { described_class.new.perform }.not_to change(AuthRequest, :count)
+  end
+end


### PR DESCRIPTION
The app is doing a lot of garbage collection, and specifically it
looks like it's allocating a lot of ActiveRecord transaction objects.

I suspect that that's caused by this in the `sign_in` controller:

    AuthRequest.expired.delete_all

Deleting expired objects on every request was implemented as an easy
"is this really worth setting up sidekiq for?" approach but, if it's
causing excessive allocation, and so excessive garbage collection,
it *is* worth setting up sidekiq to handle.

ActiveJob was already present in the app but I've removed it
completely (rather than configure it to use sidekiq as a queuing
system) because on GOV.UK we're more experienced with using sidekiq
directly.

See also https://github.com/alphagov/govuk-puppet/pull/11200

---

[Trello card](https://trello.com/c/uRW8OS61/907-move-expired-authrequest-deletion-to-sidekiq)