### PR TITLE
Fix a bug and a performance issue with email subscriptions and OidcUsers

### DIFF
--- a/app/controllers/oidc_users_controller.rb
+++ b/app/controllers/oidc_users_controller.rb
@@ -9,10 +9,13 @@ class OidcUsersController < ApplicationController
       legacy_sub: using_digital_identity? ? params[:legacy_sub] : params.fetch(:subject_identifier),
     )
 
+    email_changed = params.key?(:email) && (params[:email] != user.email)
+    email_verified_changed = params.key?(:email_verified) && params[:email_verified] != user.email_verified
+
     user.update!(params.permit(OIDC_USER_ATTRIBUTES).to_h)
     user.reload
 
-    if user.email && user.email_verified
+    if (email_changed || email_verified_changed) && user.email && user.email_verified
       begin
         # if the user has linked their notifications account to their
         # GOV.UK account we don't need to update their

--- a/spec/requests/oidc_users_spec.rb
+++ b/spec/requests/oidc_users_spec.rb
@@ -130,6 +130,15 @@ RSpec.describe "OIDC Users endpoint" do
           expect(stub_create_new).to have_been_made
         end
 
+        context "when the email and email_verified attributes have not changed" do
+          let(:email) { user.email }
+          let(:email_verified) { user.email_verified }
+
+          it "does not make any requests to email-alert-api" do
+            put oidc_user_path(subject_identifier: subject_identifier), params: params, headers: headers
+          end
+        end
+
         context "when the subscriber list has been deleted from email-alert-api" do
           before do
             stub_email_alert_api_does_not_have_subscriber_list_by_slug(slug: "slug")


### PR DESCRIPTION
Yesterday we ran a data migration which made a load of requests to the `PUT /api/oidc-users` endpoint.  This revealed a bug: the endpoint *always* reactivates subscriptions, even if they have been deactivated in email-alert-frontend!

The root cause is that we can have `EmailSubscription` records in our database which correspond to deactivated subscriptions, and we don't check whether they're still active before assuming they should be.

So, when updating a user, check:

1. Do we think the subscription is already active?
2. If so, *is it*?
3. Either reactivate or delete it.

This PR also introduces a performance improvement: for updates which don't touch the email attributes, we don't need to reactivate the subscription, as nothing has changed.  In fact, having this change in place would have prevented the bug from surfacing yesterday; though on the other hand, it's good that we found it while it affects only a few users (I can only see two such inappropriately-reactivated subscriptions).