### PR TITLE
Pass `client_id` with `jwt_bearer` auth method

### DIFF
--- a/app/lib/oidc_client.rb
+++ b/app/lib/oidc_client.rb
@@ -45,6 +45,7 @@ class OidcClient
     access_token =
       if use_client_private_key_auth?
         client.access_token!(
+          client_id: client_id,
           client_auth_method: "jwt_bearer",
           client_assertion: JSON::JWT.new(
             iss: client_id,


### PR DESCRIPTION
The auth service needs this parameter[1], but the client library we're
using doesn't pass it automatically.  So, pass it explicitly here.

Note that, with no arguments (ie, the non-JWT case) the library *does*
pass the `client_id` automatically.

[1] Probably so it knows which public key to use to validate the JWT.

---

[Trello card](https://trello.com/c/ZvDGaba4/958-use-di-auth-in-integration-give-feedback-on-their-documentation)
