### PR TITLE
Delete subscription on address change if subscriber list is missing

### DIFF
--- a/app/controllers/oidc_users_controller.rb
+++ b/app/controllers/oidc_users_controller.rb
@@ -36,7 +36,11 @@ class OidcUsersController < ApplicationController
         # this branch can be removed once we have no GOV.UK accounts
         # which have subscriptions but are *not* linked to the
         # corresponding notifications account.
-        user.email_subscriptions.each(&:reactivate_if_confirmed!)
+        user.email_subscriptions.find_each do |subscription|
+          subscription.reactivate_if_confirmed!
+        rescue EmailSubscription::SubscriberListNotFound
+          subscription.destroy!
+        end
       end
     end
 

--- a/spec/requests/oidc_users_spec.rb
+++ b/spec/requests/oidc_users_spec.rb
@@ -112,6 +112,17 @@ RSpec.describe "OIDC Users endpoint" do
           expect(stub_fetch_topic).to have_been_made
           expect(stub_create_new).to have_been_made
         end
+
+        context "when the subscriber list has been deleted from email-alert-api" do
+          before do
+            stub_email_alert_api_does_not_have_subscriber_list_by_slug(slug: "slug")
+          end
+
+          it "deletes the subscription" do
+            stub_email_alert_api_unsubscribes_a_subscription("prior-subscription-id")
+            expect { put oidc_user_path(subject_identifier: subject_identifier), params: params, headers: headers }.to change(EmailSubscription, :count).by(-1)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
If all users unsubscribe from a topic through email-alert-frontend,
after 7 days email-alert-api will delete the subscriber list.  This
will make future attempts to use that same list by slug return a 404.

Currently we don't catch these 404s, so when they happen we return a
500 error from this endpoint.  Subscriber lists usually don't go away
that often but, for the brexit checker, there are many one-user lists;
so brexit lists do go away a bit more often than other lists.

---

[Sentry error](https://sentry.io/organizations/govuk/issues/2557697861/events/latest/?project=5671868)
