### PR TITLE
Fix "booleam" typo

### DIFF
--- a/db/migrate/20211013084845_add_cookie_and_feedback_consent_to_oidc_user.rb
+++ b/db/migrate/20211013084845_add_cookie_and_feedback_consent_to_oidc_user.rb
@@ -1,7 +1,7 @@
 class AddCookieAndFeedbackConsentToOidcUser < ActiveRecord::Migration[6.1]
   def change
     change_table :oidc_users, bulk: true do |t|
-      t.booleam :cookie_consent, null: true
+      t.boolean :cookie_consent, null: true
       t.boolean :feedback_consent, null: true
     end
   end


### PR DESCRIPTION
I initially wrote this migration as two separate column creations and
ran it, then when making the PR switched to the `change_table` form
because of rubocop - and then didn't re-run the migration to check.
