### PR TITLE
Rename session_signing_key to session_secret

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -23,7 +23,7 @@ class AuthenticationController < ApplicationController
 
     render json: {
       govuk_account_session: AccountSession.new(
-        session_signing_key: Rails.application.secrets.session_signing_key,
+        session_secret: Rails.application.secrets.session_secret,
         user_id: details.fetch(:id_token).sub,
         access_token: details.fetch(:access_token),
         refresh_token: details.fetch(:refresh_token),

--- a/app/controllers/concerns/authenticated_api_concern.rb
+++ b/app/controllers/concerns/authenticated_api_concern.rb
@@ -5,7 +5,7 @@ module AuthenticatedApiConcern
     before_action do
       @govuk_account_session = AccountSession.deserialise(
         encoded_session: get_govuk_account_session(request),
-        session_signing_key: Rails.application.secrets.session_signing_key,
+        session_secret: Rails.application.secrets.session_secret,
       )
 
       head :unauthorized unless @govuk_account_session

--- a/app/lib/string_encryptor.rb
+++ b/app/lib/string_encryptor.rb
@@ -1,8 +1,8 @@
 class StringEncryptor
   KEY_LEN = ActiveSupport::MessageEncryptor.key_len
 
-  def initialize(signing_key:)
-    @signing_key = signing_key
+  def initialize(secret:)
+    @secret = secret
   end
 
   def encrypt_string(plaintext)
@@ -27,10 +27,10 @@ class StringEncryptor
 
 private
 
-  attr_reader :signing_key
+  attr_reader :secret
 
   def encryptor(salt)
-    key = ActiveSupport::KeyGenerator.new(signing_key).generate_key(salt, KEY_LEN)
+    key = ActiveSupport::KeyGenerator.new(secret).generate_key(salt, KEY_LEN)
     ActiveSupport::MessageEncryptor.new key
   end
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,5 +1,5 @@
 test:
-  session_signing_key: secret
+  session_secret: secret
   govuk_notify_api_key: govuk-notify-api-key
   govuk_notify_template_id: govuk-notify-template-id
   oauth_client_id: client-id
@@ -35,7 +35,7 @@ test:
     -----END PRIVATE KEY-----
 
 development:
-  session_signing_key: secret
+  session_secret: secret
   govuk_notify_api_key: govuk-notify-api-key
   govuk_notify_template_id: govuk-notify-template-id
   oauth_client_id: <%= ENV.fetch('GOVUK_ACCOUNT_OAUTH_CLIENT_ID', 'client-id') %>
@@ -44,7 +44,7 @@ development:
 <%= ENV["GOVUK_ACCOUNT_OAUTH_PRIVATE_KEY"]&.gsub(/^/, '    \1') %>
 
 production:
-  session_signing_key: <%= ENV['SESSION_SIGNING_KEY'] %>
+  session_secret: <%= ENV.fetch('SESSION_SECRET', ENV['SESSION_SIGNING_KEY']) %>
   govuk_notify_api_key: <%= ENV['GOVUK_NOTIFY_API_KEY'] %>
   govuk_notify_template_id: <%= ENV['GOVUK_NOTIFY_TEMPLATE_ID'] %>
   oauth_client_id: <%= ENV['GOVUK_ACCOUNT_OAUTH_CLIENT_ID'] %>

--- a/spec/lib/string_encryptor_spec.rb
+++ b/spec/lib/string_encryptor_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe StringEncryptor do
   let(:key) { "encryption-key" }
   let(:plaintext) { SecureRandom.bytes(32) }
-  let(:ciphertext) { described_class.new(signing_key: key).encrypt_string(plaintext) }
+  let(:ciphertext) { described_class.new(secret: key).encrypt_string(plaintext) }
 
   it "round-trips" do
-    expect(described_class.new(signing_key: key).decrypt_string(ciphertext)).to eq(plaintext)
+    expect(described_class.new(secret: key).decrypt_string(ciphertext)).to eq(plaintext)
   end
 
   it "rejects if the salt has been tampered with" do
@@ -14,17 +14,17 @@ RSpec.describe StringEncryptor do
     salt[0] = "X"
     new_ciphertext = Base64.urlsafe_encode64("#{salt}$$#{message}")
 
-    expect(described_class.new(signing_key: key).decrypt_string(new_ciphertext)).to be_nil
+    expect(described_class.new(secret: key).decrypt_string(new_ciphertext)).to be_nil
   end
 
   it "rejects if the salt is missing" do
     message = Base64.urlsafe_decode64(ciphertext).split("$$")[1]
     new_ciphertext = Base64.urlsafe_encode64(message)
 
-    expect(described_class.new(signing_key: key).decrypt_string(new_ciphertext)).to be_nil
+    expect(described_class.new(secret: key).decrypt_string(new_ciphertext)).to be_nil
   end
 
   it "rejects if the string has been signed with a different key" do
-    expect(described_class.new(signing_key: "a-different-key").decrypt_string(ciphertext)).to be_nil
+    expect(described_class.new(secret: "a-different-key").decrypt_string(ciphertext)).to be_nil
   end
 end

--- a/spec/support/helpers/govuk_account_session_helper.rb
+++ b/spec/support/helpers/govuk_account_session_helper.rb
@@ -6,7 +6,7 @@ module GovukAccountSessionHelper
   def placeholder_govuk_account_session_object(options = {})
     AccountSession.new(
       **{
-        session_signing_key: Rails.application.secrets.session_signing_key,
+        session_secret: Rails.application.secrets.session_secret,
         user_id: "user-id",
         access_token: "access-token",
         refresh_token: "refresh-token",


### PR DESCRIPTION
It's not the key, it's the secret used to derive the key.

When the env var has been renamed in puppet, the old one can be
removed from config/secrets.yml.
