### PR TITLE
Store exceptions from updating users to a new table

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::API
   include GDS::SSO::ControllerMethods
 
+  class CapturedSensitiveException < StandardError; end
+
   before_action :authorise_sso_user!
 
   rescue_from ApiError::Base do |error|
@@ -15,5 +17,15 @@ private
 
   def authorise_sso_user!
     authorise_user!("internal_app")
+  end
+
+  def capture_sensitive_exceptions
+    yield
+  rescue StandardError => e
+    SensitiveException.create!(
+      message: e.message,
+      full_message: e.full_message,
+    )
+    raise CapturedSensitiveException
   end
 end

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -27,7 +27,9 @@ class AuthenticationController < ApplicationController
       version: AccountSession::CURRENT_VERSION,
     )
 
-    fetch_cacheable_attributes!(govuk_account_session, details)
+    capture_sensitive_exceptions do
+      fetch_cacheable_attributes!(govuk_account_session, details)
+    end
 
     render json: {
       govuk_account_session: govuk_account_session.serialise,

--- a/app/controllers/oidc_users_controller.rb
+++ b/app/controllers/oidc_users_controller.rb
@@ -10,8 +10,10 @@ class OidcUsersController < ApplicationController
     email_changed = params.key?(:email) && (params[:email] != user.email)
     email_verified_changed = params.key?(:email_verified) && params[:email_verified] != user.email_verified
 
-    user.update!(params.permit(OIDC_USER_ATTRIBUTES).to_h.compact)
-    user.reload
+    capture_sensitive_exceptions do
+      user.update!(params.permit(OIDC_USER_ATTRIBUTES).to_h.compact)
+      user.reload
+    end
 
     if (email_changed || email_verified_changed) && user.email && user.email_verified
       begin

--- a/app/models/sensitive_exception.rb
+++ b/app/models/sensitive_exception.rb
@@ -1,0 +1,2 @@
+class SensitiveException < ApplicationRecord
+end

--- a/db/migrate/20211104103629_create_sensitive_exceptions.rb
+++ b/db/migrate/20211104103629_create_sensitive_exceptions.rb
@@ -1,0 +1,9 @@
+class CreateSensitiveExceptions < ActiveRecord::Migration[6.1]
+  def change
+    create_table :sensitive_exceptions do |t|
+      t.string :message
+      t.string :full_message
+      t.timestamps default: -> { "now()" }, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_03_101514) do
+ActiveRecord::Schema.define(version: 2021_11_04_103629) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,13 @@ ActiveRecord::Schema.define(version: 2021_11_03_101514) do
     t.index ["email"], name: "index_oidc_users_on_email", unique: true
     t.index ["legacy_sub"], name: "index_oidc_users_on_legacy_sub", unique: true
     t.index ["sub"], name: "index_oidc_users_on_sub", unique: true
+  end
+
+  create_table "sensitive_exceptions", force: :cascade do |t|
+    t.string "message"
+    t.string "full_message"
+    t.datetime "created_at", precision: 6, default: -> { "now()" }, null: false
+    t.datetime "updated_at", precision: 6, default: -> { "now()" }, null: false
   end
 
   create_table "tombstones", force: :cascade do |t|

--- a/spec/requests/oidc_users_spec.rb
+++ b/spec/requests/oidc_users_spec.rb
@@ -90,6 +90,17 @@ RSpec.describe "OIDC Users endpoint" do
         expect(user.feedback_consent).to eq(feedback_consent)
       end
 
+      context "when a different user tried to use the same email address" do
+        let!(:other_user) { FactoryBot.create(:oidc_user) }
+        let(:email) { user.email }
+
+        it "creates a sensitive exception" do
+          before = SensitiveException.count
+          expect { put oidc_user_path(subject_identifier: other_user.sub), params: params, headers: headers }.to raise_error(ApplicationController::CapturedSensitiveException)
+          expect(SensitiveException.count).to eq(before + 1)
+        end
+      end
+
       context "when the user is pre-migration" do
         let(:legacy_sub) { "legacy-subject-identifier" }
         let(:subject_identifier) { "pre-migration-subject-identifier" }


### PR DESCRIPTION
These exceptions can be raised due to non-unique email addresses.
Such an exception indicates a bug, as email addresses should be
unique, but we don't want real user data getting into Sentry.