### PR TITLE
Add new pact provider to build an oidc-user sub

### DIFF
--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -177,4 +177,10 @@ Pact.provider_states_for "GDS API Adapters" do
       stub_remote_attribute_request(name: "test_attribute_1", value: { bar: "baz" })
     end
   end
+
+  provider_state "there is a user with subject identifier 'the-subject-identifier'" do
+    set_up do
+      FactoryBot.build(:oidc_user, sub: "the-subject-identifier")
+    end
+  end
 end


### PR DESCRIPTION
Pact tests in GDS API adaptors are [curretly][1] failing because there
is no is no provider_state in account-api with the expected name
`the-subject-identifier`.

This sets up a provider that will build a user record with that value
for the Pact to verify with.

[1]: https://github.com/alphagov/gds-api-adapters/pull/1098
