### PR TITLE
Use `extra`, not `tags`, for captured sensitive exception IDs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::API
   end
 
   rescue_from CapturedSensitiveException do |error|
-    GovukError.notify("CapturedSensitiveException", { tags: { sensitive_exception_id: error.captured.id } })
+    GovukError.notify("CapturedSensitiveException", { extra: { sensitive_exception_id: error.captured.id } })
     head :internal_server_error
   end
 

--- a/app/controllers/internal/authentication_controller.rb
+++ b/app/controllers/internal/authentication_controller.rb
@@ -27,7 +27,7 @@ class Internal::AuthenticationController < InternalController
       version: AccountSession::CURRENT_VERSION,
     )
 
-    capture_sensitive_exceptions do
+    capture_sensitive_exceptions(govuk_account_session.user) do
       fetch_cacheable_attributes!(govuk_account_session, details)
     end
 

--- a/app/controllers/internal/oidc_users_controller.rb
+++ b/app/controllers/internal/oidc_users_controller.rb
@@ -10,7 +10,7 @@ class Internal::OidcUsersController < InternalController
     email_changed = params.key?(:email) && (params[:email] != user.email)
     email_verified_changed = params.key?(:email_verified) && params[:email_verified] != user.email_verified
 
-    capture_sensitive_exceptions do
+    capture_sensitive_exceptions(user) do
       user.update!(params.permit(OIDC_USER_ATTRIBUTES).to_h.compact)
       user.reload
     end


### PR DESCRIPTION
`tags` is a way of filtering events.  When looking at a group of
events, you can click the "tags" panel, and then click a tag value to
filter to only those events with the same tag.

`extra` is a way of adding additional information to a single event.
When looking at a group of events, each has an "Additional Data"
section (beneath the "Operating System" and "Runtime" sections).  No
changing of panels needed, it's right there.

So change to `extra` here as it's more correct (and more convenient)
for what we're trying to do: attach unique data to each event.

---

```ruby
GovukError.notify("Michael's Test Error", { tags: { some_tag_here: "tag-value" } })
```

<img width="1789" alt="Screenshot 2021-12-10 at 12 06 37" src="https://user-images.githubusercontent.com/75235/145571862-1730c29f-1e3a-4811-ac4f-2c6408b9896c.png">

```ruby
GovukError.notify("Michael's Test Error", { extra: { extra_data_here: "extra-data-value" } })
```

<img width="694" alt="Screenshot 2021-12-10 at 12 06 59" src="https://user-images.githubusercontent.com/75235/145571884-b3a75605-85a7-471d-b65a-e7d7f83faf2c.png">
