### PR TITLE
Special-case `has_unconfirmed_email` attribute when using DI

### DIFF
--- a/spec/lib/account_session_spec.rb
+++ b/spec/lib/account_session_spec.rb
@@ -114,6 +114,10 @@ RSpec.describe AccountSession do
         expect(account_session.get_attributes([attribute_name1])).to eq({})
       end
 
+      it "handles the 'has_unconfirmed_email' attribute as a special case" do
+        expect(account_session.get_attributes(%w[has_unconfirmed_email])).to eq({ "has_unconfirmed_email" => false })
+      end
+
       context "when the attribute is a LocalAttribute" do
         before do
           LocalAttribute.create!(
@@ -171,6 +175,12 @@ RSpec.describe AccountSession do
           account_session.user.update!(local_attribute_name => local_attribute_value)
           values = account_session.get_attributes([attribute_name1, attribute_name2, local_attribute_name])
           expect(values).to eq({ attribute_name1 => attribute_value1, attribute_name2 => attribute_value2, local_attribute_name => local_attribute_value })
+        end
+
+        it "does not handle the 'has_unconfirmed_email' attribute as a special case" do
+          stub = stub_request(:get, "http://openid-provider/v1/attributes/has_unconfirmed_email")
+          account_session.get_attributes(%w[has_unconfirmed_email])
+          expect(stub).to have_been_made
         end
 
         context "when some attributes are not found" do


### PR DESCRIPTION
DI don't have this attribute, so we never cache a value for it, which
means every page which uses it makes a userinfo request.

That's bad because it adds latency (there's an extra network request
going on) and it imposes a session timeout due to the OAuth access
token expiring (if a user tries to use an invalid token we force them
to reauthenticate).

Since DI do not have users with unconfirmed email addresses, as a
hacky work-around we can hard-code this to false.  When we've migrated
to DI in production *and* removed use of this attribute, we can remove
this special case.

---

[Trello card](https://trello.com/c/ZvDGaba4/958-use-di-auth-in-integration-give-feedback-on-their-documentation)
