### PR TITLE
Drop `local_attributes` table

### DIFF
--- a/db/migrate/20210920101003_remove_local_attributes.rb
+++ b/db/migrate/20210920101003_remove_local_attributes.rb
@@ -1,0 +1,14 @@
+class RemoveLocalAttributes < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :local_attributes, %i[oidc_user_id name], unique: true
+
+    drop_table :local_attributes do |t|
+      t.references :oidc_user, null: false
+      t.string     :name,      null: false
+      t.jsonb      :value,     null: false
+      t.boolean    :migrated,  null: false, default: false
+
+      t.timestamps default: -> { "now()" }, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_30_133729) do
+ActiveRecord::Schema.define(version: 2021_09_20_101003) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,17 +32,6 @@ ActiveRecord::Schema.define(version: 2021_07_30_133729) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["oidc_user_id", "name"], name: "index_email_subscriptions_on_oidc_user_id_and_name", unique: true
     t.index ["oidc_user_id"], name: "index_email_subscriptions_on_oidc_user_id"
-  end
-
-  create_table "local_attributes", force: :cascade do |t|
-    t.bigint "oidc_user_id", null: false
-    t.string "name", null: false
-    t.jsonb "value", null: false
-    t.datetime "created_at", precision: 6, default: -> { "now()" }, null: false
-    t.datetime "updated_at", precision: 6, default: -> { "now()" }, null: false
-    t.boolean "migrated", default: false, null: false
-    t.index ["oidc_user_id", "name"], name: "index_local_attributes_on_oidc_user_id_and_name", unique: true
-    t.index ["oidc_user_id"], name: "index_local_attributes_on_oidc_user_id"
   end
 
   create_table "oidc_users", force: :cascade do |t|


### PR DESCRIPTION
The use of this was removed in #185.  This migration is, strictly
speaking, reversible: the data which was in this table was migrated
into the `oidc_users` table by #149.  So we could revert this and
deploy code to pull the data back out if need be.
