### PR TITLE
Make check-email-subscription endpoint also take a base_path

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -21,7 +21,7 @@ management. This API is not for other government services.
   - [`DELETE /api/email-subscriptions/:subscription_name`](#delete-apiemail-subscriptionssubscription_name)
   - [`PUT /api/oidc-users/:subject_identifier`](#put-apioidc-userssubject_identifier)
   - [`DELETE /api/oidc-users/:subject_identifier`](#delete-apioidc-userssubject_identifier)
-  - [`GET /api/personalisation/check-email-subscription/:topic_slug`](#get-apipersonalisationcheck-email-subscriptiontopic_slug)
+  - [`GET /api/personalisation/check-email-subscription`](#get-apipersonalisationcheck-email-subscription)
 - [API errors](#api-errors)
   - [MFA required](#mfa-required)
   - [Unknown attribute names](#unknown-attribute-names)
@@ -657,7 +657,7 @@ GdsApi.account_api.delete_user_by_subject_identifier(
 
 Response is status code only.
 
-### `GET /api/personalisation/check-email-subscription/:topic_slug`
+### `GET /api/personalisation/check-email-subscription`
 
 Personalisation endpoint for checking if an email subscription is active.
 
@@ -673,19 +673,26 @@ See [Progressive enhancement ADR for more details](/docs/adr/002-progressive-enh
 
 #### Query parameters
 
-- `topic_slug`
+- `base_path` *(optional)*
+  - the base path of the page (to match against the "url" of an email-alert-api subscriber list)
+- `topic_slug` *(optional)*
   - the email-alert-api topic slug
+
+Exactly one of `base_path` and `topic_slug` must be specified.
 
 #### JSON response fields
 
+- `base_path`
+  - the base_path parameter, if there is one (a string)
 - `topic_slug`
-  - the email-alert-api topic slug (a string)
+  - the topic_slug parameter, if there is one (a string)
 - `active`
-  - If the subscription is active (a boolean)
+  - whether the subscription is active (a boolean)
 
 #### Response codes
 
 - 401 if the session identifier is invalid
+- 422 if neither `base_path` nor `topic_slug` are passed; or if both are
 - 200 otherwise
 
 #### Example request / response

--- a/spec/requests/check_email_subscription_spec.rb
+++ b/spec/requests/check_email_subscription_spec.rb
@@ -8,73 +8,159 @@ RSpec.describe "Personalisation - Check Email Subscription" do
   include GovukPersonalisation::TestHelpers::Requests
 
   describe "GET /api/personalisation/check-email-subscription" do
-    let(:topic_slug) { "topic_slug" }
+    let(:base_path) { nil }
+    let(:topic_slug) { nil }
+    let(:params) { { base_path: base_path, topic_slug: topic_slug }.compact }
+
+    let(:active) { false }
+
+    let(:subscription_details) do
+      {
+        base_path: base_path,
+        topic_slug: topic_slug,
+        active: active,
+      }.compact.to_json
+    end
 
     it "returns 401" do
-      get check_email_subscription_path(topic_slug: topic_slug)
+      get check_email_subscription_path, params: params
       expect(response).to have_http_status(:unauthorized)
     end
 
-    context "with an autenticated session" do
-      let(:subscription_status_details) do
-        {
-          "topic_slug": topic_slug,
-          "active": subscription_active,
-        }.to_json
+    context "with an authenticated session" do
+      let(:subscriptions) do
+        [
+          {
+            "id" => 1,
+            "created_at" => "2019-09-16 02:08:08 01:00",
+            "subscriber_list" => {
+              "id" => 2,
+              "title" => "Some thing",
+              "url" => list_url,
+              "slug" => list_slug,
+            }.compact,
+          },
+        ]
       end
 
-      let(:subscription_active) { false }
+      let(:list_url) { "/some/other/path" }
+      let(:list_slug) { "some-other-slug" }
 
       let(:oidc_user) { FactoryBot.create(:oidc_user) }
       let(:sub) { oidc_user.sub }
       let(:subscriber_id) { 42 }
-      let(:subscriptions) do
-        [
-          {
-            "id" => subscriber_id,
-            "created_at" => "2019-09-16 02:08:08 01:00",
-            "subscriber_list" => { "title" => "Some thing", "slug" => topic_slug },
-          },
-        ]
-      end
       let(:session_identifier) { placeholder_govuk_account_session_object(user_id: sub, mfa: false) }
       let(:headers) { { "Content-Type" => "application/json", "GOVUK-Account-Session" => session_identifier&.serialise }.compact }
 
-      it "logs the user out if the session is invalid" do
-        get check_email_subscription_path, headers: { "GOVUK-Account-Session" => "not-a-base64-string" }
-        expect(response).to have_http_status(:unauthorized)
+      it "returns a 422" do
+        get check_email_subscription_path, params: params, headers: headers
+        expect(response).to have_http_status(:unprocessable_entity)
       end
 
-      context "when the user has linked their notifications account" do
-        before { stub_email_alert_api_find_subscriber_by_govuk_account(oidc_user.id, subscriber_id, "test@example.com") }
+      context "when the session is invalid" do
+        let(:headers) { { "GOVUK-Account-Session" => "not-a-base64-string" } }
 
-        context "when the topic_slug matches an active subscription" do
-          before { stub_email_alert_api_has_subscriber_subscriptions(subscriber_id, "test@example.com", subscriptions: subscriptions) }
+        it "logs the user out" do
+          get check_email_subscription_path, params: params, headers: headers
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
 
-          let(:subscription_active) { true }
+      context "when a base_path is passed" do
+        let(:base_path) { "/foo" }
+        let(:subscription_slug) { "foo" }
 
-          it "returns subscription status details as active" do
-            get check_email_subscription_path(topic_slug: topic_slug), headers: headers
-            expect(response.body).to eq(subscription_status_details)
+        context "when a topic_slug is also passed" do
+          let(:topic_slug) { "topic_slug" }
+
+          it "returns a 422" do
+            get check_email_subscription_path, params: params, headers: headers
+            expect(response).to have_http_status(:unprocessable_entity)
           end
         end
 
-        context "when the topic_slug does not match an active subscription" do
+        context "when the user has linked their notifications account" do
+          before { stub_email_alert_api_find_subscriber_by_govuk_account(oidc_user.id, subscriber_id, "test@example.com") }
+
+          context "when the user has active subscriptions" do
+            before { stub_email_alert_api_has_subscriber_subscriptions(subscriber_id, "test@example.com", subscriptions: subscriptions) }
+
+            it "returns subscription status details as not active" do
+              get check_email_subscription_path, params: params, headers: headers
+              expect(response.body).to eq(subscription_details)
+            end
+
+            context "when an active subscription has a matching url" do
+              let(:list_url) { base_path }
+              let(:active) { true }
+
+              it "returns subscription status details as active" do
+                get check_email_subscription_path, params: params, headers: headers
+                expect(response.body).to eq(subscription_details)
+              end
+            end
+          end
+
+          context "when the user does not have active subscriptions" do
+            before { stub_email_alert_api_does_not_have_subscriber_subscriptions(subscriber_id) }
+
+            it "returns subscription status details as not active" do
+              get check_email_subscription_path, params: params, headers: headers
+              expect(response.body).to eq(subscription_details)
+            end
+          end
+        end
+
+        context "when the user has not linked their notifications account" do
+          before { stub_email_alert_api_find_subscriber_by_govuk_account_no_subscriber(oidc_user.id) }
+
+          it "returns subscription status details as not active" do
+            get check_email_subscription_path, params: params, headers: headers
+            expect(response.body).to eq(subscription_details)
+          end
+        end
+      end
+
+      context "when a topic_slug is passed" do
+        before { stub_email_alert_api_find_subscriber_by_govuk_account(oidc_user.id, subscriber_id, "test@example.com") }
+
+        let(:topic_slug) { "topic_slug" }
+
+        context "when a base_path is also passed" do
+          let(:base_path) { "/foo" }
+
+          it "returns a 422" do
+            get check_email_subscription_path, params: params, headers: headers
+            expect(response).to have_http_status(:unprocessable_entity)
+          end
+        end
+
+        context "when the user has active subscriptions" do
+          before { stub_email_alert_api_has_subscriber_subscriptions(subscriber_id, "test@example.com", subscriptions: subscriptions) }
+
+          it "returns subscription status details as not active" do
+            get check_email_subscription_path, params: params, headers: headers
+            expect(response.body).to eq(subscription_details)
+          end
+
+          context "when an active subscription has a matching slug" do
+            let(:list_slug) { topic_slug }
+            let(:active) { true }
+
+            it "returns subscription status details as active" do
+              get check_email_subscription_path, params: params, headers: headers
+              expect(response.body).to eq(subscription_details)
+            end
+          end
+        end
+
+        context "when the user does not have active subscriptions" do
           before { stub_email_alert_api_does_not_have_subscriber_subscriptions(subscriber_id) }
 
           it "returns subscription status details as not active" do
-            get check_email_subscription_path(topic_slug: topic_slug), headers: headers
-            expect(response.body).to eq(subscription_status_details)
+            get check_email_subscription_path, params: params, headers: headers
+            expect(response.body).to eq(subscription_details)
           end
-        end
-      end
-
-      context "when the user has not linked their notifications account" do
-        before { stub_email_alert_api_find_subscriber_by_govuk_account_no_subscriber(oidc_user.id) }
-
-        it "returns subscription status details as not active" do
-          get check_email_subscription_path(topic_slug: topic_slug), headers: headers
-          expect(response.body).to eq(subscription_status_details)
         end
       end
     end


### PR DESCRIPTION
If a base_path is given, we match against the URL field of the
subscriber list.  This is so we can find a subscription for a specific
page, without needing the frontend app to query email-alert-api for
the slug first.

I've also added tests for the case where a user has active
subscriptions which don't match, as that wasn't covered previously.

---

[Trello card](https://trello.com/c/oOpGMmxF/1126-put-the-single-page-signup-button-on-some-pages)
