### PR TITLE
Add `legacy_sub` field to `OidcUser`

### DIFF
--- a/app/models/oidc_user.rb
+++ b/app/models/oidc_user.rb
@@ -4,7 +4,9 @@ class OidcUser < ApplicationRecord
   validates :sub, presence: true
 
   def self.find_or_create_by_sub!(sub)
-    find_or_create_by!(sub: sub)
+    find_or_create_by!(sub: sub) do |new_user|
+      new_user.legacy_sub = sub
+    end
   rescue ActiveRecord::RecordNotUnique
     find_by!(sub: sub)
   end

--- a/db/migrate/20210930103307_add_legacy_sub_to_oidc_user.rb
+++ b/db/migrate/20210930103307_add_legacy_sub_to_oidc_user.rb
@@ -1,0 +1,5 @@
+class AddLegacySubToOidcUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :oidc_users, :legacy_sub, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_27_145856) do
+ActiveRecord::Schema.define(version: 2021_09_30_103307) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 2021_09_27_145856) do
     t.boolean "has_unconfirmed_email"
     t.boolean "oidc_users"
     t.jsonb "transition_checker_state"
+    t.string "legacy_sub"
     t.index ["sub"], name: "index_oidc_users_on_sub", unique: true
   end
 

--- a/spec/models/oidc_user_spec.rb
+++ b/spec/models/oidc_user_spec.rb
@@ -8,16 +8,25 @@ RSpec.describe OidcUser do
 
     it "creates a new user" do
       expect { described_class.find_or_create_by_sub!(sub) }.to change(described_class, :count).by(1)
-      expect(described_class.find_or_create_by_sub!(sub).sub).to eq(sub)
+    end
+
+    it "saves the sub and legacy_sub" do
+      user = described_class.find_or_create_by_sub!(sub)
+      expect(user.sub).to eq(sub)
+      expect(user.legacy_sub).to eq(sub)
     end
 
     context "when the user already exists" do
-      before { described_class.create!(sub: sub) }
+      let!(:user) { described_class.create!(sub: sub) }
 
       it "returns the existing model" do
-        old_user = described_class.find_by!(sub: sub)
         expect { described_class.find_or_create_by_sub!(sub) }.not_to change(described_class, :count)
-        expect(described_class.find_or_create_by_sub!(sub).id).to eq(old_user.id)
+        expect(described_class.find_or_create_by_sub!(sub).id).to eq(user.id)
+      end
+
+      it "doesn't change the legacy_sub" do
+        user.update!(legacy_sub: "some-other-value")
+        expect { described_class.find_or_create_by_sub!(sub) }.not_to change(user, :legacy_sub)
       end
     end
   end


### PR DESCRIPTION
This commit adds the column and starts saving values for new users.
There will be a follow-up migration to copy over values for existing
users, make the column non-null, and add a unique index.

To handle the change in subject identifiers when we switch to DI,
we'll look up users like so:

```ruby
def self.find_or_create_by_sub!(sub:, legacy_sub:)
  transaction do
    user = OidcUser.find_by(sub: sub)
    return user if user

    user = OidcUser.find_by(legacy_sub: legacy_sub)
    if user
      user.update!(sub: sub)
      return user
    end

    OidcUser.create!(sub: sub, legacy_sub: legacy_sub)
  end
end
```

Pre-DI migration, `sub` and `legacy_sub` will always be the same.

Post-DI migration, the only ambiguous case is when decoding a session:
is the sub in the session old or new?  We'll solve that with the card
to add a version field: we can have a new version for
session-with-DI-sub, and then we know if we get an older session we
need to call the DI userinfo endpoint to look up the new one.

---

[Trello card](https://trello.com/c/eRBL2kEZ/1050-implement-migration-of-subject-identifiers)
