### PR TITLE
Remove level of authentication from public API

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -7,12 +7,7 @@ class AuthenticationController < ApplicationController
   def sign_in
     auth_request = AuthRequest.generate!(redirect_path: params[:redirect_path])
 
-    level_of_authentication =
-      if params[:mfa]
-        WITH_MFA_LEVEL_OF_AUTHENTICATION
-      else
-        params.fetch(:level_of_authentication, DEFAULT_LEVEL_OF_AUTHENTICATION)
-      end
+    level_of_authentication = params[:mfa] ? "level1" : "level0"
 
     render json: {
       auth_uri: oidc_client_class.new.auth_uri(auth_request, level_of_authentication),

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -1,9 +1,6 @@
 class AuthenticationController < ApplicationController
   include DigitalIdentityHelper
 
-  DEFAULT_LEVEL_OF_AUTHENTICATION = "level0".freeze
-  WITH_MFA_LEVEL_OF_AUTHENTICATION = "level1".freeze
-
   def sign_in
     auth_request = AuthRequest.generate!(redirect_path: params[:redirect_path])
 
@@ -32,7 +29,7 @@ class AuthenticationController < ApplicationController
         user_id: details.fetch(:id_token).sub,
         access_token: details.fetch(:access_token),
         refresh_token: details[:refresh_token],
-        level_of_authentication: details.fetch(:level_of_authentication),
+        mfa: details.fetch(:mfa),
       ).serialise,
       redirect_path: redirect_path,
       ga_client_id: details[:ga_session_id],
@@ -61,7 +58,7 @@ private
   # before we can migrate production.
   def get_level_of_authentication_and_suchlike(client, tokens)
     if using_digital_identity?
-      tokens.merge(level_of_authentication: "level1")
+      tokens.merge(mfa: true)
     else
       oauth_response = client.get_ephemeral_state(
         access_token: tokens[:access_token],
@@ -71,7 +68,7 @@ private
       tokens.merge(
         access_token: oauth_response.fetch(:access_token),
         refresh_token: oauth_response.fetch(:refresh_token),
-        level_of_authentication: oauth_response.fetch(:result).fetch("level_of_authentication"),
+        mfa: oauth_response.fetch(:result).fetch("level_of_authentication") == "level1",
         ga_session_id: oauth_response.fetch(:result)["_ga"],
         cookie_consent: oauth_response.fetch(:result)["cookie_consent"],
       )

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -11,7 +11,6 @@ class UserController < ApplicationController
       {
         id: @govuk_account_session.user.id.to_s,
         mfa: @govuk_account_session.mfa?,
-        level_of_authentication: @govuk_account_session.level_of_authentication,
         email: attributes.dig("email", :value),
         email_verified: attributes.dig("email_verified", :value),
         has_unconfirmed_email: has_unconfirmed_email,

--- a/docs/api.md
+++ b/docs/api.md
@@ -86,9 +86,6 @@ This URL should be served to the user with a 302 response to authenticate the us
 
 #### Query parameters
 
-- `level_of_authentication` *(optional)* *(deprecated)*
-  - either `level1` (require MFA) or `level0` (do not require MFA, the default)
-  - this will be replaced by `mfa`
 - `mfa` *(optional)*
   - either `true` (require MFA) or `false` (do not require MFA, the default)
 - `redirect_path` *(optional)*
@@ -228,9 +225,6 @@ Retrieves the information needed to render the `/account/home` page.
   - the user identifier
 - `mfa`
   - `true` if the user has authenticated with MFA, `false` otherwise
-- `level_of_authentication` *(deprecated)*
-  - the user's current level of authentication (`level0` or `level1`)
-  - this will be replaced by `mfa`
 - `email`
   - the user's current email address
 - `email_verified`
@@ -263,7 +257,6 @@ Response:
 {
     "id": "some-user-identifier",
     "mfa": false,
-    "level_of_authentication": "level0",
     "email": "email@example.com",
     "email_verified": false,
     "services": {

--- a/spec/requests/attributes_spec.rb
+++ b/spec/requests/attributes_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe "Attributes" do
   end
 
   let(:session_identifier) { account_session.serialise }
-  let(:account_session) { placeholder_govuk_account_session_object(level_of_authentication: "level1") }
+  let(:account_session) { placeholder_govuk_account_session_object(mfa: mfa) }
+  let(:mfa) { true }
   let(:headers) { { "Content-Type" => "application/json", "GOVUK-Account-Session" => session_identifier } }
 
   # names must be defined in spec/fixtures/user_attributes.yml
@@ -71,7 +72,7 @@ RSpec.describe "Attributes" do
     end
 
     context "when the user tries to get a protected attribute without having done MFA" do
-      let(:session_identifier) { placeholder_govuk_account_session(level_of_authentication: "level0") }
+      let(:mfa) { false }
       let(:attribute_name1) { "transition_checker_state" }
 
       it "returns a 403" do
@@ -258,7 +259,7 @@ RSpec.describe "Attributes" do
     end
 
     context "when the user tries to set a protected attribute without having done MFA" do
-      let(:session_identifier) { placeholder_govuk_account_session(level_of_authentication: "level0") }
+      let(:mfa) { false }
       let(:attributes) { { local_attribute_name => local_attribute_value } }
 
       it "returns a 403" do

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -32,11 +32,6 @@ RSpec.describe "User information endpoint" do
     expect(response_body["id"]).to eq(session_identifier.user.id.to_s)
   end
 
-  it "returns the user's level of authentication" do
-    get "/api/user", headers: headers
-    expect(response_body["level_of_authentication"]).to eq(session_identifier.level_of_authentication)
-  end
-
   it "returns whether the user has done MFA" do
     get "/api/user", headers: headers
     expect(response_body["mfa"]).to eq(session_identifier.mfa?)

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe "User information endpoint" do
     stub_userinfo(attributes)
   end
 
-  let(:session_identifier) { placeholder_govuk_account_session_object(level_of_authentication: level_of_authentication) }
+  let(:session_identifier) { placeholder_govuk_account_session_object(mfa: mfa) }
   let(:headers) { { "Content-Type" => "application/json", "GOVUK-Account-Session" => session_identifier&.serialise }.compact }
-  let(:level_of_authentication) { "level0" }
+  let(:mfa) { false }
 
   let(:attributes) do
     {
@@ -59,8 +59,8 @@ RSpec.describe "User information endpoint" do
         expect(service_state).to eq("yes_but_must_reauthenticate")
       end
 
-      context "when the user is logged in at level1" do
-        let(:level_of_authentication) { "level1" }
+      context "when the user is logged in with MFA" do
+        let(:mfa) { true }
 
         it "returns 'yes'" do
           get "/api/user", headers: headers

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -84,7 +84,7 @@ Pact.provider_states_for "GDS API Adapters" do
 
     account_session = placeholder_govuk_account_session_object(
       user_id: oidc_user.sub,
-      level_of_authentication: "level1",
+      mfa: true,
     )
     allow(AccountSession).to receive(:deserialise).and_return(account_session)
 

--- a/spec/support/helpers/govuk_account_session_helper.rb
+++ b/spec/support/helpers/govuk_account_session_helper.rb
@@ -11,7 +11,7 @@ module GovukAccountSessionHelper
         user_id: "user-id",
         access_token: "access-token",
         refresh_token: "refresh-token",
-        level_of_authentication: AccountSession::LOWEST_LEVEL_OF_AUTHENTICATION,
+        mfa: false,
       }.merge(options),
     )
   end


### PR DESCRIPTION
Also, since we're no longer exposing this in the public API, we don't need to store it in the session any more, and can just store an MFA flag.

---

[Trello card](https://trello.com/c/ZvDGaba4/958-use-di-auth-in-integration-give-feedback-on-their-documentation)