### PR TITLE
Remove unused development-mode branch

### DIFF
--- a/app/controllers/concerns/authenticated_api_concern.rb
+++ b/app/controllers/concerns/authenticated_api_concern.rb
@@ -4,7 +4,7 @@ module AuthenticatedApiConcern
   included do
     before_action do
       @govuk_account_session = AccountSession.deserialise(
-        encoded_session: get_govuk_account_session(request),
+        encoded_session: request.headers["HTTP_GOVUK_ACCOUNT_SESSION"],
         session_secret: Rails.application.secrets.session_secret,
       )
 
@@ -18,13 +18,5 @@ module AuthenticatedApiConcern
 
   def render_api_response(options = {})
     render json: options.merge(govuk_account_session: @govuk_account_session.serialise)
-  end
-
-  def get_govuk_account_session(request)
-    if request.headers["HTTP_GOVUK_ACCOUNT_SESSION"].nil? && Rails.env.development?
-      return request.cookies["govuk_account_session"]
-    end
-
-    request.headers["HTTP_GOVUK_ACCOUNT_SESSION"]
   end
 end


### PR DESCRIPTION
Previously, we supported taking the account session value from the
request cookies when running in development mode.  This matches how
the frontend apps behave.  But in practice we don't make requests
directly to account-api itself from a browser, so this is unnecessary.
