### PR TITLE
Fix flaky test

### DIFF
--- a/spec/requests/oidc_users_spec.rb
+++ b/spec/requests/oidc_users_spec.rb
@@ -12,8 +12,7 @@ RSpec.describe "OIDC Users endpoint" do
 
   describe "PUT" do
     before do
-      next_oidc_user_id = ActiveRecord::Base.connection.execute("select last_value from oidc_users_id_seq").first["last_value"] + 1
-      stub_email_alert_api_find_subscriber_by_govuk_account_no_subscriber(next_oidc_user_id)
+      stub_request(:get, %r{\A#{GdsApi::TestHelpers::EmailAlertApi::EMAIL_ALERT_API_ENDPOINT}/subscribers/govuk-account/\d+\z}).to_return(status: 404)
     end
 
     it "creates the user if they do not exist" do


### PR DESCRIPTION
This test very rarely fails with an off-by-one in the user ID
stubbed (eg, the request is for user 1 but the stub is for user 2).  I
assume there's some race condition between one test being cleaned up
and the next test being run.

Reading the postgres counter directly is a bit of a smell though so,
since in these tests we don't care so much about the exact user ID,
just use a regex URL pattern for the stub.

---

Here's an example test failure: https://ci.integration.publishing.service.gov.uk/job/account-api/job/main/187/console
