### PR TITLE
Fetch email & email_verified from OidcUser in EmailSubscription

### DIFF
--- a/app/controllers/email_subscriptions_controller.rb
+++ b/app/controllers/email_subscriptions_controller.rb
@@ -13,7 +13,7 @@ class EmailSubscriptionsController < ApplicationController
   end
 
   def update
-    attributes = @govuk_account_session.get_attributes(%w[email email_verified])
+    @govuk_account_session.get_attributes(%w[email email_verified])
 
     email_subscription = EmailSubscription.transaction do
       EmailSubscription
@@ -24,10 +24,7 @@ class EmailSubscriptionsController < ApplicationController
         ).tap { |subscription| subscription.update!(topic_slug: params.fetch(:topic_slug)) }
     end
 
-    email_subscription.reactivate_if_confirmed!(
-      attributes["email"],
-      attributes["email_verified"],
-    )
+    email_subscription.reactivate_if_confirmed!
 
     render_api_response(email_subscription: email_subscription.to_hash)
   end

--- a/app/controllers/oidc_users_controller.rb
+++ b/app/controllers/oidc_users_controller.rb
@@ -30,12 +30,7 @@ class OidcUsersController < ApplicationController
         # this branch can be removed once we have no GOV.UK accounts
         # which have subscriptions but are *not* linked to the
         # corresponding notifications account.
-        user.email_subscriptions.each do |email_subscription|
-          email_subscription.reactivate_if_confirmed!(
-            attributes["email"],
-            attributes["email_verified"],
-          )
-        end
+        user.email_subscriptions.each(&:reactivate_if_confirmed!)
       end
     end
 

--- a/spec/models/email_subscription_spec.rb
+++ b/spec/models/email_subscription_spec.rb
@@ -37,10 +37,12 @@ RSpec.describe EmailSubscription do
     let(:email) { "email@example.com" }
     let(:email_verified) { false }
 
+    before { email_subscription.oidc_user.set_local_attributes(email: email, email_verified: email_verified) }
+
     it "doesn't call email-alert-api if the user is not confirmed" do
       stub = stub_subscriber_list
 
-      email_subscription.reactivate_if_confirmed!(email, email_verified)
+      email_subscription.reactivate_if_confirmed!
 
       expect(stub).not_to have_been_made
     end
@@ -52,7 +54,7 @@ RSpec.describe EmailSubscription do
         stub1 = stub_subscriber_list
         stub2 = stub_create_subscription
 
-        email_subscription.reactivate_if_confirmed!(email, email_verified)
+        email_subscription.reactivate_if_confirmed!
 
         expect(stub1).to have_been_made
         expect(stub2).to have_been_made
@@ -67,7 +69,7 @@ RSpec.describe EmailSubscription do
           stub_subscriber_list
           stub_create_subscription
 
-          expect { email_subscription.reactivate_if_confirmed!(email, email_verified) }.to change(SendEmailWorker.jobs, :size).by(1)
+          expect { email_subscription.reactivate_if_confirmed! }.to change(SendEmailWorker.jobs, :size).by(1)
         end
       end
 
@@ -79,7 +81,7 @@ RSpec.describe EmailSubscription do
           stub_subscriber_list
           stub_create_subscription
 
-          email_subscription.reactivate_if_confirmed!(email, email_verified)
+          email_subscription.reactivate_if_confirmed!
 
           expect(stub).to have_been_made
         end
@@ -130,28 +132,28 @@ RSpec.describe EmailSubscription do
 
   describe "#send_transition_checker_onboarding_email!" do
     it "does not send the email" do
-      expect { email_subscription.send_transition_checker_onboarding_email!(email) }.not_to change(SendEmailWorker.jobs, :size)
+      expect { email_subscription.send_transition_checker_onboarding_email! }.not_to change(SendEmailWorker.jobs, :size)
     end
 
     context "when the subscription has been activated" do
       let(:email_alert_api_subscription_id) { "subscription-id" }
 
       it "does not send the email" do
-        expect { email_subscription.send_transition_checker_onboarding_email!(email) }.not_to change(SendEmailWorker.jobs, :size)
+        expect { email_subscription.send_transition_checker_onboarding_email! }.not_to change(SendEmailWorker.jobs, :size)
       end
 
       context "when this is the transition checker subscription" do
         let(:name) { "transition-checker-results" }
 
         it "does not send the email" do
-          expect { email_subscription.send_transition_checker_onboarding_email!(email) }.not_to change(SendEmailWorker.jobs, :size)
+          expect { email_subscription.send_transition_checker_onboarding_email! }.not_to change(SendEmailWorker.jobs, :size)
         end
 
         context "when the user has not already received the onboarding email" do
           let(:has_received_transition_checker_onboarding_email) { false }
 
           it "sends the email and updates the user" do
-            expect { email_subscription.send_transition_checker_onboarding_email!(email) }.to change(SendEmailWorker.jobs, :size).by(1)
+            expect { email_subscription.send_transition_checker_onboarding_email! }.to change(SendEmailWorker.jobs, :size).by(1)
             expect(oidc_user.reload.has_received_transition_checker_onboarding_email).to be(true)
           end
         end


### PR DESCRIPTION
The `reactivate_if_confirmed!` method needs the `email` and
`email_verified` attributes, which are cached attributes: they may not
be stored locally but, given a user session, we know how to retrieve
them.

So this method used to take the attributes as parameters.

However, this gives a slightly weird API where, strictly speaking,
subscriptions can be associated with a user which use a different
email address, or which are confirmed when the user is not (or vice
versa).  So, to rule out that possibility, treat the attributes as
local attributes in `reactivate_if_confirmed!`, and we just have to
make sure that they are present before calling it.
