### PR TITLE
Fix typo in Transition Checker Onboarding Email

### DIFF
--- a/config/locales/emails.en.yml
+++ b/config/locales/emails.en.yml
@@ -7,7 +7,7 @@ en:
 
           You’ve now saved your Brexit checker results and subscribed to get email updates about Brexit.
 
-          Sign in to your GO.UK account to see your Brexit checker results:
+          Sign in to your GOV.UK account to see your Brexit checker results:
           %{sign_in_link}
 
           You will only get email updates if:


### PR DESCRIPTION
This logic hasn't been switched on yet, so nobody has received the incorrect email.

---


[Trello card](https://trello.com/c/aqRJqOKQ/914-send-brexit-checker-specific-welcome-email-when-someone-first-confirms-their-address)