### PR TITLE
Fix name of legacy subject ID attribute

### DIFF
--- a/app/lib/oidc_client.rb
+++ b/app/lib/oidc_client.rb
@@ -41,7 +41,7 @@ class OidcClient
 
     unless OidcUser.where(sub: tokens[:id_token].sub).exists?
       response = userinfo(access_token: tokens[:access_token], refresh_token: tokens[:refresh_token])
-      OidcUser.find_or_create_by_sub!(tokens[:id_token].sub, legacy_sub: response.dig(:result, "govuk-account"))
+      OidcUser.find_or_create_by_sub!(tokens[:id_token].sub, legacy_sub: response.dig(:result, "legacy_subject_id"))
       tokens.merge!(
         access_token: response.fetch(:access_token),
         refresh_token: response[:refresh_token],

--- a/spec/lib/oidc_client_spec.rb
+++ b/spec/lib/oidc_client_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe OidcClient do
     it "calls userinfo to fetch the legacy sub and creates the user model" do
       stub = stub_request(:get, "http://openid-provider/userinfo-endpoint")
         .with(headers: { Authorization: "Bearer access-token" })
-        .to_return(status: 200, body: { "govuk-account" => "legacy-sub" }.to_json)
+        .to_return(status: 200, body: { "legacy_subject_id" => "legacy-sub" }.to_json)
 
       expect { client.callback(AuthRequest.generate!, "code") }.to change(OidcUser, :count).by(1)
 
@@ -33,7 +33,7 @@ RSpec.describe OidcClient do
       it "calls userinfo to fetch the legacy sub and updates the user model" do
         stub = stub_request(:get, "http://openid-provider/userinfo-endpoint")
           .with(headers: { Authorization: "Bearer access-token" })
-          .to_return(status: 200, body: { "govuk-account" => "legacy-sub" }.to_json)
+          .to_return(status: 200, body: { "legacy_subject_id" => "legacy-sub" }.to_json)
 
         expect { client.callback(AuthRequest.generate!, "code") }.not_to change(OidcUser, :count)
 
@@ -49,7 +49,7 @@ RSpec.describe OidcClient do
       it "does not call userinfo" do
         stub = stub_request(:get, "http://openid-provider/userinfo-endpoint")
           .with(headers: { Authorization: "Bearer access-token" })
-          .to_return(status: 200, body: { "govuk-account" => "legacy-sub" }.to_json)
+          .to_return(status: 200, body: { "legacy_subject_id" => "legacy-sub" }.to_json)
 
         expect { client.callback(AuthRequest.generate!, "code") }.not_to change(OidcUser, :count)
 


### PR DESCRIPTION
It's called `legacy_subject_id`, not `govuk-account`.  A userinfo
request for my user looks like this:

    { "sub" => "new subject id"
    , "email" => "michael.s.walker@..."
    , "email_verified" => true
    , "legacy_subject_id" => "current subject id"
    }

---

[Trello card](https://trello.com/c/oybk0a6f/1074-switch-over-production-to-use-di-auth)
