### PR TITLE
Move email subscription cancel checking logic into the model 

### DIFF
--- a/app/models/email_subscription.rb
+++ b/app/models/email_subscription.rb
@@ -14,6 +14,20 @@ class EmailSubscription < ApplicationRecord
     }.compact
   end
 
+  def activated?
+    email_alert_api_subscription_id.present?
+  end
+
+  def check_if_still_active!
+    GdsApi
+      .email_alert_api.get_subscription(email_alert_api_subscription_id)
+      .to_hash
+      .dig("subscription", "ended_reason")
+      .blank?
+  rescue GdsApi::HTTPGone, GdsApi::HTTPNotFound
+    false
+  end
+
   def reactivate_if_confirmed!(email, email_verified)
     deactivate!
 

--- a/app/models/email_subscription.rb
+++ b/app/models/email_subscription.rb
@@ -21,7 +21,6 @@ class EmailSubscription < ApplicationRecord
   def check_if_still_active!
     GdsApi
       .email_alert_api.get_subscription(email_alert_api_subscription_id)
-      .to_hash
       .dig("subscription", "ended_reason")
       .blank?
   rescue GdsApi::HTTPGone, GdsApi::HTTPNotFound
@@ -38,13 +37,13 @@ class EmailSubscription < ApplicationRecord
     )
 
     subscription = GdsApi.email_alert_api.subscribe(
-      subscriber_list_id: subscriber_list.to_hash.dig("subscriber_list", "id"),
+      subscriber_list_id: subscriber_list.dig("subscriber_list", "id"),
       address: email,
       frequency: "daily",
       skip_confirmation_email: true,
     )
 
-    update!(email_alert_api_subscription_id: subscription.to_hash.dig("subscription", "id"))
+    update!(email_alert_api_subscription_id: subscription.dig("subscription", "id"))
   end
 
   def deactivate!

--- a/app/models/email_subscription.rb
+++ b/app/models/email_subscription.rb
@@ -51,10 +51,10 @@ class EmailSubscription < ApplicationRecord
     return unless email_alert_api_subscription_id
 
     GdsApi.email_alert_api.unsubscribe(email_alert_api_subscription_id)
-    update!(email_alert_api_subscription_id: nil)
   rescue GdsApi::HTTPGone, GdsApi::HTTPNotFound
     # this can happen if the subscription has been deactivated by the
     # user through email-alert-frontend
+  ensure
     update!(email_alert_api_subscription_id: nil)
   end
 end


### PR DESCRIPTION
This puts all of the email-alert-api communication in one place.  I've also moved an `update!` into an `ensure` block, to make it clearer that we always want it to run, and removed some superfluous `to_hash`es.