### PR TITLE
Pass location to email subscription button

### DIFF
--- a/app/controllers/check_email_subscription_controller.rb
+++ b/app/controllers/check_email_subscription_controller.rb
@@ -18,6 +18,7 @@ class CheckEmailSubscriptionController < ApplicationController
   before_action do
     @base_path = params[:base_path]
     @topic_slug = params[:topic_slug]
+    @button_location = params[:button_location]
 
     head :unprocessable_entity if @base_path && @topic_slug
     head :unprocessable_entity unless @base_path || @topic_slug
@@ -62,6 +63,7 @@ private
     {
       base_path: @base_path,
       topic_slug: @topic_slug,
+      button_location: @button_location,
       active: active,
       button_html: render_button_component(active),
     }.compact
@@ -70,7 +72,7 @@ private
   def render_button_component(active)
     ActionController::Base.render(
       partial: "govuk_publishing_components/components/single_page_notification_button",
-      locals: { base_path: @base_path, already_subscribed: active },
+      locals: { base_path: @base_path, button_location: @button_location, already_subscribed: active },
     ).presence
   end
 end

--- a/docs/api.md
+++ b/docs/api.md
@@ -677,6 +677,8 @@ See [Progressive enhancement ADR for more details](/docs/adr/002-progressive-enh
   - the base path of the page (to match against the "url" of an email-alert-api subscriber list)
 - `topic_slug` *(optional)*
   - the email-alert-api topic slug
+- `button_location` *(optional)*
+  - the location of the button on the page (`top` or `bottom`). This is passed to the button component to add tracking parameters for Google Analytics
 
 Exactly one of `base_path` and `topic_slug` must be specified.
 
@@ -690,6 +692,8 @@ Exactly one of `base_path` and `topic_slug` must be specified.
   - whether the subscription is active (a boolean)
 - `button_html`
   - the rendered single-page notification button component HTML, if a `base_path` was given (a string)
+- `button_location`
+  - the button_location parameter, if there is one (a string)
 
 #### Response codes
 

--- a/spec/requests/check_email_subscription_spec.rb
+++ b/spec/requests/check_email_subscription_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe "Personalisation - Check Email Subscription" do
   describe "GET /api/personalisation/check-email-subscription" do
     let(:base_path) { nil }
     let(:topic_slug) { nil }
-    let(:params) { { base_path: base_path, topic_slug: topic_slug }.compact }
+    let(:button_location) { nil }
+    let(:params) { { base_path: base_path, topic_slug: topic_slug, button_location: button_location }.compact }
 
     let(:active) { false }
 
@@ -122,6 +123,15 @@ RSpec.describe "Personalisation - Check Email Subscription" do
             it "includes the inactive-state button HTML" do
               get check_email_subscription_path, params: params, headers: headers
               expect(JSON.parse(response.body)["button_html"]).to include("Get emails about this page")
+            end
+
+            context "when a button location is passed" do
+              let(:button_location) { "top-of-page" }
+
+              it "returns the location in the response" do
+                get check_email_subscription_path, params: params, headers: headers
+                expect(JSON.parse(response.body)["button_location"]).to eq(button_location)
+              end
             end
           end
         end


### PR DESCRIPTION
It's possible to have two of these buttons on a page - one before and
one after the content. We'd like to be able to track clicks on these
separately in Google Analytics, so we need some way of differentiating
them.

Accept an optional  `button_location` parameter to the check email
subscriptions route and pass it on to the component so the component
can handle adding the required attributes for click tracking.

Also return the `button_location` in the JSON response to aid debugging.

[Trello](https://trello.com/c/oOpGMmxF/1126-put-the-single-page-signup-button-on-some-pages)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
