### PR TITLE
Add rake task to merge pre- & post-migration users

### DIFF
--- a/lib/tasks/migration.rake
+++ b/lib/tasks/migration.rake
@@ -17,4 +17,37 @@ namespace :migration do
       user.destroy!
     end
   end
+
+  desc <<~DESC
+    Merge a pre-migration and an improperly-created post-migration user
+
+    This is to handle the case where a legacy_subject_id isn't being
+    returned from the userinfo, and so we're trying to create a new
+    OidcUser record with the same email address as an existing,
+    pre-migration, one.
+
+    It will only merge users where:
+
+    - the post-migration user has no legacy_sub or email.
+    - the pre-migration user has the same sub and legacy_sub.
+    - both users were created on the right sides of the migration.
+  DESC
+  task :merge_pre_and_post_user, %i[sub legacy_sub] => :environment do |_, args|
+    migration_timestamp = Date.new(2021, 10, 28)
+    sub = args.fetch(:sub)
+    legacy_sub = args.fetch(:legacy_sub)
+
+    post_migration_user = OidcUser.where(sub: sub).where("created_at > ?", migration_timestamp).first
+    abort "post-migration user '#{sub}' not found" unless post_migration_user
+    abort "post-migration user '#{sub}' already linked to a pre-migration user" if post_migration_user.legacy_sub
+    abort "post-migration user '#{sub}' already has an email address" if post_migration_user.email
+
+    pre_migration_user = OidcUser.where(sub: legacy_sub, legacy_sub: legacy_sub).where("created_at < ?", migration_timestamp).first
+    abort "pre-migration user '#{legacy_sub}' not found" unless pre_migration_user
+
+    OidcUser.transaction do
+      post_migration_user.destroy!
+      pre_migration_user.update!(sub: sub)
+    end
+  end
 end


### PR DESCRIPTION
This is to handle the case where a legacy_subject_id isn't being
returned from the userinfo, and so we're trying to create a new
OidcUser record with the same email address as an existing,
pre-migration, one.

We have one such case so far (brought to light by the new unique index
on the email field).  I've asked DI to check the record for that user,
as they should have been migrated across.  But, so that the user can
log in, we need to merge their two records.

The task will only merge users where:

- the post-migration user has no legacy_sub or email.
- the pre-migration user has the same sub and legacy_sub.
- both users were created on the right sides of the migration.

---

[Trello card](https://trello.com/c/GYLhX263/1125-investigate-improperly-migrated-user)
