### PR TITLE
Implement Transition Checker onboarding email

### DIFF
--- a/app/models/email_subscription.rb
+++ b/app/models/email_subscription.rb
@@ -44,6 +44,8 @@ class EmailSubscription < ApplicationRecord
     )
 
     update!(email_alert_api_subscription_id: subscription.dig("subscription", "id"))
+
+    send_transition_checker_onboarding_email!(email)
   end
 
   def deactivate!
@@ -55,5 +57,19 @@ class EmailSubscription < ApplicationRecord
     # user through email-alert-frontend
   ensure
     update!(email_alert_api_subscription_id: nil)
+  end
+
+  def send_transition_checker_onboarding_email!(email)
+    return unless email_alert_api_subscription_id
+    return unless name == "transition-checker-results"
+    return if oidc_user.has_received_transition_checker_onboarding_email
+
+    SendEmailWorker.perform_async(
+      email,
+      I18n.t("emails.onboarding.transition_checker.subject"),
+      I18n.t("emails.onboarding.transition_checker.body", sign_in_link: "#{Plek.find('account-manager')}/sign-in"),
+    )
+
+    oidc_user.update!(has_received_transition_checker_onboarding_email: true)
   end
 end

--- a/config/locales/emails.en.yml
+++ b/config/locales/emails.en.yml
@@ -1,0 +1,26 @@
+en:
+  emails:
+    onboarding:
+      transition_checker:
+        body: |
+          Hello
+
+          You’ve now saved your Brexit checker results and subscribed to get email updates about Brexit.
+
+          Sign in to your GO.UK account to see your Brexit checker results:
+          %{sign_in_link}
+
+          You will only get email updates if:
+
+          - there are changes to your Brexit checker results
+          - questions or results are added which may affect you
+
+          You’ll never get more than one email a day. The email will include all the updates made that day.
+
+          You can unsubscribe from emails or change your subscription at any time:
+          https://www.gov.uk/email/manage/authenticate
+
+          -----
+
+          This is an automated email, please do not reply as we do not monitor responses.
+        subject: You’ve saved your Brexit checker results and subscribed to emails

--- a/db/migrate/20210730125116_add_has_received_transition_checker_onboarding_email_to_oidc_user.rb
+++ b/db/migrate/20210730125116_add_has_received_transition_checker_onboarding_email_to_oidc_user.rb
@@ -1,0 +1,5 @@
+class AddHasReceivedTransitionCheckerOnboardingEmailToOidcUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :oidc_users, :has_received_transition_checker_onboarding_email, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_11_093439) do
+ActiveRecord::Schema.define(version: 2021_07_30_125116) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 2021_06_11_093439) do
     t.string "sub", null: false
     t.datetime "created_at", precision: 6, default: -> { "now()" }, null: false
     t.datetime "updated_at", precision: 6, default: -> { "now()" }, null: false
+    t.boolean "has_received_transition_checker_onboarding_email", default: true, null: false
     t.index ["sub"], name: "index_oidc_users_on_sub", unique: true
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ end
 
 require File.expand_path("../config/environment", __dir__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
+require "govuk_sidekiq/testing"
 require "rspec/rails"
 require "webmock/rspec"
 
@@ -26,7 +27,10 @@ RSpec.configure do |config|
     config.after { Bullet.end_request }
   end
 
-  config.before { Rails.application.load_seed }
+  config.before do
+    Rails.application.load_seed
+    Sidekiq::Worker.clear_all
+  end
 
   config.expose_dsl_globally = false
   config.use_transactional_fixtures = true


### PR DESCRIPTION
When a user first signs up to Transition Checker notifications, we
want to send them an onboarding email.

This is part of the unbodging: the Account Manager is now sending a
much more generic email and so, on the GOV.UK side, we want to send
the more specific one.

This email will also be sent if the user signs up and only later uses
the Checker, whereas before they'd just have got the one
Checker-mentioning email regardless of whether they'd used the Checker
or not.

I thought about implementing the logic with some sort of check based
on attribute values, but decided it would be clearer (and less
fragile) to add a `has_received_transition_checker_onboarding_email`
field to the `OidcUser` model.  This new field defaults to `true`, so
we won't start sending any emails yet.  This lets us check the Notify
API keys and suchlike work in every environment, then we can deploy
another migration changing the default to `false` and begin sending
emails.

---

[Trello card](https://trello.com/c/aqRJqOKQ/914-send-brexit-checker-specific-welcome-email-when-someone-first-confirms-their-address)
