### PR TITLE
Fix docs for `/api/oidc-users/:subject_identifier` endpoint

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -18,6 +18,7 @@ management. This API is not for other government services.
   - [`GET /api/email-subscriptions/:subscription_name`](#get-apiemail-subscriptionssubscription_name)
   - [`PUT /api/email-subscriptions/:subscription_name`](#put-apiemail-subscriptionssubscription_name)
   - [`DELETE /api/email-subscriptions/:subscription_name`](#delete-apiemail-subscriptionssubscription_name)
+  - [`PUT /api/oidc-users/:subject_identifier`](#put-apioidc-userssubject_identifier)
   - [`DELETE /api/oidc-users/:subject_identifier`](#delete-apioidc-userssubject_identifier)
   - [`GET /api/saved-pages`](#get-apisaved-pages)
   - [`GET /api/saved-pages/:page_path`](#get-apisaved-pagespage_path)
@@ -507,6 +508,61 @@ GdsApi.account_api.delete_email_subscription(
 ```
 
 Response is status code only.
+
+### `PUT /api/oidc-users/:subject_identifier`
+
+Update an account and its email subscriptions by subject identifier.
+This endpoint requires the `update_protected_attributes` scope.
+
+#### Request parameters
+
+- `subject_identifier`
+  - the subject identifier of the user to delete
+
+#### JSON request parameters
+
+- `email`
+  - the new email address (a string)
+- `email_verified`
+  - whether the new email address is verified (a boolean)
+- `has_unconfirmed_email`
+  - whether the user has a pending email change to confirm (a boolean)
+
+#### JSON response fields
+
+- `sub`
+  - the subject identifier
+- `email`
+- `email_verified`
+- `has_unconfirmed_email`
+
+#### Response codes
+
+- 200
+
+#### Example request / response
+
+Request (with gds-api-adapters):
+
+```ruby
+GdsApi.account_api.update_user_by_subject_identifier(
+    subject_identifier: "subject-identifier",
+    email: "user@example.com",
+    email_verified: true,
+    has_unconfirmed_email: false,
+)
+```
+
+Response:
+
+```json
+{
+    "sub": "subject-identifier",
+    "email": "user@example.com",
+    "email_verified": true,
+    "has_unconfirmed_email": false
+}
+```
 
 ### `DELETE /api/oidc-users/:subject_identifier`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,13 +12,13 @@ management. This API is not for other government services.
   - [`GET /api/oauth2/sign-in`](#get-apioauth2sign-in)
   - [`POST /api/oauth2/callback`](#post-apioauth2callback)
   - [`GET /api/user`](#get-apiuser)
-  - [`DELETE /api/user`](#delete-apiuser)
   - [`GET /api/attributes`](#get-apiattributes)
   - [`PATCH /api/attributes`](#patch-apiattributes)
   - [`GET /api/attributes/names`](#get-apiattributesnames)
   - [`GET /api/email-subscriptions/:subscription_name`](#get-apiemail-subscriptionssubscription_name)
   - [`PUT /api/email-subscriptions/:subscription_name`](#put-apiemail-subscriptionssubscription_name)
   - [`DELETE /api/email-subscriptions/:subscription_name`](#delete-apiemail-subscriptionssubscription_name)
+  - [`DELETE /api/oidc-users/:subject_identifier`](#delete-apioidc-userssubject_identifier)
   - [`GET /api/saved-pages`](#get-apisaved-pages)
   - [`GET /api/saved-pages/:page_path`](#get-apisaved-pagespage_path)
   - [`PUT /api/saved-pages/:page_path`](#put-apisaved-pagespage_path)
@@ -225,33 +225,6 @@ Response:
     }
 }
 ```
-
-### `DELETE /api/user`
-
-Removes a user's account.
-
-#### Request headers
-
-- `GOVUK-Account-Session`
-  - the user's session identifier
-
-#### Response codes
-
-- 401 if the session identifier is invalid
-- 404 if the user cannot be found
-- 204 otherwise
-
-#### Example request / response
-
-Request (with gds-api-adapters):
-
-```ruby
-GdsApi.account_api.delete_user(
-    govuk_account_session: "session-identifier",
-)
-```
-
-Response is status code only.
 
 ### `GET /api/attributes`
 
@@ -530,6 +503,33 @@ Request (with gds-api-adapters):
 GdsApi.account_api.delete_email_subscription(
     name: "transition-checker",
     govuk_account_session: "session-identifier",
+)
+```
+
+Response is status code only.
+
+### `DELETE /api/oidc-users/:subject_identifier`
+
+Delete an account by subject identifier.  This endpoint requires the
+`update_protected_attributes` scope.
+
+#### Request parameters
+
+- `subject_identifier`
+  - the subject identifier of the user to delete
+
+#### Response codes
+
+- 404 if the user cannot be found
+- 204 otherwise
+
+#### Example request / response
+
+Request (with gds-api-adapters):
+
+```ruby
+GdsApi.account_api.delete_user_by_subject_identifier(
+    subject_identifier: "subject-identifier",
 )
 ```
 


### PR DESCRIPTION
On a semi-related note, I wonder about changing our API docs to look more like [the GitHub ones](https://docs.github.com/en/rest/reference/actions), which I think are easier to read.