### PR TITLE
Version Account Sessions

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -28,6 +28,7 @@ class AuthenticationController < ApplicationController
       refresh_token: details[:refresh_token],
       mfa: details.fetch(:mfa),
       digital_identity_session: using_digital_identity?,
+      version: AccountSession::CURRENT_VERSION,
     )
 
     render json: {

--- a/spec/support/helpers/govuk_account_session_helper.rb
+++ b/spec/support/helpers/govuk_account_session_helper.rb
@@ -13,6 +13,7 @@ module GovukAccountSessionHelper
         refresh_token: "refresh-token",
         mfa: false,
         digital_identity_session: true,
+        version: AccountSession::CURRENT_VERSION,
       }.merge(options),
     )
   end


### PR DESCRIPTION
[Trello](https://trello.com/c/RZaqXBLI/1039-add-a-version-field-to-the-account-session-cookie)

We will occasionally add or remove things from the session cookie as our needs change.  But we also want to retain backwards compatibility, rather than force everyone to reauthenticate whenever we change something.  So we need to be able to upgrade old sessions.

Upgrading is much easier if you know exactly what you have to upgrade, rather than having to infer it based on the presence or absence of individual fields.