### PR TITLE
Enable cookie middleware

### DIFF
--- a/app/controllers/check_email_subscription_controller.rb
+++ b/app/controllers/check_email_subscription_controller.rb
@@ -1,6 +1,7 @@
 require "gds_api/email_alert_api"
 
 class CheckEmailSubscriptionController < ApplicationController
+  include ActionController::Cookies
   include GovukPersonalisation::ControllerConcern
 
   skip_before_action :authorise_sso_user!

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,8 @@ module AccountApi
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
 
+    config.middleware.use ActionDispatch::Cookies
+
     config.x.user_attributes = config_for("user_attributes")
   end
 end


### PR DESCRIPTION
This is needed for the govuk_personalisation controller concern in
development mode.  An alternative would be parsing the `Cookie`
request header ourselves.
