### PR TITLE
Add a rake task to return a user's transition checker results

### DIFF
--- a/lib/tasks/support.rake
+++ b/lib/tasks/support.rake
@@ -7,4 +7,15 @@ namespace :support do
       puts "User '#{args[:email]}' does not exist"
     end
   end
+
+  desc "Get a user's Transition Checker results"
+  task :tc_results, [:email] => :environment do |_, args|
+    user = OidcUser.find_by("lower(email) = ?", args[:email].downcase)
+    abort "User does not exist" unless user
+
+    criteria_keys = user.transition_checker_state&.dig("criteria_keys")
+    abort "User has no saved transition checker answers" unless criteria_keys
+
+    puts "https://www.gov.uk/transition-check/results?#{Rack::Utils.build_nested_query(c: criteria_keys)}"
+  end
 end


### PR DESCRIPTION
I've just been doing this in a Rails console, but every time I have to
look up what the Rack function is called; and in any case it's better
to not need regular production console access.
