### PR TITLE
Make find_or_create OidcUser atomic

### DIFF
--- a/app/controllers/oidc_users_controller.rb
+++ b/app/controllers/oidc_users_controller.rb
@@ -2,7 +2,7 @@ class OidcUsersController < ApplicationController
   OIDC_USER_ATTRIBUTES = %w[email email_verified has_unconfirmed_email].freeze
 
   def update
-    user = OidcUser.find_or_create_by!(sub: params.fetch(:subject_identifier))
+    user = OidcUser.find_or_create_by_sub!(params.fetch(:subject_identifier))
     user.set_local_attributes(params.permit(OIDC_USER_ATTRIBUTES).to_h)
     attributes = user.get_local_attributes(OIDC_USER_ATTRIBUTES)
 

--- a/app/lib/account_session.rb
+++ b/app/lib/account_session.rb
@@ -40,7 +40,7 @@ class AccountSession
   end
 
   def user
-    @user ||= OidcUser.find_or_create_by!(sub: user_id)
+    @user ||= OidcUser.find_or_create_by_sub!(user_id)
   end
 
   def level_of_authentication_as_integer

--- a/app/models/oidc_user.rb
+++ b/app/models/oidc_user.rb
@@ -5,6 +5,12 @@ class OidcUser < ApplicationRecord
 
   validates :sub, presence: true
 
+  def self.find_or_create_by_sub!(sub)
+    find_or_create_by!(sub: sub)
+  rescue ActiveRecord::RecordNotUnique
+    find_by!(sub: sub)
+  end
+
   def get_local_attributes(names = [])
     values = names.index_with do |name|
       in_model = self[name]

--- a/spec/models/oidc_user_spec.rb
+++ b/spec/models/oidc_user_spec.rb
@@ -8,4 +8,23 @@ RSpec.describe OidcUser do
   describe "validations" do
     it { is_expected.to validate_presence_of(:sub) }
   end
+
+  describe "#find_or_create_by_sub!" do
+    let(:sub) { "subject-identifier" }
+
+    it "creates a new user" do
+      expect { described_class.find_or_create_by_sub!(sub) }.to change(described_class, :count).by(1)
+      expect(described_class.find_or_create_by_sub!(sub).sub).to eq(sub)
+    end
+
+    context "when the user already exists" do
+      before { described_class.create!(sub: sub) }
+
+      it "returns the existing model" do
+        old_user = described_class.find_by!(sub: sub)
+        expect { described_class.find_or_create_by_sub!(sub) }.not_to change(described_class, :count)
+        expect(described_class.find_or_create_by_sub!(sub).id).to eq(old_user.id)
+      end
+    end
+  end
 end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -35,7 +35,7 @@ module PactStubHelpers
 end
 
 def oidc_user
-  OidcUser.find_or_create_by(sub: "user-id")
+  OidcUser.find_or_create_by_sub!("user-id")
 end
 
 def url_encode(str)


### PR DESCRIPTION
The `find_or_create_by!` method isn't atomic, it's implemented like
so:

    def self.find_or_create_by!(options)
      find_by(options) || create!(options)
    end

So if two threads do a `find_or_create_by!` concurrently, there's a
race condition.  For `OidcUser`s, we can't end up with duplicate
records, as we always do `find_or_create_by!(sub: ...)`, and there's a
unique index on `sub`.  Instead we just get a `RecordNotUnique` error,
which isn't great.

We've only seen this issue crop up once, so it's pretty rare.  But
it'll likely become more common as we get more active users.  So,
handle the case where the record isn't unique by doing a `find_by!`.

Unfortunately, there isn't a good way to test that the race condition
is fixed.  But, since the error is ultimately coming from the
database (as it's a constraint violation) not Ruby code, and as it
seems a safe assumption that Postgres is thread-safe, I'm confident it
is.

---

[Sentry error](https://sentry.io/organizations/govuk/issues/2651850217/?project=5671868)
