### PR TITLE
Store the ID token JWT in the session, and add an end-session endpoint

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -38,6 +38,17 @@ class AuthenticationController < ApplicationController
     head :unauthorized
   end
 
+  def end_session
+    end_session_uri =
+      if using_digital_identity?
+        oidc_end_session_url
+      else
+        "#{Plek.find('account-manager')}/sign-out?continue=1"
+      end
+
+    render json: { end_session_uri: end_session_uri }
+  end
+
 private
 
   # TODO: Digital Identity don't yet have an implementation of levels
@@ -64,6 +75,21 @@ private
         ga_session_id: oauth_response.fetch(:result)["_ga"],
         cookie_consent: oauth_response.fetch(:result)["cookie_consent"],
       )
+    end
+  end
+
+  def oidc_end_session_url
+    end_session_endpoint = oidc_client_class.new.end_session_endpoint
+    id_token = AccountSession.deserialise(
+      encoded_session: request.headers["HTTP_GOVUK_ACCOUNT_SESSION"],
+      session_secret: Rails.application.secrets.session_secret,
+    )&.id_token
+
+    if id_token
+      querystring = Rack::Utils.build_nested_query(id_token_hint: id_token)
+      "#{end_session_endpoint}?#{querystring}"
+    else
+      end_session_endpoint
     end
   end
 end

--- a/app/lib/account_session.rb
+++ b/app/lib/account_session.rb
@@ -9,13 +9,14 @@ class AccountSession
 
   LOWEST_LEVEL_OF_AUTHENTICATION = "level0"
 
-  attr_reader :user_id, :level_of_authentication
+  attr_reader :id_token, :user_id, :level_of_authentication
 
-  def initialize(session_secret:, access_token:, refresh_token:, level_of_authentication:, user_id: nil)
+  def initialize(session_secret:, access_token:, refresh_token:, level_of_authentication:, user_id: nil, id_token: nil)
     @session_secret = session_secret
     @access_token = access_token
     @refresh_token = refresh_token
     @level_of_authentication = level_of_authentication
+    @id_token = id_token
     @frozen = false
 
     @user_id = user_id || userinfo["sub"]
@@ -53,6 +54,7 @@ class AccountSession
 
   def to_hash
     {
+      id_token: id_token,
       user_id: user_id,
       access_token: @access_token,
       refresh_token: @refresh_token,

--- a/app/lib/oidc_client.rb
+++ b/app/lib/oidc_client.rb
@@ -63,13 +63,15 @@ class OidcClient
     response = access_token.token_response
 
     if oidc_nonce
-      id_token = OpenIDConnect::ResponseObject::IdToken.decode access_token.id_token, discover.jwks
+      id_token_jwt = access_token.id_token
+      id_token = OpenIDConnect::ResponseObject::IdToken.decode id_token_jwt, discover.jwks
       id_token.verify! client_id: client_id, issuer: discover.issuer, nonce: oidc_nonce
     end
 
     {
       access_token: response[:access_token],
       refresh_token: response[:refresh_token],
+      id_token_jwt: id_token_jwt,
       id_token: id_token,
     }.compact
   rescue Rack::OAuth2::Client::Error

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
     scope :oauth2 do
       get "/sign-in", to: "authentication#sign_in"
       post "/callback", to: "authentication#callback"
+      get "/end-session", to: "authentication#end_session"
     end
 
     get "/user", to: "user#show"

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,6 +11,7 @@ management. This API is not for other government services.
 - [API endpoints](#api-endpoints)
   - [`GET /api/oauth2/sign-in`](#get-apioauth2sign-in)
   - [`POST /api/oauth2/callback`](#post-apioauth2callback)
+  - [`GET /api/oauth2/end-session`](#get-apioauth2end-session)
   - [`GET /api/user`](#get-apiuser)
   - [`GET /api/attributes`](#get-apiattributes)
   - [`PATCH /api/attributes`](#patch-apiattributes)
@@ -168,6 +169,44 @@ Response:
     "redirect_path": "/guidance/keeping-a-pet-pig-or-micropig",
     "ga_client_id": "ga-123-userid",
     "cookie_consent": false,
+}
+```
+
+### `GET /api/oauth2/end-session`
+
+Generates a sign out URL.
+
+This URL should be served to the user with a 302 response to terminate their session with the identity provider and connected services.  If the session identifier is given, it may be passed to the identity provider to validate the user's session.
+
+#### Request headers
+
+- `GOVUK-Account-Session` *(optional)*
+  - the user's session identifier
+
+#### JSON response fields
+
+- `end_session_uri`
+  - an absolute URL, pointing to the identity provider, which the user should be redirected to to end their session
+
+#### Response codes
+
+- 200
+
+#### Example request / response
+
+Request (with gds-api-adapters):
+
+```ruby
+GdsApi.account_api.get_end_session_url(
+    govuk_account_session: "session-identifier",
+)
+```
+
+Response:
+
+```json
+{
+    "end_session_uri": "https://www.account.publishing.service.gov.uk/sign-out?continue=1"
 }
 ```
 

--- a/spec/lib/account_session_spec.rb
+++ b/spec/lib/account_session_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe AccountSession do
       let(:id_token) { nil }
 
       it "successfully decodes with a nil token value" do
-        expect(described_class.new(session_signing_key: "secret", **params).to_hash).to eq(params.merge(id_token: nil))
+        expect(described_class.new(session_secret: "secret", **params).to_hash).to eq(params.merge(id_token: nil))
       end
     end
 

--- a/spec/support/helpers/govuk_account_session_helper.rb
+++ b/spec/support/helpers/govuk_account_session_helper.rb
@@ -7,6 +7,7 @@ module GovukAccountSessionHelper
     AccountSession.new(
       **{
         session_secret: Rails.application.secrets.session_secret,
+        id_token: "id-token",
         user_id: "user-id",
         access_token: "access-token",
         refresh_token: "refresh-token",

--- a/spec/support/helpers/oidc_client_helper.rb
+++ b/spec/support/helpers/oidc_client_helper.rb
@@ -16,6 +16,7 @@ module OidcClientHelper
     token_response = {
       access_token: "access-token",
       refresh_token: "refresh-token",
+      id_token_jwt: "id-token",
       id_token: instance_double(
         "OpenIDConnect::ResponseObject::IdToken",
         iss: "http://openid-provider",


### PR DESCRIPTION
This commit adds the original ID token value (a JWT) to the session, so that we can follow the [OIDC session management standard](https://openid.net/specs/openid-connect-session-1_0.html) Digital Identity have adopted.  The account manager doesn't use this standard (it has its own way of logging users out), so this is another bit of code with an `if using_digital_identity?` case - which isn't great, but is only temporary.

We'll need to add this endpoint to gds-api-adapters, then it can be used in the current [frontend SessionsController](https://github.com/alphagov/frontend/blob/5d7f08f7ad87033f3d602d378609aa6e74d720a0/app/controllers/sessions_controller.rb#L29-L38).

---

[Trello card](https://trello.com/c/ZvDGaba4/958-use-di-auth-in-integration-give-feedback-on-their-documentation)