### PR TITLE
Revert "Bump sidekiq-scheduler from 3.0.1 to 3.1.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "openid_connect"
 gem "pg"
 
 # https://github.com/moove-it/sidekiq-scheduler/issues/345
-gem "sidekiq-scheduler", "3.1.0"
+gem "sidekiq-scheduler", "3.0.1"
 
 group :development, :test do
   gem "awesome_print"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -431,7 +431,7 @@ GEM
       redis (>= 3.3.5, < 4.2)
     sidekiq-logging-json (0.0.19)
       sidekiq (>= 3)
-    sidekiq-scheduler (3.1.0)
+    sidekiq-scheduler (3.0.1)
       e2mmap
       redis (>= 3, < 5)
       rufus-scheduler (~> 3.2)
@@ -538,7 +538,7 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   shoulda-matchers
-  sidekiq-scheduler (= 3.1.0)
+  sidekiq-scheduler (= 3.0.1)
   simplecov
   webmock
 


### PR DESCRIPTION
We're explicitly using version 3.0.1, because 3.1.0 has an issue (mentioned in a comment above the version constraint):

```
ERR unknown command `exists?`, with args beginning with: `account-api:schedules`,
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/redis-4.1.4/lib/redis/client.rb:126:in `call'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/redis-4.1.4/lib/redis.rb:3312:in `block in method_missing'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/redis-4.1.4/lib/redis.rb:51:in `block in synchronize'
/usr/lib/rbenv/versions/2.7.2/lib/ruby/2.7.0/monitor.rb:202:in `synchronize'
/usr/lib/rbenv/versions/2.7.2/lib/ruby/2.7.0/monitor.rb:202:in `mon_synchronize'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/redis-4.1.4/lib/redis.rb:51:in `synchronize'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/redis-4.1.4/lib/redis.rb:3311:in `method_missing'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/redis-namespace-1.8.1/lib/redis/namespace.rb:476:in `call_with_namespace'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/redis-namespace-1.8.1/lib/redis/namespace.rb:352:in `block (2 levels) in <class:Namespace>'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/sidekiq-scheduler-3.1.0/lib/sidekiq-scheduler/redis_manager.rb:101:in `block in schedule_exist?'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/sidekiq-5.2.9/lib/sidekiq.rb:97:in `block in redis'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/connection_pool-2.2.5/lib/connection_pool.rb:63:in `block (2 levels) in with'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/connection_pool-2.2.5/lib/connection_pool.rb:62:in `handle_interrupt'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/connection_pool-2.2.5/lib/connection_pool.rb:62:in `block in with'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/connection_pool-2.2.5/lib/connection_pool.rb:59:in `handle_interrupt'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/connection_pool-2.2.5/lib/connection_pool.rb:59:in `with'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/sidekiq-5.2.9/lib/sidekiq.rb:94:in `redis'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/sidekiq-scheduler-3.1.0/lib/sidekiq-scheduler/redis_manager.rb:99:in `schedule_exist?'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/sidekiq-scheduler-3.1.0/lib/sidekiq-scheduler/schedule.rb:84:in `get_all_schedules'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/sidekiq-scheduler-3.1.0/lib/sidekiq-scheduler/schedule.rb:43:in `schedule='
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/sidekiq-scheduler-3.1.0/lib/sidekiq-scheduler/manager.rb:29:in `initialize'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/sidekiq-scheduler-3.1.0/lib/sidekiq-scheduler.rb:16:in `new'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/sidekiq-scheduler-3.1.0/lib/sidekiq-scheduler.rb:16:in `block (2 levels) in <main>'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/sidekiq-5.2.9/lib/sidekiq/util.rb:57:in `block in fire_event'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/sidekiq-5.2.9/lib/sidekiq/util.rb:55:in `each'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/sidekiq-5.2.9/lib/sidekiq/util.rb:55:in `fire_event'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/sidekiq-5.2.9/lib/sidekiq/cli.rb:91:in `run'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/sidekiq-5.2.9/bin/sidekiq:12:in `<top (required)>'
/data/apps/account-api/shared/bundle/ruby/2.7.0/bin/sidekiq:23:in `load'
/data/apps/account-api/shared/bundle/ruby/2.7.0/bin/sidekiq:23:in `<top (required)>'
/usr/lib/rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/cli/exec.rb:63:in `load'
/usr/lib/rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/cli/exec.rb:63:in `kernel_load'
/usr/lib/rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/cli/exec.rb:28:in `run'
/usr/lib/rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/cli.rb:476:in `exec'
/usr/lib/rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/usr/lib/rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/usr/lib/rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/vendor/thor/lib/thor.rb:399:in `dispatch'
/usr/lib/rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/cli.rb:30:in `dispatch'
/usr/lib/rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/vendor/thor/lib/thor/base.rb:476:in `start'
/usr/lib/rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/cli.rb:24:in `start'
/usr/lib/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/libexec/bundle:46:in `block in <top (required)>'
/usr/lib/rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/friendly_errors.rb:123:in `with_friendly_errors'
/usr/lib/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/libexec/bundle:34:in `<top (required)>'
/usr/lib/rbenv/versions/2.7.2/bin/bundle:23:in `load'
/usr/lib/rbenv/versions/2.7.2/bin/bundle:23:in `<main>'
```

Reverts alphagov/account-api#152