### PR TITLE
Add a rake task to check if a user exists

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,16 +29,13 @@ group :development, :test do
   gem "factory_bot_rails"
   gem "govuk_schemas"
   gem "govuk_test"
+  gem "listen"
   gem "pact", require: false
   gem "pact_broker-client"
   gem "pry-byebug"
   gem "pry-rails"
   gem "rspec-rails"
   gem "rubocop-govuk"
-end
-
-group :development do
-  gem "listen"
 end
 
 group :test do

--- a/lib/tasks/support.rake
+++ b/lib/tasks/support.rake
@@ -1,0 +1,10 @@
+namespace :support do
+  desc "Check if a user exists for the given email address"
+  task :find_user, [:email] => :environment do |_, args|
+    if OidcUser.find_by("lower(email) = ?", args[:email].downcase)
+      puts "User '#{args[:email]}' exists"
+    else
+      puts "User '#{args[:email]}' does not exist"
+    end
+  end
+end

--- a/spec/lib/support_spec.rb
+++ b/spec/lib/support_spec.rb
@@ -1,0 +1,31 @@
+Rails.application.load_tasks
+
+RSpec.describe "Support tasks" do
+  describe ":find_user" do
+    subject(:task) { Rake.application["support:find_user"] }
+
+    context "when there are no users" do
+      it "outputs the user doesn't exist" do
+        expect { task.execute({ email: "foo@example.gov.uk" }) }.to output("User 'foo@example.gov.uk' does not exist\n").to_stdout
+      end
+    end
+
+    context "when a user with email 'foo@example.gov.uk' exists" do
+      before do
+        FactoryBot.create(:oidc_user, email: "foo@example.gov.uk")
+      end
+
+      it "can find that user by email" do
+        expect { task.execute({ email: "foo@example.gov.uk" }) }.to output("User 'foo@example.gov.uk' exists\n").to_stdout
+      end
+
+      it "outputs other users don't exist" do
+        expect { task.execute({ email: "bar@example.com" }) }.to output("User 'bar@example.com' does not exist\n").to_stdout
+      end
+
+      it "performs a lowercase search for the user" do
+        expect { task.execute({ email: "FOO@Example.Gov.uK" }) }.to output("User 'FOO@Example.Gov.uK' exists\n").to_stdout
+      end
+    end
+  end
+end

--- a/spec/lib/support_spec.rb
+++ b/spec/lib/support_spec.rb
@@ -4,12 +4,6 @@ RSpec.describe "Support tasks" do
   describe ":find_user" do
     subject(:task) { Rake.application["support:find_user"] }
 
-    context "when there are no users" do
-      it "outputs the user doesn't exist" do
-        expect { task.execute({ email: "foo@example.gov.uk" }) }.to output("User 'foo@example.gov.uk' does not exist\n").to_stdout
-      end
-    end
-
     context "when a user with email 'foo@example.gov.uk' exists" do
       before do
         FactoryBot.create(:oidc_user, email: "foo@example.gov.uk")


### PR DESCRIPTION
Look up users by email address to see if they have an account. We have
to do this occasionally, so add a more convenient method than using the
Rails console.

[Trello card](https://trello.com/c/MoyeH1GU/1017-add-a-rake-task-to-check-if-an-account-exists)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
