### PR TITLE
Add rake task to move unmigrated users to a new table

### DIFF
--- a/app/models/unmigrated_oidc_user.rb
+++ b/app/models/unmigrated_oidc_user.rb
@@ -1,0 +1,3 @@
+class UnmigratedOidcUser < ApplicationRecord
+  validates :sub, presence: true
+end

--- a/db/migrate/20211103101514_move_unmigrated_users_to_new_table.rb
+++ b/db/migrate/20211103101514_move_unmigrated_users_to_new_table.rb
@@ -1,0 +1,13 @@
+class MoveUnmigratedUsersToNewTable < ActiveRecord::Migration[6.1]
+  def change
+    create_table :unmigrated_oidc_users do |t|
+      t.string  :sub, null: false
+      t.string  :email
+      t.boolean :email_verified
+      t.boolean :has_unconfirmed_email
+      t.jsonb   :transition_checker_state
+
+      t.timestamps default: -> { "now()" }, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_26_094310) do
+ActiveRecord::Schema.define(version: 2021_11_03_101514) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,16 @@ ActiveRecord::Schema.define(version: 2021_10_26_094310) do
     t.datetime "created_at", precision: 6, default: -> { "now()" }, null: false
     t.datetime "updated_at", precision: 6, default: -> { "now()" }, null: false
     t.index ["sub"], name: "index_tombstones_on_sub", unique: true
+  end
+
+  create_table "unmigrated_oidc_users", force: :cascade do |t|
+    t.string "sub", null: false
+    t.string "email"
+    t.boolean "email_verified"
+    t.boolean "has_unconfirmed_email"
+    t.jsonb "transition_checker_state"
+    t.datetime "created_at", precision: 6, default: -> { "now()" }, null: false
+    t.datetime "updated_at", precision: 6, default: -> { "now()" }, null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/lib/tasks/migration.rake
+++ b/lib/tasks/migration.rake
@@ -1,0 +1,20 @@
+namespace :migration do
+  desc "Move unmigrated users to the unmigrated_oidc_users table"
+  task move_unmigrated_users_to_new_table: :environment do
+    users_to_migrate = OidcUser.where(email_verified: false).where("created_at < ?", Date.new(2021, 10, 28))
+    puts "migrating #{users_to_migrate.count}"
+
+    users_to_migrate.each do |user|
+      UnmigratedOidcUser.create!(
+        sub: user.sub,
+        email: user.email,
+        email_verified: user.email_verified,
+        has_unconfirmed_email: user.has_unconfirmed_email,
+        transition_checker_state: user.transition_checker_state,
+        created_at: user.created_at,
+        updated_at: user.updated_at,
+      )
+      user.destroy!
+    end
+  end
+end


### PR DESCRIPTION
There are ~7000 users who didn't confirm their email address before
the cut-off date, and so who didn't get migrated.  9 of those have
since re-registered, which means we have 9 `OidcUser` records with
duplicate email addresses.

This causes a problem, because email addresses are otherwise unique.
So, let's move these users to another table.  Eventually we will
delete them, but that won't happen until after the brexit checker goes
away at least.

---

[Trello card](https://trello.com/c/eIgHkyyw/1123-move-unmigrated-users-to-a-different-database-table)
