### PR TITLE
Do not create tombstone records for legacy subs

### DIFF
--- a/app/models/oidc_user.rb
+++ b/app/models/oidc_user.rb
@@ -29,6 +29,5 @@ class OidcUser < ApplicationRecord
 
   def create_tombstone
     Tombstone.create!(sub: sub)
-    Tombstone.create!(sub: legacy_sub) if legacy_sub
   end
 end

--- a/spec/models/oidc_user_spec.rb
+++ b/spec/models/oidc_user_spec.rb
@@ -9,14 +9,6 @@ RSpec.describe OidcUser do
       expect { described_class.create!(sub: sub).destroy! }.to change(Tombstone, :count).by(1)
       expect(Tombstone.find_by(sub: sub)).not_to be_nil
     end
-
-    it "creates a tombstone record for the legacy_sub when destroyed" do
-      sub = "subject-identifier"
-      legacy_sub = "legacy-subject-identifier"
-      expect { described_class.create!(sub: sub, legacy_sub: legacy_sub).destroy! }.to change(Tombstone, :count).by(2)
-      expect(Tombstone.find_by(sub: sub)).not_to be_nil
-      expect(Tombstone.find_by(sub: legacy_sub)).not_to be_nil
-    end
   end
 
   describe "#find_or_create_by_sub!" do


### PR DESCRIPTION
This prevents destroying unmigrated users, as their sub and legacy_sub
are the same.  For migrated users, we don't need to know the destroyed
legacy_sub, because if we try to join up data with DI, we'll do it by
the sub instead.
