### PR TITLE
Send Transition Checker onboarding email

### DIFF
--- a/db/migrate/20210730133729_change_default_for_has_received_transition_checker_onboarding_email.rb
+++ b/db/migrate/20210730133729_change_default_for_has_received_transition_checker_onboarding_email.rb
@@ -1,0 +1,5 @@
+class ChangeDefaultForHasReceivedTransitionCheckerOnboardingEmail < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :oidc_users, :has_received_transition_checker_onboarding_email, from: true, to: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_30_125116) do
+ActiveRecord::Schema.define(version: 2021_07_30_133729) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,7 +48,7 @@ ActiveRecord::Schema.define(version: 2021_07_30_125116) do
     t.string "sub", null: false
     t.datetime "created_at", precision: 6, default: -> { "now()" }, null: false
     t.datetime "updated_at", precision: 6, default: -> { "now()" }, null: false
-    t.boolean "has_received_transition_checker_onboarding_email", default: true, null: false
+    t.boolean "has_received_transition_checker_onboarding_email", default: false, null: false
     t.index ["sub"], name: "index_oidc_users_on_sub", unique: true
   end
 


### PR DESCRIPTION
This changes the `has_received_...` column default from true to false,
so users created after this point will be sent the email when they
first activate a Transition Checker subscription.

---

[Trello card](https://trello.com/c/aqRJqOKQ/914-send-brexit-checker-specific-welcome-email-when-someone-first-confirms-their-address)
