### PR TITLE
Add endpoint to match a user by email address & add an index on the field

### DIFF
--- a/app/controllers/concerns/authenticated_api_concern.rb
+++ b/app/controllers/concerns/authenticated_api_concern.rb
@@ -1,10 +1,12 @@
 module AuthenticatedApiConcern
   extend ActiveSupport::Concern
 
+  HEADER_NAME = "HTTP_GOVUK_ACCOUNT_SESSION".freeze
+
   included do
     before_action do
       @govuk_account_session = AccountSession.deserialise(
-        encoded_session: request.headers["HTTP_GOVUK_ACCOUNT_SESSION"],
+        encoded_session: request.headers[HEADER_NAME],
         session_secret: Rails.application.secrets.session_secret,
       )
 

--- a/app/controllers/match_user_by_email_controller.rb
+++ b/app/controllers/match_user_by_email_controller.rb
@@ -1,0 +1,32 @@
+class MatchUserByEmailController < ApplicationController
+  before_action :fetch_session_if_present
+
+  def show
+    email = params.fetch(:email).downcase
+
+    if @govuk_account_session&.user&.email == email
+      render json: { match: true }
+      return
+    end
+
+    if OidcUser.where(email: email).exists?
+      render json: { match: false }
+    else
+      head :not_found
+    end
+  end
+
+private
+
+  def fetch_session_if_present
+    encoded_session = request.headers[AuthenticatedApiConcern::HEADER_NAME]
+    return unless encoded_session
+
+    @govuk_account_session = AccountSession.deserialise(
+      encoded_session: encoded_session,
+      session_secret: Rails.application.secrets.session_secret,
+    )
+  rescue AccountSession::ReauthenticateUserError
+    @govuk_account_session = nil
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
     end
 
     get "/user", to: "user#show"
+    get "/user/match-by-email", to: "match_user_by_email#show"
 
     resources :oidc_users, only: %i[update destroy], param: :subject_identifier, path: "oidc-users"
 

--- a/db/migrate/20211101130206_add_index_on_oidc_users_email.rb
+++ b/db/migrate/20211101130206_add_index_on_oidc_users_email.rb
@@ -1,0 +1,5 @@
+class AddIndexOnOidcUsersEmail < ActiveRecord::Migration[6.1]
+  def change
+    add_index :oidc_users, :email, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_26_094310) do
+ActiveRecord::Schema.define(version: 2021_11_01_130206) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 2021_10_26_094310) do
     t.string "legacy_sub"
     t.boolean "cookie_consent"
     t.boolean "feedback_consent"
+    t.index ["email"], name: "index_oidc_users_on_email", unique: true
     t.index ["legacy_sub"], name: "index_oidc_users_on_legacy_sub", unique: true
     t.index ["sub"], name: "index_oidc_users_on_sub", unique: true
   end

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,6 +13,7 @@ management. This API is not for other government services.
   - [`POST /api/oauth2/callback`](#post-apioauth2callback)
   - [`GET /api/oauth2/end-session`](#get-apioauth2end-session)
   - [`GET /api/user`](#get-apiuser)
+  - [`GET /user/match-by-email`](#get-apiusermatch-by-email)
   - [`GET /api/attributes`](#get-apiattributes)
   - [`PATCH /api/attributes`](#patch-apiattributes)
   - [`GET /api/email-subscriptions/:subscription_name`](#get-apiemail-subscriptionssubscription_name)
@@ -258,6 +259,70 @@ Response:
     "services": {
         "transition_checker": "yes_but_must_reauthenticate",
     }
+}
+```
+
+### `GET /user/match-by-email`
+
+Checks if a user with the given email address exists and if it is the
+logged-in user (if a session is given).
+
+This is only used by email-alert-frontend, so it can check if an
+address corresponds to an account and either log the user in or show
+an appropriate message with a single API call.
+
+#### Request headers
+
+- `GOVUK-Account-Session` *(optional)*
+  - the user's session identifier, if not given `"match": true` is not a possible response
+
+#### Query parameters
+
+- `email`
+  - the email address to search for
+
+#### JSON response fields
+
+- `match`
+  - `true` if the session has the given email address, or `false` if a different user has that email address
+
+#### Response codes
+
+- 404 if there is no user with that email address
+- 200 otherwise
+
+#### Example request / response
+
+Request (with gds-api-adapters):
+
+```ruby
+GdsApi.account_api.match_user_by_email(
+    email: "email@example.com",
+)
+```
+
+Response:
+
+```json
+{
+    "match": false
+}
+```
+
+Request with a session (with gds-api-adapters):
+
+```ruby
+GdsApi.account_api.match_user_by_email(
+    email: "email@example.com",
+    govuk_account_session: "session-identifier",
+)
+```
+
+Response:
+
+```json
+{
+    "match": true
 }
 ```
 

--- a/spec/requests/match_user_by_email_spec.rb
+++ b/spec/requests/match_user_by_email_spec.rb
@@ -1,0 +1,71 @@
+RSpec.describe "Matching users by email address" do
+  let(:session_identifier) { nil }
+  let(:session_header_value) { session_identifier&.serialise }
+  let(:headers) { { "Content-Type" => "application/json", "GOVUK-Account-Session" => session_header_value }.compact }
+
+  let(:email) { "no-such-email@example.com" }
+  let(:params) { { email: email } }
+
+  it "returns 404 Not Found" do
+    get "/api/user/match-by-email", params: params, headers: headers
+    expect(response).to have_http_status(:not_found)
+  end
+
+  context "when a session is given" do
+    let(:session_identifier) { placeholder_govuk_account_session_object }
+
+    it "returns 404 Not Found" do
+      get "/api/user/match-by-email", params: params, headers: headers
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context "when the address matches a user" do
+    let!(:user) { FactoryBot.create(:oidc_user) }
+    let(:email) { user.email }
+
+    it "returns 200 OK" do
+      get "/api/user/match-by-email", params: params, headers: headers
+      expect(response).to be_successful
+    end
+
+    it "returns `match: false`" do
+      get "/api/user/match-by-email", params: params, headers: headers
+      expect(JSON.parse(response.body)).to eq({ "match" => false })
+    end
+
+    it "does a case-insensitive match of the address" do
+      get "/api/user/match-by-email", params: { email: user.email.upcase }, headers: headers
+      expect(response).to be_successful
+    end
+
+    context "when a session is given" do
+      let(:session_identifier) { placeholder_govuk_account_session_object }
+
+      it "returns `match: false`" do
+        get "/api/user/match-by-email", params: params, headers: headers
+        expect(JSON.parse(response.body)).to eq({ "match" => false })
+      end
+
+      context "when the session header value is invalid" do
+        let(:session_header_value) { "." }
+
+        it "treats it as nonexistent" do
+          get "/api/user/match-by-email", params: params, headers: headers
+          expect(JSON.parse(response.body)).to eq({ "match" => false })
+        end
+      end
+
+      context "when the address matches the session" do
+        before { session_identifier.user.update!(email: email) }
+
+        let(:email) { "user-from-session@example.com" }
+
+        it "returns `match: true`" do
+          get "/api/user/match-by-email", params: params, headers: headers
+          expect(JSON.parse(response.body)).to eq({ "match" => true })
+        end
+      end
+    end
+  end
+end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -153,4 +153,10 @@ Pact.provider_states_for "GDS API Adapters" do
       FactoryBot.create(:oidc_user, sub: "the-subject-identifier")
     end
   end
+
+  provider_state "there is a user with email address 'email@example.com'" do
+    set_up do
+      FactoryBot.create(:oidc_user, email: "email@example.com")
+    end
+  end
 end


### PR DESCRIPTION
This will be used to implement the sniffer page in
email-alert-frontend, where we want to examine the email address the
user has just entered and do one of three things:

- Log the user in to email-alert-frontend if they're logged into the
right GOV.UK account; or

- Tell the user to sign in, if a GOV.UK account exists with the email
address they entered; or

- Fall back to the magic link method if there is no GOV.UK account for
that email address.

email-alert-frontend will use this endpoint like so:

    def match_user_by_email(email)
      response = GdsApi.match_user_by_email(
        email: @address,
        govuk_account_session: account_session_header,
      )

      if response["match"]
        :ok
      else
        :must_reauthenticate
      end
    rescue GdsApi::HTTPNotFound
      :no_account
    end

The alternative would be to add an endpoint to find a user by email
address, and then for email-alert-frontend to do something like this:

    def match_user_by_email(email)
      response = GdsApi.account_api.get_attributes(
        attributes: %w[email],
        govuk_account_session: account_session_header,
      )

      return :ok if response["values"]["email"] == email

      GdsApi.account_api.find_user_by_email(email: email)
      :must_reauthenticate
    rescue GdsApi::HTTPNotFound
      :no_account
    end

which would be slower because it makes two API calls rather than one.

---

[Trello card](https://trello.com/c/5ZoujfPL/1115-implement-email-management-account-sniffer-logic)