### PR TITLE
Personalisation route

### DIFF
--- a/app/controllers/check_email_subscription_controller.rb
+++ b/app/controllers/check_email_subscription_controller.rb
@@ -1,0 +1,46 @@
+require "gds_api/email_alert_api"
+
+class CheckEmailSubscriptionController < ApplicationController
+  include GovukPersonalisation::ControllerConcern
+
+  skip_before_action :authorise_sso_user!
+
+  before_action do
+    @govuk_account_session = AccountSession.deserialise(
+      encoded_session: @account_session_header,
+      session_secret: Rails.application.secrets.session_secret,
+    )
+
+    unless @govuk_account_session
+      logout_and_401
+    end
+  end
+
+  rescue_from OidcClient::OAuthFailure do
+    logout_and_401
+  end
+
+  def show
+    sub = GdsApi.email_alert_api.find_subscriber_by_govuk_account(govuk_account_id: @govuk_account_session.user.id).to_hash.dig("subscriber", "id")
+    subscriptions = GdsApi.email_alert_api.get_subscriptions(id: sub).to_hash.fetch("subscriptions")
+    is_active = subscriptions.find { |subscription| subscription.dig("subscriber_list", "slug") == params["topic_slug"] }.present?
+
+    render json: response_json(active: is_active)
+  rescue GdsApi::HTTPNotFound
+    render json: response_json
+  end
+
+private
+
+  def logout_and_401
+    logout!
+    head :unauthorized
+  end
+
+  def response_json(active: false)
+    {
+      topic_slug: params[:topic_slug],
+      active: active,
+    }
+  end
+end

--- a/app/controllers/check_email_subscription_controller.rb
+++ b/app/controllers/check_email_subscription_controller.rb
@@ -14,6 +14,8 @@ class CheckEmailSubscriptionController < ApplicationController
     unless @govuk_account_session
       logout_and_401
     end
+
+    set_no_cache_headers
   end
 
   rescue_from OidcClient::OAuthFailure do
@@ -31,6 +33,10 @@ class CheckEmailSubscriptionController < ApplicationController
   end
 
 private
+
+  def set_no_cache_headers
+    response.headers["Cache-Control"] = "no-store"
+  end
 
   def logout_and_401
     logout!

--- a/config/content_items.yml
+++ b/config/content_items.yml
@@ -28,3 +28,8 @@ special_routes:
     base_path: "/account/cookies-and-feedback"
     title: "Cookie and feedback settings"
     rendering_app: "frontend"
+  - content_id: "f8f91a56-2298-4365-9590-d7e80fe8c066"
+    base_path: "/api/personalisation/check-email-subscription"
+    title: "Account API - Check email Subscription"
+    description: "Personalisation API exposing email subscription data for progressive enhancement of GOV.UK pages"
+    rendering_app: "account-api"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,5 +21,9 @@ Rails.application.routes.draw do
     patch "/attributes", to: "attributes#update"
 
     resources :email_subscriptions, only: %i[show update destroy], param: :subscription_name, path: "email-subscriptions"
+
+    scope :personalisation do
+      get "check-email-subscription", to: "check_email_subscription#show", as: :check_email_subscription
+    end
   end
 end

--- a/docs/api.md
+++ b/docs/api.md
@@ -20,6 +20,7 @@ management. This API is not for other government services.
   - [`DELETE /api/email-subscriptions/:subscription_name`](#delete-apiemail-subscriptionssubscription_name)
   - [`PUT /api/oidc-users/:subject_identifier`](#put-apioidc-userssubject_identifier)
   - [`DELETE /api/oidc-users/:subject_identifier`](#delete-apioidc-userssubject_identifier)
+  - [`GET /api/personalisation/check-email-subscription/:topic_slug`](#get-apipersonalisationcheck-email-subscriptiontopic_slug)
 - [API errors](#api-errors)
   - [MFA required](#mfa-required)
   - [Unknown attribute names](#unknown-attribute-names)
@@ -592,6 +593,55 @@ GdsApi.account_api.delete_user_by_subject_identifier(
 ```
 
 Response is status code only.
+
+### `GET /api/personalisation/check-email-subscription/:topic_slug`
+
+Personalisation endpoint for checking if an email subscription is active.
+
+Currently this returns a simple JSON response.
+
+Future iterations may see this endpoint return rendered HTML to progressively enhance our frontend applications.
+
+See [Progressive enhancement ADR for more details](/docs/adr/002-progressive-enhancement.md)
+
+#### Request parameters
+- `subject_identifier`
+  - the subject identifier from a user session
+
+#### Query parameters
+
+- `topic_slug`
+  - the email-alert-api topic slug
+
+#### JSON response fields
+
+- `topic_slug`
+  - the email-alert-api topic slug (a string)
+- `active`
+  - If the subscription is active (a boolean)
+
+#### Response codes
+
+- 401 if the session identifier is invalid
+- 200 otherwise
+
+#### Example request / response
+
+Note: This endpoint is not included in the GDS API Adaptors wrappers.
+As a personalisation endpoint, it allows us to progressively enhance pages from client side requests.
+
+To test the endpoint with curl:
+
+```
+curl -H "GOVUK-Account-Session={{account_session_header}}" "{{GOV.UK environment}}/api/personalisation/check-email-subscription?topic_slug=example-topic-slug"
+```
+
+```json
+{
+    "topic_slug": "example-topic-slug",
+    "active": true
+}
+```
 
 ## API errors
 

--- a/spec/requests/check_email_subscription_spec.rb
+++ b/spec/requests/check_email_subscription_spec.rb
@@ -1,0 +1,82 @@
+require "gds_api/test_helpers/account_api"
+require "gds_api/test_helpers/email_alert_api"
+require "govuk_personalisation/test_helpers/requests"
+
+RSpec.describe "Personalisation - Check Email Subscription" do
+  include GdsApi::TestHelpers::AccountApi
+  include GdsApi::TestHelpers::EmailAlertApi
+  include GovukPersonalisation::TestHelpers::Requests
+
+  describe "GET /api/personalisation/check-email-subscription" do
+    let(:topic_slug) { "topic_slug" }
+
+    it "returns 401" do
+      get check_email_subscription_path(topic_slug: topic_slug)
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    context "with an autenticated session" do
+      let(:subscription_status_details) do
+        {
+          "topic_slug": topic_slug,
+          "active": subscription_active,
+        }.to_json
+      end
+
+      let(:subscription_active) { false }
+
+      let(:oidc_user) { FactoryBot.create(:oidc_user) }
+      let(:sub) { oidc_user.sub }
+      let(:subscriber_id) { 42 }
+      let(:subscriptions) do
+        [
+          {
+            "id" => subscriber_id,
+            "created_at" => "2019-09-16 02:08:08 01:00",
+            "subscriber_list" => { "title" => "Some thing", "slug" => topic_slug },
+          },
+        ]
+      end
+      let(:session_identifier) { placeholder_govuk_account_session_object(user_id: sub, mfa: false) }
+      let(:headers) { { "Content-Type" => "application/json", "GOVUK-Account-Session" => session_identifier&.serialise }.compact }
+
+      it "logs the user out if the session is invalid" do
+        get check_email_subscription_path, headers: { "GOVUK-Account-Session" => "not-a-base64-string" }
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      context "when the user has linked their notifications account" do
+        before { stub_email_alert_api_find_subscriber_by_govuk_account(oidc_user.id, subscriber_id, "test@example.com") }
+
+        context "when the topic_slug matches an active subscription" do
+          before { stub_email_alert_api_has_subscriber_subscriptions(subscriber_id, "test@example.com", subscriptions: subscriptions) }
+
+          let(:subscription_active) { true }
+
+          it "returns subscription status details as active" do
+            get check_email_subscription_path(topic_slug: topic_slug), headers: headers
+            expect(response.body).to eq(subscription_status_details)
+          end
+        end
+
+        context "when the topic_slug does not match an active subscription" do
+          before { stub_email_alert_api_does_not_have_subscriber_subscriptions(subscriber_id) }
+
+          it "returns subscription status details as not active" do
+            get check_email_subscription_path(topic_slug: topic_slug), headers: headers
+            expect(response.body).to eq(subscription_status_details)
+          end
+        end
+      end
+
+      context "when the user has not linked their notifications account" do
+        before { stub_email_alert_api_find_subscriber_by_govuk_account_no_subscriber(oidc_user.id) }
+
+        it "returns subscription status details as not active" do
+          get check_email_subscription_path(topic_slug: topic_slug), headers: headers
+          expect(response.body).to eq(subscription_status_details)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Trello](https://trello.com/c/4kqU5mjD/1051-add-public-endpoint-to-account-api-to-check-if-the-current-user-has-a-subscription)

Add a personalisation endpoint in prepartion of our progressive enhancement features, it will allow a logged in user to gain a minimal amount of information about email subscriptions so that we can vary front ends.

Have separated the commits for ease of review, will squash down to a single commit when it comes out of draft.
