### PR TITLE
Populate `legacy_sub`, add an index, and partially implement user migration

### DIFF
--- a/app/lib/account_session.rb
+++ b/app/lib/account_session.rb
@@ -18,6 +18,18 @@ class AccountSession
     @frozen = false
 
     @user_id = user_id || userinfo["sub"]
+
+    # TODO: When we have session versioning, and when we know what the
+    # DI claim will be for the legacy sub, implement upgrading the old
+    # session and user record.  The logic will be something like:
+    #
+    # if using_digital_identity? && this is a pre-migration session
+    #   @user = OidcUser.find_or_create_by_sub!(userinfo["sub"], legacy_sub: userinfo["legacy_sub"])
+    #   @user_id = @user.sub
+    # end
+    #
+    # then the use of `legacy_sub` can be removed from the `user`
+    # method.
   end
 
   def self.deserialise(encoded_session:, session_secret:)
@@ -40,7 +52,7 @@ class AccountSession
   end
 
   def user
-    @user ||= OidcUser.find_or_create_by_sub!(user_id)
+    @user ||= OidcUser.find_or_create_by_sub!(user_id, legacy_sub: user_id)
   end
 
   def mfa?

--- a/db/migrate/20210930105948_populate_legacy_sub_and_create_index.rb
+++ b/db/migrate/20210930105948_populate_legacy_sub_and_create_index.rb
@@ -1,0 +1,21 @@
+class PopulateLegacySubAndCreateIndex < ActiveRecord::Migration[6.1]
+  def up
+    OidcUser.update_all("legacy_sub = sub")
+
+    # The SQL standard (and, more relevantly to us, Postgres) allows a
+    # nullable field with a unique index to have multiple NULL values.
+    # This lets us enforce our desired correctness constraint:
+    #
+    # sub      | legacy_sub | meaning
+    # -------- | ---------- | -------
+    # NULL     | NULL       | invalid - sub is not nullable
+    # NULL     | not NULL   | invalid - sub is not nullable
+    # not NULL | NULL       | user was created post-migration
+    # not NULL | not NULL   | user was created pre-migration, and has a unique legacy_sub
+    add_index :oidc_users, :legacy_sub, unique: true
+  end
+
+  def down
+    remove_index :oidc_users, :legacy_sub
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_30_103307) do
+ActiveRecord::Schema.define(version: 2021_09_30_105948) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(version: 2021_09_30_103307) do
     t.boolean "oidc_users"
     t.jsonb "transition_checker_state"
     t.string "legacy_sub"
+    t.index ["legacy_sub"], name: "index_oidc_users_on_legacy_sub", unique: true
     t.index ["sub"], name: "index_oidc_users_on_sub", unique: true
   end
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -506,6 +506,8 @@ This endpoint requires the `update_protected_attributes` scope.
 
 #### JSON request parameters
 
+- `legacy_sub` *(optional)*
+  - if this is a user created pre-migration, their original subject identifier (a string)
 - `email`
   - the new email address (a string)
 - `email_verified`
@@ -558,6 +560,11 @@ Delete an account by subject identifier.  This endpoint requires the
 
 - `subject_identifier`
   - the subject identifier of the user to delete
+
+#### Query parameters
+
+- `legacy_sub` *(optional)*
+  - if this is a user created pre-migration, their original subject identifier (a string)
 
 #### Response codes
 

--- a/spec/models/oidc_user_spec.rb
+++ b/spec/models/oidc_user_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe OidcUser do
     end
 
     context "when the user already exists" do
-      let!(:user) { described_class.create!(sub: sub) }
+      let!(:user) { FactoryBot.create(:oidc_user, sub: sub) }
 
       it "returns the existing model" do
         expect { described_class.find_or_create_by_sub!(sub) }.not_to change(described_class, :count)

--- a/spec/requests/oidc_users_spec.rb
+++ b/spec/requests/oidc_users_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "OIDC Users endpoint" do
     end
 
     context "when the user already exists" do
-      let!(:user) { OidcUser.create!(sub: subject_identifier) }
+      let!(:user) { FactoryBot.create(:oidc_user, sub: subject_identifier) }
 
       it "does not create a new user" do
         expect { put oidc_user_path(subject_identifier: subject_identifier), params: params, headers: headers }.not_to change(OidcUser, :count)
@@ -95,7 +95,7 @@ RSpec.describe "OIDC Users endpoint" do
 
   describe "DELETE" do
     context "when the user exists" do
-      before { OidcUser.create!(sub: subject_identifier) }
+      before { FactoryBot.create(:oidc_user, sub: subject_identifier) }
 
       it "deletes the user" do
         expect { delete oidc_user_path(subject_identifier: subject_identifier), params: params, headers: headers }.to change(OidcUser, :count).by(-1)


### PR DESCRIPTION
After writing the commit message of b193159, I realised that we don't
actually want this column to be non-nullable.  Because,
post-migration, we will want to create users who have a `sub` but not
a `legacy_sub`.

Usefully, SQL allows multiple NULL values in a nullable field which
has a unique index.  I imagine this is because NULLs are incomparable
in SQL (both `NULL = NULL` and `NULL != NULL` are false).

The change to `OidcUsersController` will let us update or delete users
by legacy subject identifier.  When updating a user, we'll also save the
new subject identifier.  This will gradually migrate our data as people
update their account.

We will also need to implement user migration in the `AccountSession`,
but there are some prerequisites (noted in a comment).