### PR TITLE
Remove simplecov from bin/rails

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -1,10 +1,4 @@
 #!/usr/bin/env ruby
-if ENV["RAILS_ENV"] == "test"
-  require "simplecov"
-  SimpleCov.start "rails"
-  puts "required simplecov"
-end
-
 APP_PATH = File.expand_path("../config/application", __dir__)
 require_relative "../config/boot"
 require "rails/commands"


### PR DESCRIPTION
This is causing problems with govuk-docker and conflicting dependency
versions:

    Traceback (most recent call last):
            15: from bin/rails:9:in `<main>'
            14: from bin/rails:9:in `require_relative'
            13: from /govuk/account-api/config/boot.rb:3:in `<top (required)>'
            12: from /root/.rbenv/versions/2.7.2/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:155:in `require'
            11: from /root/.rbenv/versions/2.7.2/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:155:in `require'
            10: from /root/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/setup.rb:10:in `<top (required)>'
             9: from /root/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/ui/shell.rb:88:in `silence'
             8: from /root/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/ui/shell.rb:136:in `with_level'
             7: from /root/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/setup.rb:10:in `block in <top (required)>'
             6: from /root/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler.rb:149:in `setup'
             5: from /root/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/runtime.rb:26:in `setup'
             4: from /root/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/runtime.rb:26:in `map'
             3: from /root/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/spec_set.rb:147:in `each'
             2: from /root/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/spec_set.rb:147:in `each'
             1: from /root/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/runtime.rb:31:in `block in setup'
    /root/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated docile 1.4.0, but your Gemfile requires docile 1.3.5. Prepending `bundle exec` to your command may solve this. (Gem::LoadError)

Since we're not using a separate test process, we can just remove
simplecov from this file.
