### PR TITLE
Remove use of refresh tokens entirely

### DIFF
--- a/app/controllers/internal/authentication_controller.rb
+++ b/app/controllers/internal/authentication_controller.rb
@@ -68,7 +68,7 @@ private
 
     return if attributes_to_cache.empty?
 
-    userinfo = details[:userinfo] || oidc_client.userinfo(access_token: details[:access_token], refresh_token: details[:refresh_token])[:result]
+    userinfo = details[:userinfo] || oidc_client.userinfo(access_token: details[:access_token])
 
     govuk_account_session.set_attributes(userinfo.slice(*attributes_to_cache))
   end

--- a/app/lib/oidc_client/fake.rb
+++ b/app/lib/oidc_client/fake.rb
@@ -34,7 +34,6 @@ class OidcClient::Fake < OidcClient
 
     {
       access_token: user.sub,
-      refresh_token: "refresh-token",
       id_token_jwt: id_token_jwt,
       id_token: id_token,
     }.compact
@@ -45,13 +44,9 @@ class OidcClient::Fake < OidcClient
     raise NoDevelopmentUser unless user
 
     {
-      access_token: access_token,
-      result:
-        {
-          "sub" => user.sub,
-          "email" => user.email,
-          "email_verified" => user.email_verified,
-        },
+      "sub" => user.sub,
+      "email" => user.email,
+      "email_verified" => user.email_verified,
     }
   end
 

--- a/spec/lib/oidc_client/fake_spec.rb
+++ b/spec/lib/oidc_client/fake_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe OidcClient::Fake do
         "email_verified" => user.email_verified || false,
       }
 
-      expect(client.userinfo(access_token: access_token)).to eq({ access_token: access_token, result: userinfo })
+      expect(client.userinfo(access_token: access_token)).to eq(userinfo)
     end
 
     it "throws an error if the access token doesn't correspond to a user" do

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -1,11 +1,10 @@
 RSpec.describe "Authentication" do
   before do
     stub_oidc_discovery
-    stub_token_response(refresh_token: refresh_token)
+    stub_token_response
   end
 
   let(:headers) { { "Content-Type" => "application/json" } }
-  let(:refresh_token) { "refresh-token" }
 
   describe "/sign-in" do
     it "creates an AuthRequest to persist the attributes" do
@@ -83,16 +82,6 @@ RSpec.describe "Authentication" do
         post callback_path, headers: headers, params: { state: auth_request.to_oauth_state, code: "12345" }.to_json
         expect(response).to be_successful
         expect(JSON.parse(response.body)).to include("cookie_consent" => cookie_consent, "feedback_consent" => feedback_consent)
-      end
-    end
-
-    context "when there is no refresh token" do
-      let(:refresh_token) { nil }
-
-      it "responds successfully" do
-        stub_userinfo
-        post callback_path, headers: headers, params: { state: auth_request.to_oauth_state, code: "12345" }.to_json
-        expect(response).to be_successful
       end
     end
 

--- a/spec/support/helpers/oidc_client_helper.rb
+++ b/spec/support/helpers/oidc_client_helper.rb
@@ -12,10 +12,9 @@ module OidcClientHelper
     # rubocop:enable RSpec/AnyInstance
   end
 
-  def stub_token_response(refresh_token: "refresh-token", vot: "Cl")
+  def stub_token_response(vot: "Cl")
     token_response = {
       access_token: "access-token",
-      refresh_token: refresh_token,
       id_token_jwt: "id-token",
       id_token: instance_double(
         "OpenIDConnect::ResponseObject::IdToken",


### PR DESCRIPTION
Our pre-DI auth prototype service issued refresh tokens.  We used
these to fetch the UserInfo response when a user tried to use an
attribute which we don't have cached for them.

DI do not do refresh tokens, so we made the minimal change needed to
our code: we added support for there *not* being a refresh
token (rather than assuming one always exists) and also made the
attribute-caching happen as soon as the access token is fetched, not
when the attribute is needed.  But we left the ability to use refresh
tokens in place.

DI have spotted us using invalid access tokens on occasion, and have
suggested that we might be re-using tokens.  This is kind of weird as
we now only use the access token to fetch the userinfo in the auth
callback: there are two places where we do that, but we share the
userinfo response if it gets fetched in the first place.  So we
shouldn't try to use the same access token twice.

I suspect that the change we made to support DI was not quite right.

If a userinfo request fails due to a 4xx error (which should ideally
not happen anyway), we'll call `OidcClient#refresh_client_tokens` and
retry the request.  We don't have anything to skip that if the refresh
token is missing, so my hunch is that that function just returns the
access token the client already has, and so one token is getting used
a second time.

Since we don't need refresh tokens in production, we can simplify the
OidcClient by stripping them out entirely.  If access tokens are still
being reused, this wasn't the real problem and we'll need to do some
more digging.  But even if that is the case, this change is positive.

---

[Trello card](https://trello.com/c/TbmyNJn9/1193-look-into-access-code-re-use-bug)
