### PR TITLE
For linked accounts, end notifications on account deletion

### DIFF
--- a/app/controllers/oidc_users_controller.rb
+++ b/app/controllers/oidc_users_controller.rb
@@ -16,40 +16,7 @@ class OidcUsersController < ApplicationController
     end
 
     if (email_changed || email_verified_changed) && user.email && user.email_verified
-      begin
-        # if the user has linked their notifications account to their
-        # GOV.UK account we don't need to update their
-        # `user.email_subscriptions`, because we can update the
-        # subscriber directly.
-        subscriber_id = GdsApi.email_alert_api
-          .find_subscriber_by_govuk_account(govuk_account_id: user.id)
-          .dig("subscriber", "id")
-        GdsApi.email_alert_api.change_subscriber(
-          id: subscriber_id,
-          new_address: user.email,
-          on_conflict: "merge",
-        )
-      rescue GdsApi::HTTPNotFound
-        # but for users who haven't linked their notifications account
-        # to their GOV.UK account, we do need to update any
-        # account-linked subscriptions they have (eg, brexit checker
-        # users who haven't touched notifications since registering
-        # through the checker).
-        #
-        # this branch can be removed once we have no GOV.UK accounts
-        # which have subscriptions but are *not* linked to the
-        # corresponding notifications account.
-        user.email_subscriptions.find_each do |subscription|
-          if subscription.activated? && !subscription.check_if_still_active!
-            subscription.destroy!
-            next
-          end
-
-          subscription.reactivate_if_confirmed!
-        rescue EmailSubscription::SubscriberListNotFound
-          subscription.destroy!
-        end
-      end
+      update_email_alert_api_address(user)
     end
 
     render json: user.get_attributes_by_name(OIDC_USER_ATTRIBUTES).merge(sub: user.sub)
@@ -61,14 +28,7 @@ class OidcUsersController < ApplicationController
       legacy_sub: params[:legacy_sub],
     )
 
-    begin
-      subscriber_id = GdsApi.email_alert_api
-        .find_subscriber_by_govuk_account(govuk_account_id: user.id)
-        .dig("subscriber", "id")
-      GdsApi.email_alert_api.unsubscribe_subscriber(subscriber_id)
-    rescue GdsApi::HTTPNotFound
-      nil
-    end
+    end_email_alert_api_subscriptions(user)
 
     user.destroy!
 
@@ -81,5 +41,52 @@ private
 
   def authorise_sso_user!
     authorise_user!("update_protected_attributes")
+  end
+
+  def update_email_alert_api_address(user)
+    # if the user has linked their notifications account to their
+    # GOV.UK account we don't need to update their
+    # `user.email_subscriptions`, because we can update the subscriber
+    # directly.
+    GdsApi.email_alert_api.change_subscriber(
+      id: email_alert_api_subscriber_id(user),
+      new_address: user.email,
+      on_conflict: "merge",
+    )
+  rescue GdsApi::HTTPNotFound
+    # but for users who haven't linked their notifications account to
+    # their GOV.UK account, we do need to update any account-linked
+    # subscriptions they have (eg, brexit checker users who haven't
+    # touched notifications since registering through the checker).
+    #
+    # this branch can be removed once we have no GOV.UK accounts which
+    # have subscriptions but are *not* linked to the corresponding
+    # notifications account.
+    user.email_subscriptions.find_each do |subscription|
+      if subscription.activated? && !subscription.check_if_still_active!
+        subscription.destroy!
+        next
+      end
+
+      subscription.reactivate_if_confirmed!
+    rescue EmailSubscription::SubscriberListNotFound
+      subscription.destroy!
+    end
+  end
+
+  def end_email_alert_api_subscriptions(user)
+    GdsApi.email_alert_api.unsubscribe_subscriber(
+      email_alert_api_subscriber_id(user),
+    )
+  rescue GdsApi::HTTPNotFound
+    # if there is no linked notifications account, there is nothing to
+    # do
+    nil
+  end
+
+  def email_alert_api_subscriber_id(user)
+    GdsApi.email_alert_api
+      .find_subscriber_by_govuk_account(govuk_account_id: user.id)
+      .dig("subscriber", "id")
   end
 end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -150,7 +150,8 @@ Pact.provider_states_for "GDS API Adapters" do
 
   provider_state "there is a user with subject identifier 'the-subject-identifier'" do
     set_up do
-      FactoryBot.create(:oidc_user, sub: "the-subject-identifier")
+      user = FactoryBot.create(:oidc_user, sub: "the-subject-identifier")
+      stub_request(:get, "#{GdsApi::TestHelpers::EmailAlertApi::EMAIL_ALERT_API_ENDPOINT}/subscribers/govuk-account/#{user.id}").to_return(status: 404)
     end
   end
 


### PR DESCRIPTION
When a user is deleted, we end the subscriptions we know about in
account-api: currently this is just the brexit checker subscription.

This commit extends that to handle ending *all* subscriptions, in the
case where the user has linked their notifications account to their
GOV.UK account.

---

[Trello card](https://trello.com/c/32TCYJFr/1152-end-a-users-email-subscriptions-when-they-delete-their-account)
