### PR TITLE
Delete users

### DIFF
--- a/app/controllers/oidc_users_controller.rb
+++ b/app/controllers/oidc_users_controller.rb
@@ -42,6 +42,14 @@ class OidcUsersController < ApplicationController
     render json: attributes.merge(sub: user.sub)
   end
 
+  def destroy
+    user = OidcUser.find_by!(sub: params.fetch(:subject_identifier))
+    user.destroy!
+    head :no_content and return
+  rescue ActiveRecord::RecordNotFound
+    head :not_found and return
+  end
+
 private
 
   def authorise_sso_user!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
 
     get "/user", to: "user#show"
 
-    resources :oidc_users, only: %i[update], param: :subject_identifier, path: "oidc-users"
+    resources :oidc_users, only: %i[update destroy], param: :subject_identifier, path: "oidc-users"
 
     get "/attributes", to: "attributes#show"
     patch "/attributes", to: "attributes#update"

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,6 +12,7 @@ management. This API is not for other government services.
   - [`GET /api/oauth2/sign-in`](#get-apioauth2sign-in)
   - [`POST /api/oauth2/callback`](#post-apioauth2callback)
   - [`GET /api/user`](#get-apiuser)
+  - [`DELETE /api/user`](#delete-apiuser)
   - [`GET /api/attributes`](#get-apiattributes)
   - [`PATCH /api/attributes`](#patch-apiattributes)
   - [`GET /api/attributes/names`](#get-apiattributesnames)
@@ -224,6 +225,33 @@ Response:
     }
 }
 ```
+
+### `DELETE /api/user`
+
+Removes a user's account.
+
+#### Request headers
+
+- `GOVUK-Account-Session`
+  - the user's session identifier
+
+#### Response codes
+
+- 401 if the session identifier is invalid
+- 404 if the user cannot be found
+- 204 otherwise
+
+#### Example request / response
+
+Request (with gds-api-adapters):
+
+```ruby
+GdsApi.account_api.delete_user(
+    govuk_account_session: "session-identifier",
+)
+```
+
+Response is status code only.
 
 ### `GET /api/attributes`
 

--- a/spec/requests/oidc_users_spec.rb
+++ b/spec/requests/oidc_users_spec.rb
@@ -100,7 +100,9 @@ RSpec.describe "OIDC Users endpoint" do
 
     context "when a user does not exist" do
       it "does not change the count of users and returns not found" do
-        expect { delete oidc_user_path(subject_identifier: subject_identifier), params: params, headers: headers }.not_to change(OidcUser, :count)
+        without_detailed_exceptions do
+          expect { delete oidc_user_path(subject_identifier: subject_identifier), params: params, headers: headers }.not_to change(OidcUser, :count)
+        end
         expect(response).to be_not_found
       end
     end

--- a/spec/requests/oidc_users_spec.rb
+++ b/spec/requests/oidc_users_spec.rb
@@ -87,4 +87,22 @@ RSpec.describe "OIDC Users endpoint" do
       end
     end
   end
+
+  describe "DELETE" do
+    context "when the user exists" do
+      before { OidcUser.create!(sub: subject_identifier) }
+
+      it "deletes the user" do
+        expect { delete oidc_user_path(subject_identifier: subject_identifier), params: params, headers: headers }.to change(OidcUser, :count).by(-1)
+        expect(response).to be_no_content
+      end
+    end
+
+    context "when a user does not exist" do
+      it "does not change the count of users and returns not found" do
+        expect { delete oidc_user_path(subject_identifier: subject_identifier), params: params, headers: headers }.not_to change(OidcUser, :count)
+        expect(response).to be_not_found
+      end
+    end
+  end
 end

--- a/spec/support/without_detailed_exceptions.rb
+++ b/spec/support/without_detailed_exceptions.rb
@@ -1,0 +1,17 @@
+module WithoutDetailedExceptions
+  RSpec.configure do |config|
+    config.include self, type: :request
+  end
+
+  def without_detailed_exceptions
+    env_config = Rails.application.env_config
+    original_show_exceptions = env_config["action_dispatch.show_exceptions"]
+    original_show_detailed_exceptions = env_config["action_dispatch.show_detailed_exceptions"]
+    env_config["action_dispatch.show_exceptions"] = true
+    env_config["action_dispatch.show_detailed_exceptions"] = false
+    yield
+  ensure
+    env_config["action_dispatch.show_exceptions"] = original_show_exceptions
+    env_config["action_dispatch.show_detailed_exceptions"] = original_show_detailed_exceptions
+  end
+end


### PR DESCRIPTION
A part of: [Trello](https://trello.com/c/b95YV8qC/912-%E2%9D%97-delete-users-in-account-api-when-theyre-deleted-in-account-manager)

We are currently migrating features from our PaaS based
[account-manager-prototype](https://github.com/alphagov/govuk-account-manager-prototype)
to account-api.

Accounts API now acts as an additional store of user data. When a user
deletes their account through the account manager we require an
authenticated endpoint that will forward the request to account-api so
we can remove their data there too.