### PR TITLE
Publish a redirect from /account to /account/home

### DIFF
--- a/config/content_items.yml
+++ b/config/content_items.yml
@@ -7,6 +7,11 @@ help_pages:
     description: "Find the government service you need to sign in to. At the moment, there are separate accounts for different government services."
     rendering_app: "frontend"
 
+redirects:
+  - content_id: "0833d91b-d772-4144-b81f-e7a42df96d5b"
+    base_path: "/account"
+    destination: "/account/home"
+
 special_routes:
   - content_id: "49ecdc1f-c98b-430e-8256-7a402239daf8"
     base_path: "/sign-in/redirect"

--- a/lib/publishing_api_tasks.rb
+++ b/lib/publishing_api_tasks.rb
@@ -6,6 +6,8 @@ class PublishingApiTasks
   PUBLISHING_APP = "account-api"
   LOCALE = "en"
 
+  attr_reader :content_items
+
   def initialize(publishing_api: nil, logger: nil, content_items: nil)
     @logger = logger || Logger.new($stdout)
     @publishing_api = publishing_api || GdsApi.publishing_api

--- a/lib/publishing_api_tasks.rb
+++ b/lib/publishing_api_tasks.rb
@@ -44,6 +44,28 @@ class PublishingApiTasks
     publish_content_item(content_id, payload, "major")
   end
 
+  def publish_redirects
+    @content_items[:redirects].each do |redirect|
+      base_path = redirect.fetch(:base_path)
+      payload =
+        {
+          document_type: "redirect",
+          schema_name: "redirect",
+          base_path: base_path,
+          redirects: [
+            {
+              path: base_path,
+              destination: redirect.fetch(:destination),
+              type: "exact",
+            },
+          ],
+        }
+
+      claim_path base_path
+      publish_content_item(redirect.fetch(:content_id), payload, "major")
+    end
+  end
+
   def publish_special_routes
     publisher = GdsApi::PublishingApi::SpecialRoutePublisher.new(
       publishing_api: @publishing_api,

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,6 +1,11 @@
 require_relative "../publishing_api_tasks"
 
 namespace :publishing_api do
+  desc "Publish redirects"
+  task publish_redirects: :environment do
+    PublishingApiTasks.new.publish_redirects
+  end
+
   desc "Publish special routes"
   task publish_special_routes: :environment do
     PublishingApiTasks.new.publish_special_routes

--- a/spec/lib/publishing_api_tasks_spec.rb
+++ b/spec/lib/publishing_api_tasks_spec.rb
@@ -10,6 +10,36 @@ RSpec.describe PublishingApiTasks do
   let(:logger) { instance_double("Logger") }
   let(:content_items) { nil }
 
+  describe "content item definitions" do
+    subject(:content_items) { described_class.new.content_items }
+
+    it "all have a unique content ID" do
+      content_ids = {}
+      content_items[:help_pages].each { |_, item| increment(content_ids, item[:content_id]) }
+      content_items[:redirects].each { |item| increment(content_ids, item[:content_id]) }
+      content_items[:special_routes].each { |item| increment(content_ids, item[:content_id]) }
+
+      content_ids.each do |content_id, count|
+        expect("#{content_id}: #{count}").to eq("#{content_id}: 1")
+      end
+    end
+
+    it "all have a unique base path" do
+      base_paths = {}
+      content_items[:help_pages].each { |_, item| increment(base_paths, item[:base_path]) }
+      content_items[:redirects].each { |item| increment(base_paths, item[:base_path]) }
+      content_items[:special_routes].each { |item| increment(base_paths, item[:base_path]) }
+
+      base_paths.each do |base_path, count|
+        expect("#{base_path}: #{count}").to eq("#{base_path}: 1")
+      end
+    end
+
+    def increment(hash, item)
+      hash[item] = hash.fetch(item, 0) + 1
+    end
+  end
+
   describe "#publish_help_page" do
     before { allow(logger).to receive(:info) }
 

--- a/spec/lib/publishing_api_tasks_spec.rb
+++ b/spec/lib/publishing_api_tasks_spec.rb
@@ -30,6 +30,25 @@ RSpec.describe PublishingApiTasks do
     end
   end
 
+  describe "#publish_redirects" do
+    before { allow(logger).to receive(:info) }
+
+    let(:redirect) { { content_id: SecureRandom.uuid, base_path: "/foo", destination: "/bar" } }
+    let(:content_items) { { redirects: [redirect] } }
+
+    it "takes ownership of the route and publishes the content item" do
+      stub_claim_path = stub_call_claim_path(redirect[:base_path])
+      stub_put_content = stub_call_put_content(redirect[:content_id], { redirects: [{ path: redirect[:base_path], destination: redirect[:destination], type: "exact" }] }, "major")
+      stub_publish = stub_call_publish(redirect[:content_id], "major")
+
+      tasks.publish_redirects
+
+      expect(stub_claim_path).to have_been_made
+      expect(stub_put_content).to have_been_made
+      expect(stub_publish).to have_been_made
+    end
+  end
+
   describe "#publish_special_routes" do
     before { allow(logger).to receive(:info) }
 


### PR DESCRIPTION
We've decided that, since all the account things are under `/account`, the actual top-level path `https://www.gov.uk/account` should do something too.

Also refactor the PublishingApiTasks a bit:

- Specify the locale for help pages and redirects (to be consistent with special routes)
- Add a helper method to do the put-content & publish step
- Add some test helper methods to reduce repetition

---

[Trello card](https://trello.com/c/OIJrfei8/1128-make-account-redirect-to-account-home)