### PR TITLE
Remove `has_unconfirmed_email` attribute

### DIFF
--- a/app/controllers/internal/authentication_controller.rb
+++ b/app/controllers/internal/authentication_controller.rb
@@ -70,9 +70,6 @@ private
 
     userinfo = details[:userinfo] || oidc_client.userinfo(access_token: details[:access_token], refresh_token: details[:refresh_token])[:result]
 
-    # TODO: remove merge! when this attribute is deleted
-    userinfo.merge!("has_unconfirmed_email" => false)
-
     govuk_account_session.set_attributes(userinfo.slice(*attributes_to_cache))
   end
 

--- a/app/controllers/internal/oidc_users_controller.rb
+++ b/app/controllers/internal/oidc_users_controller.rb
@@ -1,5 +1,5 @@
 class Internal::OidcUsersController < InternalController
-  OIDC_USER_ATTRIBUTES = %w[email email_verified has_unconfirmed_email cookie_consent feedback_consent].freeze
+  OIDC_USER_ATTRIBUTES = %w[email email_verified cookie_consent feedback_consent].freeze
 
   def update
     user = OidcUser.find_or_create_by_sub!(

--- a/app/controllers/internal/user_controller.rb
+++ b/app/controllers/internal/user_controller.rb
@@ -1,19 +1,15 @@
 class Internal::UserController < InternalController
   include AuthenticatedApiConcern
 
-  HOMEPAGE_ATTRIBUTES = %w[email email_verified has_unconfirmed_email transition_checker_state].freeze
+  HOMEPAGE_ATTRIBUTES = %w[email email_verified transition_checker_state].freeze
 
   def show
-    has_unconfirmed_email = attributes.dig(:has_unconfirmed_email, :value)
-    has_unconfirmed_email = false if has_unconfirmed_email.nil?
-
     render_api_response(
       {
         id: @govuk_account_session.user.id.to_s,
         mfa: @govuk_account_session.mfa?,
         email: attributes.dig("email", :value),
         email_verified: attributes.dig("email_verified", :value),
-        has_unconfirmed_email: has_unconfirmed_email,
         services: {
           transition_checker: attribute_service("transition_checker_state"),
         }.compact,

--- a/app/lib/oidc_client/fake.rb
+++ b/app/lib/oidc_client/fake.rb
@@ -51,7 +51,6 @@ class OidcClient::Fake < OidcClient
           "sub" => user.sub,
           "email" => user.email,
           "email_verified" => user.email_verified,
-          "has_unconfirmed_email" => user.has_unconfirmed_email,
         },
     }
   end
@@ -63,7 +62,6 @@ private
       sub: SecureRandom.uuid,
       email: "email@example.com",
       email_verified: true,
-      has_unconfirmed_email: false,
     )
   end
 end

--- a/config/user_attributes.yml
+++ b/config/user_attributes.yml
@@ -7,11 +7,6 @@ shared:
     type: cached
     writable: false
 
-  # TODO: remove this attribute after removing its use from other apps
-  has_unconfirmed_email:
-    type: cached
-    writable: false
-
   cookie_consent:
     type: local
 

--- a/db/migrate/20211207090018_remove_has_unconfirmed_email_from_oidc_users.rb
+++ b/db/migrate/20211207090018_remove_has_unconfirmed_email_from_oidc_users.rb
@@ -1,0 +1,5 @@
+class RemoveHasUnconfirmedEmailFromOidcUsers < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :oidc_users, :has_unconfirmed_email, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_04_103629) do
+ActiveRecord::Schema.define(version: 2021_12_07_090018) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,7 +41,6 @@ ActiveRecord::Schema.define(version: 2021_11_04_103629) do
     t.boolean "has_received_transition_checker_onboarding_email", default: false, null: false
     t.string "email"
     t.boolean "email_verified"
-    t.boolean "has_unconfirmed_email"
     t.boolean "oidc_users"
     t.jsonb "transition_checker_state"
     t.string "legacy_sub"

--- a/docs/api.md
+++ b/docs/api.md
@@ -575,8 +575,6 @@ This endpoint requires the `update_protected_attributes` scope.
   - the new email address (a string)
 - `email_verified` *(optional)*
   - whether the new email address is verified (a boolean)
-- `has_unconfirmed_email` *(optional)*
-  - whether the user has a pending email change to confirm (a boolean)
 - `cookie_consent` *(optional)*
   - whether the user has consented to analytics cookies, this is temporary while we import data from the account-manager (a boolean)
 - `feedback_consent` *(optional)*
@@ -588,7 +586,6 @@ This endpoint requires the `update_protected_attributes` scope.
   - the subject identifier
 - `email`
 - `email_verified`
-- `has_unconfirmed_email`
 - `cookie_consent`
 - `feedback_consent`
 
@@ -605,7 +602,6 @@ GdsApi.account_api.update_user_by_subject_identifier(
     subject_identifier: "subject-identifier",
     email: "user@example.com",
     email_verified: true,
-    has_unconfirmed_email: false,
     cookie_consent: true,
     feedback_consent: false,
 )
@@ -618,7 +614,6 @@ Response:
     "sub": "subject-identifier",
     "email": "user@example.com",
     "email_verified": true,
-    "has_unconfirmed_email": false
 }
 ```
 

--- a/spec/factories/oidc_user_factory.rb
+++ b/spec/factories/oidc_user_factory.rb
@@ -3,6 +3,5 @@ FactoryBot.define do
     sequence(:sub) { |n| "user-id-#{n}" }
     sequence(:email) { |n| "user-#{n}@example.com" }
     email_verified { true }
-    has_unconfirmed_email { false }
   end
 end

--- a/spec/lib/oidc_client/fake_spec.rb
+++ b/spec/lib/oidc_client/fake_spec.rb
@@ -64,7 +64,6 @@ RSpec.describe OidcClient::Fake do
         "sub" => user.sub,
         "email" => user.email || "email@example.com",
         "email_verified" => user.email_verified || false,
-        "has_unconfirmed_email" => user.has_unconfirmed_email || false,
       }
 
       expect(client.userinfo(access_token: access_token)).to eq({ access_token: access_token, result: userinfo })

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -61,16 +61,15 @@ RSpec.describe "Authentication" do
     end
 
     context "when cacheable attributes are missing" do
-      let!(:user) { FactoryBot.create(:oidc_user, sub: "user-id", email: nil, email_verified: nil, has_unconfirmed_email: nil) }
+      let!(:user) { FactoryBot.create(:oidc_user, sub: "user-id", email: nil, email_verified: nil) }
 
       it "fetches them from userinfo" do
-        stub = stub_userinfo(email: "email@example.com", email_verified: true, has_unconfirmed_email: false)
+        stub = stub_userinfo(email: "email@example.com", email_verified: true)
         post callback_path, headers: headers, params: { state: auth_request.to_oauth_state, code: "12345" }.to_json
         expect(response).to be_successful
         expect(stub).to have_been_made
         expect(user.reload.email).to eq("email@example.com")
         expect(user.reload.email_verified).to be(true)
-        expect(user.reload.has_unconfirmed_email).to be(false)
       end
     end
 

--- a/spec/requests/oidc_users_spec.rb
+++ b/spec/requests/oidc_users_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe "OIDC Users endpoint" do
       {
         email: email,
         email_verified: email_verified,
-        has_unconfirmed_email: has_unconfirmed_email,
         legacy_sub: legacy_sub,
         cookie_consent: cookie_consent,
         feedback_consent: feedback_consent,
@@ -20,7 +19,6 @@ RSpec.describe "OIDC Users endpoint" do
     end
     let(:email) { "email@example.com" }
     let(:email_verified) { true }
-    let(:has_unconfirmed_email) { false }
     let(:cookie_consent) { true }
     let(:feedback_consent) { false }
 
@@ -42,7 +40,6 @@ RSpec.describe "OIDC Users endpoint" do
       put oidc_user_path(subject_identifier: subject_identifier), params: params, headers: headers
       expect(JSON.parse(response.body)["email"]).to eq(email)
       expect(JSON.parse(response.body)["email_verified"]).to eq(email_verified)
-      expect(JSON.parse(response.body)["has_unconfirmed_email"]).to eq(has_unconfirmed_email)
       expect(JSON.parse(response.body)["cookie_consent"]).to eq(cookie_consent)
       expect(JSON.parse(response.body)["feedback_consent"]).to eq(feedback_consent)
     end
@@ -61,31 +58,27 @@ RSpec.describe "OIDC Users endpoint" do
         put oidc_user_path(subject_identifier: subject_identifier), params: params, headers: headers
         expect(JSON.parse(response.body)["email"]).to eq(email)
         expect(JSON.parse(response.body)["email_verified"]).to eq(email_verified)
-        expect(JSON.parse(response.body)["has_unconfirmed_email"]).to eq(has_unconfirmed_email)
         expect(JSON.parse(response.body)["cookie_consent"]).to eq(cookie_consent)
         expect(JSON.parse(response.body)["feedback_consent"]).to eq(feedback_consent)
 
         user.reload
         expect(user.email).to eq(email)
         expect(user.email_verified).to eq(email_verified)
-        expect(user.has_unconfirmed_email).to eq(has_unconfirmed_email)
         expect(user.cookie_consent).to eq(cookie_consent)
         expect(user.feedback_consent).to eq(feedback_consent)
       end
 
       it "doesn't update nil attributes" do
         put oidc_user_path(subject_identifier: subject_identifier), params: params, headers: headers
-        put oidc_user_path(subject_identifier: subject_identifier), params: { email: "new-email@example.com", email_verified: nil, has_unconfirmed_email: nil, cookie_consent: nil, feedback_consent: nil }.to_json, headers: headers
+        put oidc_user_path(subject_identifier: subject_identifier), params: { email: "new-email@example.com", email_verified: nil, cookie_consent: nil, feedback_consent: nil }.to_json, headers: headers
         expect(JSON.parse(response.body)["email"]).to eq("new-email@example.com")
         expect(JSON.parse(response.body)["email_verified"]).to eq(email_verified)
-        expect(JSON.parse(response.body)["has_unconfirmed_email"]).to eq(has_unconfirmed_email)
         expect(JSON.parse(response.body)["cookie_consent"]).to eq(cookie_consent)
         expect(JSON.parse(response.body)["feedback_consent"]).to eq(feedback_consent)
 
         user.reload
         expect(user.email).to eq("new-email@example.com")
         expect(user.email_verified).to eq(email_verified)
-        expect(user.has_unconfirmed_email).to eq(has_unconfirmed_email)
         expect(user.cookie_consent).to eq(cookie_consent)
         expect(user.feedback_consent).to eq(feedback_consent)
       end
@@ -112,13 +105,11 @@ RSpec.describe "OIDC Users endpoint" do
           expect(JSON.parse(response.body)["sub"]).to eq("post-migration-subject-identifier")
           expect(JSON.parse(response.body)["email"]).to eq(email)
           expect(JSON.parse(response.body)["email_verified"]).to eq(email_verified)
-          expect(JSON.parse(response.body)["has_unconfirmed_email"]).to eq(has_unconfirmed_email)
 
           user.reload
           expect(user.sub).to eq("post-migration-subject-identifier")
           expect(user.email).to eq(email)
           expect(user.email_verified).to eq(email_verified)
-          expect(user.has_unconfirmed_email).to eq(has_unconfirmed_email)
         end
       end
 

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe "User information endpoint" do
     {
       email: "email@example.com",
       email_verified: true,
-      has_unconfirmed_email: false,
     }
   end
 

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -9,11 +9,10 @@ Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
 module PactStubHelpers
   EMAIL_ADDRESS = "user@example.com".freeze
 
-  def stub_cached_attributes(email_verified: true, has_unconfirmed_email: false)
+  def stub_cached_attributes(email_verified: true)
     oidc_user.update!(
       email: EMAIL_ADDRESS,
       email_verified: email_verified,
-      has_unconfirmed_email: has_unconfirmed_email,
     )
   end
 


### PR DESCRIPTION
This attribute is no longer used since we
switched to DI's SSO service as they require users to confirm their
email address as part of the account creation journey.

[Trello](https://trello.com/c/SdkcF8EO/13-remove-hasunconfirmedemail-attribute)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
