### PR TITLE
Drop flash messages in the session

### DIFF
--- a/app/lib/account_session.rb
+++ b/app/lib/account_session.rb
@@ -18,9 +18,10 @@ class AccountSession
   end
 
   def self.deserialise(encoded_session:, session_signing_key:)
-    return if encoded_session.blank?
+    encoded_session_without_flash = encoded_session&.split("$$")&.first
+    return if encoded_session_without_flash.blank?
 
-    serialised_session = StringEncryptor.new(signing_key: session_signing_key).decrypt_string(encoded_session)
+    serialised_session = StringEncryptor.new(signing_key: session_signing_key).decrypt_string(encoded_session_without_flash)
     if serialised_session
       new(
         session_signing_key: session_signing_key,

--- a/spec/lib/account_session_spec.rb
+++ b/spec/lib/account_session_spec.rb
@@ -26,6 +26,14 @@ RSpec.describe AccountSession do
       expect(decoded).to eq(params)
     end
 
+    it "decodes successfully in the presence of flash messages" do
+      encoded = described_class.new(session_signing_key: "secret", **params).serialise
+      decoded = described_class.deserialise(encoded_session: "#{encoded}$$some,flash,keys", session_signing_key: "secret")
+
+      expect(decoded).not_to be_nil
+      expect(decoded.to_hash).to eq(params)
+    end
+
     it "rejects a session signed with a different key" do
       encoded = described_class.new(session_signing_key: "secret", **params).serialise
       decoded = described_class.deserialise(encoded_session: encoded, session_signing_key: "different-secret")


### PR DESCRIPTION
We're implementing flash messages by appending keys to the session,
separated from the actual session with a "$$".  So, change the
`AccountSession` to drop any flash portion, as we don't need it in
this app.

---

[Trello card](https://trello.com/c/I0ulYzeX/946-implement-a-way-to-use-flash-messages-for-accounty-things)
