### PR TITLE
Handle content-store gone exceptions when redirecting saved pages

### DIFF
--- a/lib/message_queue_processor.rb
+++ b/lib/message_queue_processor.rb
@@ -73,7 +73,7 @@ class MessageQueueProcessor
     else
       destroy_saved_pages(saved_pages)
     end
-  rescue GdsApi::ContentStore::ItemNotFound
+  rescue GdsApi::ContentStore::ItemNotFound, GdsApi::HTTPGone
     destroy_saved_pages(saved_pages)
   end
 

--- a/spec/lib/message_queue_processor_spec.rb
+++ b/spec/lib/message_queue_processor_spec.rb
@@ -91,6 +91,17 @@ RSpec.describe MessageQueueProcessor do
             expect { saved_page.reload }.to raise_error(ActiveRecord::RecordNotFound)
           end
         end
+
+        context "when the redirect target has been marked 'gone'" do
+          before { stub_content_store_has_gone_item(alternative_path, content_item) }
+
+          let(:expected_effect) { "destroyed" }
+
+          it "destroys matching pages" do
+            expect(actual_output).to eq(expected_output)
+            expect { saved_page.reload }.to raise_error(ActiveRecord::RecordNotFound)
+          end
+        end
       end
     end
 
@@ -119,6 +130,17 @@ RSpec.describe MessageQueueProcessor do
 
       context "when the redirect target does not exist" do
         before { stub_content_store_does_not_have_item(alternative_path, content_item) }
+
+        let(:expected_effect) { "destroyed" }
+
+        it "destroys matching pages" do
+          expect(actual_output).to eq(expected_output)
+          expect { saved_page.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+
+      context "when the redirect target has been marked 'gone'" do
+        before { stub_content_store_has_gone_item(alternative_path, content_item) }
 
         let(:expected_effect) { "destroyed" }
 


### PR DESCRIPTION
Currently if a redirect target is `gone`, this throws an exception:

```
 GdsApi::HTTPGone: URL: https://content-store.production.govuk-internal.digital/content/international-development-funding/rapid-funding-envelope-for-hiv-aids-tanzania
Response body:
{"analytics_identifier":null,"base_path":"/international-development-funding/rapid-funding-envelope-for-hiv-aids-tanzania","content_id":null,"document_type":"gone","first_published_at":null,"locale":"en","phase":"live","public_updated_at":"2016-08-09T13:29:27.000+00:00","publishing_app":"specialist-publisher","publishing_scheduled_at":null,"rendering_app":null,"scheduled_publishing_delay_seconds":null,"schema_name":"gone","title":null,"updated_at":"2021-06-09T10:10:15.309Z","withdrawn_notice":{},"publishing_request_id":null,"links":{},"description":null,"details":{"explanation":null,"alternative_path":null}}

/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/gds-api-adapters-73.0.0/lib/gds_api/json_client.rb:108:in `rescue in do_json_request'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/gds-api-adapters-73.0.0/lib/gds_api/json_client.rb:96:in `do_json_request'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/gds-api-adapters-73.0.0/lib/gds_api/json_client.rb:52:in `get_json'
/usr/lib/rbenv/versions/2.7.2/lib/ruby/2.7.0/forwardable.rb:235:in `get_json'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/gds-api-adapters-73.0.0/lib/gds_api/content_store.rb:14:in `content_item'
/data/vhost/account-api/releases/20210903125021/lib/message_queue_processor.rb:55:in `redirect_saved_pages'
/data/vhost/account-api/releases/20210903125021/lib/message_queue_processor.rb:20:in `process_message'
/data/vhost/account-api/releases/20210903125021/lib/message_queue_processor.rb:3:in `process'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/govuk_message_queue_consumer-3.5.0/lib/govuk_message_queue_consumer/message_consumer.rb:13:in `block (2 levels) in process'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/govuk_message_queue_consumer-3.5.0/lib/govuk_message_queue_consumer/message_consumer.rb:13:in `select'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/govuk_message_queue_consumer-3.5.0/lib/govuk_message_queue_consumer/message_consumer.rb:13:in `block in process'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/govuk_message_queue_consumer-3.5.0/lib/govuk_message_queue_consumer/message_consumer.rb:9:in `each'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/govuk_message_queue_consumer-3.5.0/lib/govuk_message_queue_consumer/message_consumer.rb:9:in `inject'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/govuk_message_queue_consumer-3.5.0/lib/govuk_message_queue_consumer/message_consumer.rb:9:in `process'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/govuk_message_queue_consumer-3.5.0/lib/govuk_message_queue_consumer/consumer.rb:37:in `block in run'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/bunny-2.17.0/lib/bunny/consumer.rb:56:in `call'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/bunny-2.17.0/lib/bunny/channel.rb:1768:in `block in handle_frameset'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/bunny-2.17.0/lib/bunny/consumer_work_pool.rb:108:in `block (2 levels) in run_loop'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/bunny-2.17.0/lib/bunny/consumer_work_pool.rb:103:in `loop'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/bunny-2.17.0/lib/bunny/consumer_work_pool.rb:103:in `block in run_loop'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/bunny-2.17.0/lib/bunny/consumer_work_pool.rb:102:in `catch'
/data/vhost/account-api/shared/bundle/ruby/2.7.0/gems/bunny-2.17.0/lib/bunny/consumer_work_pool.rb:102:in `run_loop'
```

But this case should be treated the same as a 404: remove the page.