### PR TITLE
Add single-page button HTML to the API response 

### DIFF
--- a/app/controllers/check_email_subscription_controller.rb
+++ b/app/controllers/check_email_subscription_controller.rb
@@ -62,6 +62,14 @@ private
       base_path: @base_path,
       topic_slug: @topic_slug,
       active: active,
+      button_html: render_button_component(active),
     }.compact
+  end
+
+  def render_button_component(active)
+    ActionController::Base.render(
+      partial: "govuk_publishing_components/components/single_page_notification_button",
+      locals: { base_path: @base_path, already_subscribed: active },
+    ).presence
   end
 end

--- a/docs/api.md
+++ b/docs/api.md
@@ -688,6 +688,8 @@ Exactly one of `base_path` and `topic_slug` must be specified.
   - the topic_slug parameter, if there is one (a string)
 - `active`
   - whether the subscription is active (a boolean)
+- `button_html`
+  - the rendered single-page notification button component HTML, if a `base_path` was given (a string)
 
 #### Response codes
 
@@ -703,13 +705,15 @@ As a personalisation endpoint, it allows us to progressively enhance pages from 
 To test the endpoint with curl:
 
 ```
-curl -H "GOVUK-Account-Session={{account_session_header}}" "{{GOV.UK environment}}/api/personalisation/check-email-subscription?topic_slug=example-topic-slug"
+curl -H "GOVUK-Account-Session={{account_session_header}}" \
+  "{{GOV.UK environment}}/api/personalisation/check-email-subscription?base_path=/guidance/keeping-a-pet-pig-or-micropig"
 ```
 
 ```json
 {
-    "topic_slug": "example-topic-slug",
-    "active": true
+    "base_path": "/guidance/keeping-a-pet-pig-or-micropig",
+    "active": true,
+    "button_html": "<form>...</form>"
 }
 ```
 

--- a/spec/requests/check_email_subscription_spec.rb
+++ b/spec/requests/check_email_subscription_spec.rb
@@ -126,15 +126,6 @@ RSpec.describe "Personalisation - Check Email Subscription" do
 
         let(:topic_slug) { "topic_slug" }
 
-        context "when a base_path is also passed" do
-          let(:base_path) { "/foo" }
-
-          it "returns a 422" do
-            get check_email_subscription_path, params: params, headers: headers
-            expect(response).to have_http_status(:unprocessable_entity)
-          end
-        end
-
         context "when the user has active subscriptions" do
           before { stub_email_alert_api_has_subscriber_subscriptions(subscriber_id, "test@example.com", subscriptions: subscriptions) }
 

--- a/spec/requests/check_email_subscription_spec.rb
+++ b/spec/requests/check_email_subscription_spec.rb
@@ -16,10 +16,10 @@ RSpec.describe "Personalisation - Check Email Subscription" do
 
     let(:subscription_details) do
       {
-        base_path: base_path,
-        topic_slug: topic_slug,
-        active: active,
-      }.compact.to_json
+        "base_path" => base_path,
+        "topic_slug" => topic_slug,
+        "active" => active,
+      }.compact
     end
 
     it "returns 401" do
@@ -87,7 +87,12 @@ RSpec.describe "Personalisation - Check Email Subscription" do
 
             it "returns subscription status details as not active" do
               get check_email_subscription_path, params: params, headers: headers
-              expect(response.body).to eq(subscription_details)
+              expect(JSON.parse(response.body)).to include(subscription_details)
+            end
+
+            it "includes the inactive-state button HTML" do
+              get check_email_subscription_path, params: params, headers: headers
+              expect(JSON.parse(response.body)["button_html"]).to include("Get emails about this page")
             end
 
             context "when an active subscription has a matching url" do
@@ -96,7 +101,12 @@ RSpec.describe "Personalisation - Check Email Subscription" do
 
               it "returns subscription status details as active" do
                 get check_email_subscription_path, params: params, headers: headers
-                expect(response.body).to eq(subscription_details)
+                expect(JSON.parse(response.body)).to include(subscription_details)
+              end
+
+              it "includes the active-state button HTML" do
+                get check_email_subscription_path, params: params, headers: headers
+                expect(JSON.parse(response.body)["button_html"]).to include("Stop getting emails about this page")
               end
             end
           end
@@ -106,7 +116,12 @@ RSpec.describe "Personalisation - Check Email Subscription" do
 
             it "returns subscription status details as not active" do
               get check_email_subscription_path, params: params, headers: headers
-              expect(response.body).to eq(subscription_details)
+              expect(JSON.parse(response.body)).to include(subscription_details)
+            end
+
+            it "includes the inactive-state button HTML" do
+              get check_email_subscription_path, params: params, headers: headers
+              expect(JSON.parse(response.body)["button_html"]).to include("Get emails about this page")
             end
           end
         end
@@ -116,7 +131,12 @@ RSpec.describe "Personalisation - Check Email Subscription" do
 
           it "returns subscription status details as not active" do
             get check_email_subscription_path, params: params, headers: headers
-            expect(response.body).to eq(subscription_details)
+            expect(JSON.parse(response.body)).to include(subscription_details)
+          end
+
+          it "includes the inactive-state button HTML" do
+            get check_email_subscription_path, params: params, headers: headers
+            expect(JSON.parse(response.body)["button_html"]).to include("Get emails about this page")
           end
         end
       end
@@ -131,7 +151,12 @@ RSpec.describe "Personalisation - Check Email Subscription" do
 
           it "returns subscription status details as not active" do
             get check_email_subscription_path, params: params, headers: headers
-            expect(response.body).to eq(subscription_details)
+            expect(JSON.parse(response.body)).to include(subscription_details)
+          end
+
+          it "does not include button HTML" do
+            get check_email_subscription_path, params: params, headers: headers
+            expect(response.body).not_to include("button_html")
           end
 
           context "when an active subscription has a matching slug" do
@@ -140,7 +165,12 @@ RSpec.describe "Personalisation - Check Email Subscription" do
 
             it "returns subscription status details as active" do
               get check_email_subscription_path, params: params, headers: headers
-              expect(response.body).to eq(subscription_details)
+              expect(JSON.parse(response.body)).to include(subscription_details)
+            end
+
+            it "does not include button HTML" do
+              get check_email_subscription_path, params: params, headers: headers
+              expect(response.body).not_to include("button_html")
             end
           end
         end
@@ -150,7 +180,12 @@ RSpec.describe "Personalisation - Check Email Subscription" do
 
           it "returns subscription status details as not active" do
             get check_email_subscription_path, params: params, headers: headers
-            expect(response.body).to eq(subscription_details)
+            expect(JSON.parse(response.body)).to include(subscription_details)
+          end
+
+          it "does not include button HTML" do
+            get check_email_subscription_path, params: params, headers: headers
+            expect(response.body).not_to include("button_html")
           end
         end
       end


### PR DESCRIPTION
This is so that the javascript can just replace the existing button,
rather than trying to do some more fancy DOM manipulation.

---

To try this out locally, you'll also need #277 

---

[Trello card](https://trello.com/c/oOpGMmxF/1126-put-the-single-page-signup-button-on-some-pages)