### PR TITLE
Set `legacy_sub` when creating a user to update

### DIFF
--- a/app/controllers/oidc_users_controller.rb
+++ b/app/controllers/oidc_users_controller.rb
@@ -6,7 +6,7 @@ class OidcUsersController < ApplicationController
   def update
     user = OidcUser.find_or_create_by_sub!(
       params.fetch(:subject_identifier),
-      legacy_sub: using_digital_identity? ? params[:legacy_sub] : nil,
+      legacy_sub: using_digital_identity? ? params[:legacy_sub] : params.fetch(:subject_identifier),
     )
 
     user.update!(params.permit(OIDC_USER_ATTRIBUTES).to_h)


### PR DESCRIPTION
If a user signs up and then confirms their email address before
returning to GOV.UK, this endpoint will create the user record.
Pre-migration, we need to record the sub as the `legacy_sub` in this
case.

---

[Trello card](https://trello.com/c/eRBL2kEZ/1050-implement-migration-of-subject-identifiers)
