### PR TITLE
Do not use `fetch` for values which can safely be `nil`

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -26,12 +26,12 @@ class AuthenticationController < ApplicationController
         session_secret: Rails.application.secrets.session_secret,
         user_id: details.fetch(:id_token).sub,
         access_token: details.fetch(:access_token),
-        refresh_token: details.fetch(:refresh_token),
+        refresh_token: details[:refresh_token],
         level_of_authentication: details.fetch(:level_of_authentication),
       ).serialise,
       redirect_path: redirect_path,
-      ga_client_id: details.fetch(:ga_session_id),
-      cookie_consent: details.fetch(:cookie_consent),
+      ga_client_id: details[:ga_session_id],
+      cookie_consent: details[:cookie_consent],
     }
   rescue OidcClient::OAuthFailure
     head :unauthorized
@@ -56,11 +56,7 @@ private
   # before we can migrate production.
   def get_level_of_authentication_and_suchlike(client, tokens)
     if using_digital_identity?
-      tokens.merge(
-        level_of_authentication: "level1",
-        ga_session_id: nil,
-        cookie_consent: false,
-      )
+      tokens.merge(level_of_authentication: "level1")
     else
       oauth_response = client.get_ephemeral_state(
         access_token: tokens[:access_token],

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -1,10 +1,11 @@
 RSpec.describe "Authentication" do
   before do
     stub_oidc_discovery
-    stub_token_response
+    stub_token_response(refresh_token: refresh_token)
   end
 
   let(:headers) { { "Content-Type" => "application/json" } }
+  let(:refresh_token) { "refresh-token" }
 
   describe "/sign-in" do
     it "creates an AuthRequest to persist the attributes" do
@@ -34,6 +35,15 @@ RSpec.describe "Authentication" do
       post callback_path, headers: headers, params: { state: auth_request.to_oauth_state, code: "12345" }.to_json
       expect(response).to be_successful
       expect(JSON.parse(response.body)).to include("govuk_account_session", "redirect_path" => auth_request.redirect_path)
+    end
+
+    context "when there is no refresh token" do
+      let(:refresh_token) { nil }
+
+      it "responds successfully" do
+        post callback_path, headers: headers, params: { state: auth_request.to_oauth_state, code: "12345" }.to_json
+        expect(response).to be_successful
+      end
     end
 
     context "when using the account manager" do

--- a/spec/support/helpers/oidc_client_helper.rb
+++ b/spec/support/helpers/oidc_client_helper.rb
@@ -12,10 +12,10 @@ module OidcClientHelper
     # rubocop:enable RSpec/AnyInstance
   end
 
-  def stub_token_response
+  def stub_token_response(refresh_token: "refresh-token")
     token_response = {
       access_token: "access-token",
-      refresh_token: "refresh-token",
+      refresh_token: refresh_token,
       id_token_jwt: "id-token",
       id_token: instance_double(
         "OpenIDConnect::ResponseObject::IdToken",
@@ -25,7 +25,7 @@ module OidcClientHelper
         exp: 300,
         iat: 0,
       ),
-    }
+    }.compact
 
     # rubocop:disable RSpec/AnyInstance
     allow_any_instance_of(OidcClient).to receive(:tokens!).and_return(token_response)


### PR DESCRIPTION
Using `fetch` implies that the value is present, but that's not
necessarily the case:

- Digital Identity don't yet have refresh tokens
- They're going for a different approach for GA session IDs
- A missing cookie consent value is treated as false

So rather than fill in `nil` or `false` as default values for these
things, just allow them to be missing.

---

[Sentry error](https://sentry.io/organizations/govuk/issues/2623524890/?project=5671868&referrer=slack)