### PR TITLE
Update content on `/sign-in`

### DIFF
--- a/app/views/help_pages/sign_in.html.erb
+++ b/app/views/help_pages/sign_in.html.erb
@@ -38,9 +38,9 @@
       path: "/sign-in-childcare-account",
       description: "Get 30 hours free childcare and pay for Tax-Free Childcare.",
     },{
-      text: "Manage your student loan balance",
-      path: "/sign-in-to-manage-your-student-loan-balance",
-      description: "See your student loan balance and manage your repayments.",
+      text: "Manage your GOV.UK emails",
+      path: "/email/manage",
+      description: "Manage the emails you get about GOV.UK pages you’re interested in.",
     }]
     links.each_with_index do |link, index|
       link[:data_attributes] = {

--- a/app/views/help_pages/sign_in.html.erb
+++ b/app/views/help_pages/sign_in.html.erb
@@ -22,6 +22,14 @@
       path: "/log-in-register-hmrc-online-services",
       description: "Sign in to HMRC services using Government Gateway or GOV.UK Verify.",
     },{
+      text: "Report a COVID-19 rapid lateral flow test result",
+      path: "/report-covid19-result",
+      description: "Report your result to the NHS after using a rapid lateral flow test kit.",
+    },{
+      text: "Passenger locator form",
+      path: "/provide-journey-contact-details-before-travel-uk",
+      description: "Edit and submit an unfinished passenger locator form for travelling to the UK.",
+    },{
       text: "Check your State Pension forecast",
       path: "/check-state-pension",
       description: "Find out how much State Pension you could get and when.",
@@ -29,10 +37,6 @@
       text: "Childcare account",
       path: "/sign-in-childcare-account",
       description: "Get 30 hours free childcare and pay for Tax-Free Childcare.",
-    },{
-      text: "Passenger locator form",
-      path: "/provide-journey-contact-details-before-travel-uk",
-      description: "Edit and submit an unfinished passenger locator form.",
     },{
       text: "Manage your student loan balance",
       path: "/sign-in-to-manage-your-student-loan-balance",


### PR DESCRIPTION
Update the list of services on `www.gov.uk/sign-in`:

- Add 'Report a COVID-19 rapid lateral flow test result'
- Move 'Passenger locator form' up a position & update the description
- Replace 'Manage your student loan balance' with 'Manage your GOV.UK emails'

After these changes are deployed to production we'll need to run the `publishing_api:publish_help_page[sign_in]` rake task to update the page. 

[Trello](https://trello.com/c/qLJfEnY4/1180-add-lateral-flow-test-and-email-updates-to-sign-in-to-a-service)
[Figma](https://www.figma.com/file/LjCm4D7zaur9zLXjJ0aylu/Sign-in-to-a-service-(sorting-hat)-experiment?node-id=865%3A3867)

The new page:
![image](https://user-images.githubusercontent.com/6362602/146199963-48732f99-b5d2-44e7-a0f1-ee71ae2cdefc.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
