### PR TITLE
Fix format of fake userinfo response when running locally

### DIFF
--- a/app/lib/oidc_client/fake.rb
+++ b/app/lib/oidc_client/fake.rb
@@ -45,10 +45,14 @@ class OidcClient::Fake < OidcClient
     raise NoDevelopmentUser unless user
 
     {
-      "sub" => user.sub,
-      "email" => user.email,
-      "email_verified" => user.email_verified,
-      "has_unconfirmed_email" => user.has_unconfirmed_email,
+      access_token: access_token,
+      result:
+        {
+          "sub" => user.sub,
+          "email" => user.email,
+          "email_verified" => user.email_verified,
+          "has_unconfirmed_email" => user.has_unconfirmed_email,
+        },
     }
   end
 

--- a/spec/lib/oidc_client/fake_spec.rb
+++ b/spec/lib/oidc_client/fake_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe OidcClient::Fake do
         "has_unconfirmed_email" => user.has_unconfirmed_email || false,
       }
 
-      expect(client.userinfo(access_token: access_token)).to eq(userinfo)
+      expect(client.userinfo(access_token: access_token)).to eq({ access_token: access_token, result: userinfo })
     end
 
     it "throws an error if the access token doesn't correspond to a user" do


### PR DESCRIPTION
The method has to return a result in the form:

    {
      access_token: access_token,
      result: { actual userinfo response },
    }

To match the real client.  Otherwise the authentication controller
callback throws an error calling `merge!` on nil.
