### PR TITLE
Remove unneeded ga_client_id parameter from auth callback response

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -36,10 +36,6 @@ class AuthenticationController < ApplicationController
       redirect_path: redirect_path,
       cookie_consent: govuk_account_session.user.cookie_consent,
       feedback_consent: govuk_account_session.user.feedback_consent,
-      # TODO: remove `ga_client_id` after we switch to DI, we're using
-      # a different approach there which doesn't go via the
-      # account-api
-      ga_client_id: details[:ga_session_id],
     }
   rescue OidcClient::OAuthFailure
     head :unauthorized

--- a/docs/api.md
+++ b/docs/api.md
@@ -135,8 +135,6 @@ On a `401: Unauthorized` response, the identity provider has rejected the authen
   - a session identifier
 - `redirect_path` *(optional)*
   - the `redirect_path` which was previously passed to `GET /api/oauth2/sign-in`, if given
-- `ga_client_id` *(optional)*
-  - the Google Analytics client ID which the identity provider used for analytics
 - `cookie_consent`
   - whether the user has accepted or rejected usage cookies (a boolean, or `null` if the user hasn't saved a preference)
 - `feedback_consent`
@@ -164,7 +162,6 @@ Response:
 {
     "govuk_account_session": "YWNjZXNzLXRva2Vu.cmVmcmVzaC10b2tlbg==",
     "redirect_path": "/guidance/keeping-a-pet-pig-or-micropig",
-    "ga_client_id": "ga-123-userid",
     "cookie_consent": false,
 }
 ```


### PR DESCRIPTION
This value has always been `nil` since we migrated to DI in
production.
