### PR TITLE
Remove cookie & feedback consent from OidcUsersController

### DIFF
--- a/app/controllers/internal/oidc_users_controller.rb
+++ b/app/controllers/internal/oidc_users_controller.rb
@@ -1,5 +1,5 @@
 class Internal::OidcUsersController < InternalController
-  OIDC_USER_ATTRIBUTES = %w[email email_verified cookie_consent feedback_consent].freeze
+  OIDC_USER_ATTRIBUTES = %w[email email_verified].freeze
 
   def update
     user = OidcUser.find_or_create_by_sub!(

--- a/docs/api.md
+++ b/docs/api.md
@@ -575,10 +575,6 @@ This endpoint requires the `update_protected_attributes` scope.
   - the new email address (a string)
 - `email_verified` *(optional)*
   - whether the new email address is verified (a boolean)
-- `cookie_consent` *(optional)*
-  - whether the user has consented to analytics cookies, this is temporary while we import data from the account-manager (a boolean)
-- `feedback_consent` *(optional)*
-  - whether the user has consented to being contacted for feedback, this is temporary while we import data from the account-manager (a boolean)
 
 #### JSON response fields
 
@@ -586,8 +582,6 @@ This endpoint requires the `update_protected_attributes` scope.
   - the subject identifier
 - `email`
 - `email_verified`
-- `cookie_consent`
-- `feedback_consent`
 
 #### Response codes
 
@@ -602,8 +596,6 @@ GdsApi.account_api.update_user_by_subject_identifier(
     subject_identifier: "subject-identifier",
     email: "user@example.com",
     email_verified: true,
-    cookie_consent: true,
-    feedback_consent: false,
 )
 ```
 

--- a/spec/requests/oidc_users_spec.rb
+++ b/spec/requests/oidc_users_spec.rb
@@ -13,14 +13,10 @@ RSpec.describe "OIDC Users endpoint" do
         email: email,
         email_verified: email_verified,
         legacy_sub: legacy_sub,
-        cookie_consent: cookie_consent,
-        feedback_consent: feedback_consent,
       }.compact.to_json
     end
     let(:email) { "email@example.com" }
     let(:email_verified) { true }
-    let(:cookie_consent) { true }
-    let(:feedback_consent) { false }
 
     before do
       stub_request(:get, %r{\A#{GdsApi::TestHelpers::EmailAlertApi::EMAIL_ALERT_API_ENDPOINT}/subscribers/govuk-account/\d+\z}).to_return(status: 404)
@@ -40,8 +36,6 @@ RSpec.describe "OIDC Users endpoint" do
       put oidc_user_path(subject_identifier: subject_identifier), params: params, headers: headers
       expect(JSON.parse(response.body)["email"]).to eq(email)
       expect(JSON.parse(response.body)["email_verified"]).to eq(email_verified)
-      expect(JSON.parse(response.body)["cookie_consent"]).to eq(cookie_consent)
-      expect(JSON.parse(response.body)["feedback_consent"]).to eq(feedback_consent)
     end
 
     context "when the user already exists" do
@@ -58,29 +52,21 @@ RSpec.describe "OIDC Users endpoint" do
         put oidc_user_path(subject_identifier: subject_identifier), params: params, headers: headers
         expect(JSON.parse(response.body)["email"]).to eq(email)
         expect(JSON.parse(response.body)["email_verified"]).to eq(email_verified)
-        expect(JSON.parse(response.body)["cookie_consent"]).to eq(cookie_consent)
-        expect(JSON.parse(response.body)["feedback_consent"]).to eq(feedback_consent)
 
         user.reload
         expect(user.email).to eq(email)
         expect(user.email_verified).to eq(email_verified)
-        expect(user.cookie_consent).to eq(cookie_consent)
-        expect(user.feedback_consent).to eq(feedback_consent)
       end
 
       it "doesn't update nil attributes" do
         put oidc_user_path(subject_identifier: subject_identifier), params: params, headers: headers
-        put oidc_user_path(subject_identifier: subject_identifier), params: { email: "new-email@example.com", email_verified: nil, cookie_consent: nil, feedback_consent: nil }.to_json, headers: headers
+        put oidc_user_path(subject_identifier: subject_identifier), params: { email: "new-email@example.com", email_verified: nil }.to_json, headers: headers
         expect(JSON.parse(response.body)["email"]).to eq("new-email@example.com")
         expect(JSON.parse(response.body)["email_verified"]).to eq(email_verified)
-        expect(JSON.parse(response.body)["cookie_consent"]).to eq(cookie_consent)
-        expect(JSON.parse(response.body)["feedback_consent"]).to eq(feedback_consent)
 
         user.reload
         expect(user.email).to eq("new-email@example.com")
         expect(user.email_verified).to eq(email_verified)
-        expect(user.cookie_consent).to eq(cookie_consent)
-        expect(user.feedback_consent).to eq(feedback_consent)
       end
 
       context "when a different user tried to use the same email address" do


### PR DESCRIPTION
These parameters were only used to migrate data from the account
manager.
