### PR TITLE
Downgrade to sidekiq-scheduler 3.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,9 @@ gem "govuk_sidekiq"
 gem "httparty"
 gem "openid_connect"
 gem "pg"
-gem "sidekiq-scheduler"
+
+# https://github.com/moove-it/sidekiq-scheduler/issues/345
+gem "sidekiq-scheduler", "3.0.1"
 
 group :development, :test do
   gem "awesome_print"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -416,7 +416,7 @@ GEM
       redis (>= 3.3.5, < 4.2)
     sidekiq-logging-json (0.0.19)
       sidekiq (>= 3)
-    sidekiq-scheduler (3.1.0)
+    sidekiq-scheduler (3.0.1)
       e2mmap
       redis (>= 3, < 5)
       rufus-scheduler (~> 3.2)
@@ -522,7 +522,7 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   shoulda-matchers
-  sidekiq-scheduler
+  sidekiq-scheduler (= 3.0.1)
   simplecov
   webmock
 


### PR DESCRIPTION
In 3.1.0 it tries to use `exists?` instead of `exists`, but `exists?`
does not exist:

https://github.com/moove-it/sidekiq-scheduler/issues/345

---

[Trello card](https://trello.com/c/uRW8OS61/907-move-expired-authrequest-deletion-to-sidekiq)