### PR TITLE
Reduce sidekiq concurrency to 2

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,5 @@
 ---
+:concurrency: 2
 :logfile: ./log/sidekiq.json.log
 
 :queues:


### PR DESCRIPTION
We only use sidekiq currently to delete old `AuthRequest`s, we don't
need the default of 10 workers.  By reducing this, we'll reduce the
memory usage on the machine, and let us increase the number of unicorn
workers.
