### PR TITLE
Set up email delivery with Notify

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "gds-sso"
 gem "govuk_app_config"
 gem "govuk_message_queue_consumer"
 gem "govuk_sidekiq"
+gem "notifications-ruby-client"
 gem "openid_connect"
 gem "pg"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,6 +224,8 @@ GEM
     nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
+    notifications-ruby-client (5.3.0)
+      jwt (>= 1.5, < 3)
     null_logger (0.0.1)
     oauth2 (1.4.7)
       faraday (>= 0.8, < 2.0)
@@ -524,6 +526,7 @@ DEPENDENCIES
   govuk_sidekiq
   govuk_test
   listen
+  notifications-ruby-client
   openid_connect
   pact
   pact_broker-client

--- a/app/workers/send_email_worker.rb
+++ b/app/workers/send_email_worker.rb
@@ -1,0 +1,57 @@
+require "notifications/client"
+
+class SendEmailWorker < ApplicationWorker
+  def perform(address, subject, body)
+    @address = address
+    @subject = subject
+    @body = body
+
+    if send_to_notify?
+      GovukStatsd.time("send_email_worker.email_send_request.notify") { send_notify_email }
+    else
+      send_pseudo_email
+    end
+  end
+
+private
+
+  attr_reader :address, :subject, :body
+
+  def send_notify_email
+    Notifications::Client.new(notify_api_key).send_email(
+      email_address: address,
+      template_id: notify_template_id,
+      personalisation: {
+        subject: subject,
+        body: body,
+      },
+    )
+    GovukStatsd.increment("send_email_worker.email_send_request.notify.success")
+  rescue Notifications::Client::RequestError, Net::OpenTimeout, Net::ReadTimeout, SocketError => e
+    GovukStatsd.increment("send_email_worker.email_send_request.notify.failure")
+    raise e
+  end
+
+  def send_pseudo_email
+    Rails.logger.info <<~INFO
+      To: #{address}
+      Subject: #{subject}
+
+      --
+
+      #{body}
+    INFO
+  end
+
+  def send_to_notify?
+    Rails.env.production?
+  end
+
+  def notify_api_key
+    Rails.application.secrets.govuk_notify_api_key
+  end
+
+  def notify_template_id
+    Rails.application.secrets.govuk_notify_template_id
+  end
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,4 @@
+Sidekiq.configure_server do
+  # Calls to Rails.logger in a sidekiq process will use Sidekiq's logger
+  Rails.logger = Sidekiq::Logging.logger
+end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,14 +1,20 @@
 test:
   session_signing_key: secret
+  govuk_notify_api_key: govuk-notify-api-key
+  govuk_notify_template_id: govuk-notify-template-id
   oauth_client_id: client-id
   oauth_client_secret: client-secret
 
 development:
   session_signing_key: secret
+  govuk_notify_api_key: govuk-notify-api-key
+  govuk_notify_template_id: govuk-notify-template-id
   oauth_client_id: <%= ENV.fetch('GOVUK_ACCOUNT_OAUTH_CLIENT_ID', 'client-id') %>
   oauth_client_secret: <%= ENV.fetch('GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET', 'client-secret') %>
 
 production:
   session_signing_key: <%= ENV['SESSION_SIGNING_KEY'] %>
+  govuk_notify_api_key: <%= ENV['GOVUK_NOTIFY_API_KEY'] %>
+  govuk_notify_template_id: <%= ENV['GOVUK_NOTIFY_TEMPLATE_ID'] %>
   oauth_client_id: <%= ENV['GOVUK_ACCOUNT_OAUTH_CLIENT_ID'] %>
   oauth_client_secret: <%= ENV['GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET'] %>

--- a/spec/workers/send_email_worker_spec.rb
+++ b/spec/workers/send_email_worker_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe SendEmailWorker do
+  let(:address) { "email@example.com" }
+  let(:message_subject) { "An Email from Us to You" }
+  let(:body) { "Email\nBody\nGoes\nHere" }
+
+  it "logs the message to INFO" do
+    logged_message = <<~INFO
+      To: #{address}
+      Subject: #{message_subject}
+
+      --
+
+      #{body}
+    INFO
+
+    allow(Rails.logger).to receive(:info)
+    described_class.new.perform(address, message_subject, body)
+    expect(Rails.logger).to have_received(:info).with(logged_message)
+  end
+
+  context "with Rails.env.production? true" do
+    before { allow(Rails.env).to receive(:production?).and_return(true) }
+
+    it "calls GOV.UK Notify" do
+      client = instance_double("Notifications::Client")
+      allow(Notifications::Client).to receive(:new).with(Rails.application.secrets.govuk_notify_api_key).and_return(client)
+      allow(client).to receive(:send_email)
+      described_class.new.perform(address, message_subject, body)
+      expect(client).to have_received(:send_email).with(
+        email_address: address,
+        template_id: Rails.application.secrets.govuk_notify_template_id,
+        personalisation: {
+          subject: message_subject,
+          body: body,
+        },
+      )
+    end
+  end
+end


### PR DESCRIPTION
We will use this to send special account-related emails to people;
this functionality won't be directly exposed in an API which other
apps can call to send one-off emails.

We're doing this in account-api rather than email-alert-api because
email-alert-api doesn't do emails to individual addresses: it does
emails to *lists*.  We could emulate this by creating a
single-subscriber list, sending the email, and then deleting the list;
but that's a bit of an abuse, we shouldn't go down that route.

I've gone for an approach similar to email-alert-api[1]: a Sidekiq job
which calls the Notify API directly.

I also looked at the mail-notify gem[2], but it looks like that
doesn't send email asynchronously, so we'd need to wrap calls to it in
a Sidekiq job anyway.

Finally, I considered using ActionMailer directly, like the Account
Manager does[3], but I think that's quite tightly tied to ActiveJob,
and previously I had decided not to introduce ActiveJob to this
project as we don't generally use it in other GOV.UK apps.

So overall, I think a Sidekiq worker which we call with an address,
subject, and body, is the right combination of simplicity and
familiarity.

[1] https://github.com/alphagov/email-alert-api/blob/main/app/workers/send_email_worker.rb
[2] https://github.com/dxw/mail-notify
[3] https://github.com/alphagov/govuk-account-manager-prototype/blob/main/app/mailers/application_mailer.rb

---

[Trello card](https://trello.com/c/aqRJqOKQ/914-send-brexit-checker-specific-welcome-email-when-someone-first-confirms-their-address)