### PR TITLE
Omit details of root cause when reporting a sensitive exception

### DIFF
--- a/spec/requests/oidc_users_spec.rb
+++ b/spec/requests/oidc_users_spec.rb
@@ -95,9 +95,9 @@ RSpec.describe "OIDC Users endpoint" do
         let(:email) { user.email }
 
         it "creates a sensitive exception" do
-          before = SensitiveException.count
-          expect { put oidc_user_path(subject_identifier: other_user.sub), params: params, headers: headers }.to raise_error(ApplicationController::CapturedSensitiveException)
-          expect(SensitiveException.count).to eq(before + 1)
+          expect(GovukError).to receive(:notify)
+          expect { put oidc_user_path(subject_identifier: other_user.sub), params: params, headers: headers }.to change(SensitiveException, :count).by(1)
+          expect(response).to have_http_status(:internal_server_error)
         end
       end
 


### PR DESCRIPTION
Throwing a `CapturedSensitiveException` inside a `rescue` embeds the
details of the causing exception inside it.  This is usually a useful
feature, letting you drill down into the root cause of a problem.

But when our goal is to hide exceptions which contain user data, it's
not so helpful.

This commit adds a handler for `CapturedSensitiveException`s which
just reports a string (and the ID of the newly-created
`SensitiveException` record) to Sentry.  Since we're not reporting an
actual exception object, there's no stack trace or any other details
being sent to Sentry.
