### PR TITLE
Make /account a special route going to frontend

### DIFF
--- a/config/content_items.yml
+++ b/config/content_items.yml
@@ -7,12 +7,13 @@ help_pages:
     description: "Find the government service you need to sign in to. At the moment, there are separate accounts for different government services."
     rendering_app: "frontend"
 
-redirects:
-  - content_id: "0833d91b-d772-4144-b81f-e7a42df96d5b"
-    base_path: "/account"
-    destination: "/account/home"
+redirects: []
 
 special_routes:
+  - content_id: "0833d91b-d772-4144-b81f-e7a42df96d5b"
+    base_path: "/account"
+    title: "Sign in to GOV.UK (OAuth Redirect)"
+    rendering_app: "frontend"
   - content_id: "49ecdc1f-c98b-430e-8256-7a402239daf8"
     base_path: "/sign-in/redirect"
     title: "Sign in to GOV.UK (OAuth Redirect)"


### PR DESCRIPTION
Depends on https://github.com/alphagov/frontend/pull/3122

---

We've decided to retire /sign-in/redirect in favour of the
nicer-looking /account.  When we've updated everything which uses the
old route, we can unpublish it.

---

[Trello card](https://trello.com/c/1tMOYsbk/1218-change-sign-in-link-to-use-di-domain)
