### PR TITLE
Do not store ID token JWT in the session

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -24,7 +24,6 @@ class AuthenticationController < ApplicationController
     render json: {
       govuk_account_session: AccountSession.new(
         session_secret: Rails.application.secrets.session_secret,
-        id_token: details.fetch(:id_token_jwt),
         user_id: details.fetch(:id_token).sub,
         access_token: details.fetch(:access_token),
         refresh_token: details.fetch(:refresh_token),


### PR DESCRIPTION
I think this is making us hit an HTTP header size limit.  The HTTP
spec doesn't define such a limit, but servers commonly have one:
nginx (which we use) is 4KB to 8KB.

With the ID token included, the full session value when I log in on
staging is 2704 bytes.  2KB is a big chunk of a 4KB to 8KB limit.
There are no app errors logged to Sentry, and I can see the
account-api is returning a 200 response to frontend, so the apps
themselves seem to be working - but a 503 error is returned to the
browser.

This doesn't seem to happen on integration.  Maybe DI have smaller ID
tokens than we do?  In any case, the problem on staging isn't
promising, and suggests that even though things are working on
integration we're likely close to a limit.

So I think we'll need to store ID tokens server side.  Which is
unfortunate, as all the other session information is in the cookie.

Anyway, for now we don't *need* the ID token to implement logging out,
so we can just not include it in the session until we figure out how
we're going to handle the storage.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
