### PR TITLE
Merge the `LocalAttribute`s into the `OidcUser` model

### DIFF
--- a/db/migrate/20210715153551_add_local_attribute_fields_to_oidc_user.rb
+++ b/db/migrate/20210715153551_add_local_attribute_fields_to_oidc_user.rb
@@ -1,0 +1,13 @@
+class AddLocalAttributeFieldsToOidcUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :local_attributes, :migrated, :boolean, default: false, null: false
+
+    change_table :oidc_users, bulk: true do |t|
+      t.string  :email
+      t.boolean :email_verified
+      t.boolean :has_unconfirmed_email
+      t.boolean :oidc_users
+      t.jsonb   :transition_checker_state
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define(version: 2021_07_30_133729) do
     t.jsonb "value", null: false
     t.datetime "created_at", precision: 6, default: -> { "now()" }, null: false
     t.datetime "updated_at", precision: 6, default: -> { "now()" }, null: false
+    t.boolean "migrated", default: false, null: false
     t.index ["oidc_user_id", "name"], name: "index_local_attributes_on_oidc_user_id_and_name", unique: true
     t.index ["oidc_user_id"], name: "index_local_attributes_on_oidc_user_id"
   end
@@ -49,6 +50,11 @@ ActiveRecord::Schema.define(version: 2021_07_30_133729) do
     t.datetime "created_at", precision: 6, default: -> { "now()" }, null: false
     t.datetime "updated_at", precision: 6, default: -> { "now()" }, null: false
     t.boolean "has_received_transition_checker_onboarding_email", default: false, null: false
+    t.string "email"
+    t.boolean "email_verified"
+    t.boolean "has_unconfirmed_email"
+    t.boolean "oidc_users"
+    t.jsonb "transition_checker_state"
     t.index ["sub"], name: "index_oidc_users_on_sub", unique: true
   end
 

--- a/spec/fixtures/user_attributes.yml
+++ b/spec/fixtures/user_attributes.yml
@@ -1,3 +1,11 @@
+# overwrite this to be writable
+has_unverified_email:
+  type: cached
+  permissions:
+    check: 0
+    get: 0
+    set: 0
+
 test_attribute_1:
   type: remote
   permissions:
@@ -11,27 +19,6 @@ test_attribute_2:
     check: 0
     get: 0
     set: 0
-
-test_attribute_cache:
-  type: cached
-  permissions:
-    check: 0
-    get: 0
-    set: 0
-
-test_local_attribute:
-  type: local
-  permissions:
-    check: 0
-    get: 0
-    set: 0
-
-test_unwritable_attribute:
-  type: local
-  writable: false
-  permissions:
-    check: 0
-    get: 0
 
 foo:
   type: remote

--- a/spec/requests/attributes/names_spec.rb
+++ b/spec/requests/attributes/names_spec.rb
@@ -3,8 +3,9 @@ RSpec.describe "Attribute names" do
     stub_oidc_discovery
     stub_userinfo
 
+    normal_file = YAML.safe_load(File.read(Rails.root.join("config/user_attributes.yml"))).with_indifferent_access
     fixture_file = YAML.safe_load(File.read(Rails.root.join("spec/fixtures/user_attributes.yml"))).with_indifferent_access
-    allow(UserAttributes).to receive(:load_config_file).and_return(fixture_file)
+    allow(UserAttributes).to receive(:load_config_file).and_return(normal_file.merge(fixture_file))
   end
 
   let(:session_identifier) { placeholder_govuk_account_session }
@@ -13,7 +14,7 @@ RSpec.describe "Attribute names" do
   # names must be defined in spec/fixtures/user_attributes.yml
   let(:attribute_name1) { "test_attribute_1" }
   let(:attribute_name2) { "test_attribute_2" }
-  let(:local_attribute_name) { "test_local_attribute" }
+  let(:local_attribute_name) { "transition_checker_state" }
   let(:unknown_attribute_name1) { "this_does_not_exist1" }
   let(:unknown_attribute_name2) { "this_does_not_exist2" }
 

--- a/spec/requests/oidc_users_spec.rb
+++ b/spec/requests/oidc_users_spec.rb
@@ -45,8 +45,11 @@ RSpec.describe "OIDC Users endpoint" do
         user.set_local_attributes(email: "old-email@example.com", email_verified: false)
 
         put oidc_user_path(subject_identifier: subject_identifier), params: params, headers: headers
+        expect(JSON.parse(response.body)["email"]).to eq(email)
+        expect(JSON.parse(response.body)["email_verified"]).to eq(email_verified)
+        expect(JSON.parse(response.body)["has_unconfirmed_email"]).to eq(has_unconfirmed_email)
 
-        expect(user.get_local_attributes(%i[email email_verified has_unconfirmed_email])).to eq({ "email" => email, "email_verified" => email_verified, "has_unconfirmed_email" => has_unconfirmed_email })
+        expect(user.reload.get_local_attributes(%w[email email_verified has_unconfirmed_email])).to eq({ "email" => email, "email_verified" => email_verified, "has_unconfirmed_email" => has_unconfirmed_email })
       end
 
       context "when the user has linked their notifications account" do


### PR DESCRIPTION
Having a separate table with named attributes works well when we don't
know what attributes we're going to have, as in principle it means a
client can all our API with any attribute names and we'd store or
return them appropriately.  But then we undermined that by defining
them all in a config file anyway.

Given that we're not really making use of the flexibility of the
current model, why not go all the way and merge it into a single
database table?  This will reduce database queries and lessen memory
allocation.

This commit will gradually migrate attributes into the `OidcUser`
model as they get updated.  We can do this in a big-bang style by
running this in a rails console:

    OidcUser.find_each(&:set_local_attributes)

Then, when all the `LocalAttribute`s are gone, we can:

1. Deploy a PR which removes all reference to `LocalAttribute`
2. Then deploy a PR which drops the database table

In the end, `get` and `set_local_attributes` will be:

    def get_local_attributes(names = [])
      names.index_with { |name| self[name] }.compact
    end

    def set_local_attributes(values)
      update!(values)
    end

...or maybe we'll even drop those methods entirely.
