### PR TITLE
Always accept legacy_sub parameter in `OidcUsersController`

### DIFF
--- a/app/controllers/oidc_users_controller.rb
+++ b/app/controllers/oidc_users_controller.rb
@@ -6,7 +6,7 @@ class OidcUsersController < ApplicationController
   def update
     user = OidcUser.find_or_create_by_sub!(
       params.fetch(:subject_identifier),
-      legacy_sub: using_digital_identity? ? params[:legacy_sub] : params.fetch(:subject_identifier),
+      legacy_sub: params.fetch(:legacy_sub, params.fetch(:subject_identifier)),
     )
 
     email_changed = params.key?(:email) && (params[:email] != user.email)
@@ -58,7 +58,7 @@ class OidcUsersController < ApplicationController
   def destroy
     OidcUser.find_by_sub!(
       params.fetch(:subject_identifier),
-      legacy_sub: using_digital_identity? ? params[:legacy_sub] : nil,
+      legacy_sub: params[:legacy_sub],
     ).destroy!
     head :no_content
   rescue ActiveRecord::RecordNotFound


### PR DESCRIPTION
This makes it possible to test these aspects of the user migration in
production without switching over to DI fully.  Since we're not
sending this parameter from the legacy account-manager, this is safe.

---

[Trello card](https://trello.com/c/oybk0a6f/1074-switch-over-production-to-use-di-auth)
