### PR TITLE
Add a rake task to publish a single special route

### DIFF
--- a/lib/publishing_api_tasks.rb
+++ b/lib/publishing_api_tasks.rb
@@ -68,6 +68,30 @@ class PublishingApiTasks
     end
   end
 
+  def publish_special_route(content_id)
+    publisher = GdsApi::PublishingApi::SpecialRoutePublisher.new(
+      publishing_api: @publishing_api,
+      logger: @logger,
+    )
+
+    special_route = @content_items[:special_routes].find { |route| route[:content_id] == content_id }
+
+    if special_route.nil?
+      puts "No special route found with content_id: #{content_id}"
+      puts "Check files stored in: https://github.com/alphagov/account-api/blob/main/config/content_items.yml"
+      return
+    end
+
+    claim_path special_route.fetch(:base_path)
+
+    publisher.publish(
+      special_route.merge(
+        publishing_app: PUBLISHING_APP,
+        type: "exact",
+      ),
+    )
+  end
+
   def publish_special_routes
     publisher = GdsApi::PublishingApi::SpecialRoutePublisher.new(
       publishing_api: @publishing_api,

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -15,4 +15,9 @@ namespace :publishing_api do
   task :publish_help_page, [:name] => :environment do |_, args|
     PublishingApiTasks.new.publish_help_page args[:name]
   end
+
+  desc "Publish a single special route by content_id"
+  task :publish_special_route, [:content_id] => :environment do |_, args|
+    PublishingApiTasks.new.publish_special_route args[:content_id]
+  end
 end

--- a/spec/lib/publishing_api_tasks_spec.rb
+++ b/spec/lib/publishing_api_tasks_spec.rb
@@ -79,6 +79,26 @@ RSpec.describe PublishingApiTasks do
     end
   end
 
+  describe "#publish_special_route" do
+    before { allow(logger).to receive(:info) }
+
+    let(:content_id) { SecureRandom.uuid }
+    let(:special_route) { { content_id: content_id, base_path: "/foo", title: "title", rendering_app: "frontend" } }
+    let(:content_items) { { special_routes: [special_route] } }
+
+    it "takes ownership of the route and publishes the content item" do
+      stub_claim_path = stub_call_claim_path(special_route[:base_path])
+      stub_put_content = stub_call_put_content(special_route[:content_id], special_route.except(:content_id), "major")
+      stub_publish = stub_call_publish(special_route[:content_id], "major")
+
+      tasks.publish_special_route(content_id)
+
+      expect(stub_claim_path).to have_been_made
+      expect(stub_put_content).to have_been_made
+      expect(stub_publish).to have_been_made
+    end
+  end
+
   describe "#publish_special_routes" do
     before { allow(logger).to receive(:info) }
 


### PR DESCRIPTION
We have a way of publishing them all, but not a single one.
Let's change that, you can pass in a contnet ID.

If that ID is not stored amongst this apps special routes, then return
early and output a message.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
