### PR TITLE
Fix interpreting ?mfa=false as truthy & add test

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -4,7 +4,7 @@ class AuthenticationController < ApplicationController
   def sign_in
     auth_request = AuthRequest.generate!(redirect_path: params[:redirect_path])
 
-    level_of_authentication = params[:mfa] ? "level1" : "level0"
+    level_of_authentication = params[:mfa] == "true" ? "level1" : "level0"
 
     render json: {
       auth_uri: oidc_client_class.new.auth_uri(auth_request, level_of_authentication),

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -38,6 +38,14 @@ RSpec.describe "Authentication" do
         expect(JSON.parse(response.body)["auth_uri"]).not_to include("level1")
       end
 
+      context "when mfa: false is given" do
+        it "passes 'level0' to the account manager" do
+          get sign_in_path, params: { mfa: false }
+          expect(JSON.parse(response.body)["auth_uri"]).to include("level0")
+          expect(JSON.parse(response.body)["auth_uri"]).not_to include("level1")
+        end
+      end
+
       context "when mfa: true is given" do
         it "passes 'level1' to the account manager" do
           get sign_in_path, params: { mfa: true }


### PR DESCRIPTION
This parameter is passed as a GET parameter, not a JSON POST
parameter, so it's decoded to the string `"false"` (which is truthy)
rather than the value `false`.
