### PR TITLE
Make cookie & feedback consent attributes writable

### DIFF
--- a/config/user_attributes.yml
+++ b/config/user_attributes.yml
@@ -13,11 +13,9 @@ has_unconfirmed_email:
 
 cookie_consent:
   type: local
-  writable: false
 
 feedback_consent:
   type: local
-  writable: false
 
 transition_checker_state:
   type: local


### PR DESCRIPTION
The account-manager is no longer updating these attributes, so we can
safely update them here.

---

[Trello card](https://trello.com/c/oybk0a6f/1074-switch-over-production-to-use-di-auth)
