### PR TITLE
Remove references to transition checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,13 @@ In development, this app uses a stub OIDC provider which signs you in
 as the first user in the database.
 
 This app does not serve any user-facing pages. To see the app working, you
-must run an app which uses it, such as [Finder Frontend][].
+must run an app which uses it, such as [frontend][].
 
-After starting Finder Frontend, you should be able to access the
-following links:
+After starting Frontend, you should be able to access the [account
+dashboard][].
 
-- the [Brexit checker journey start page][tc-start]
-- the [Brexit checker results page][tc-results] that reflects the
-  answers you give during the Brexit checker journey
-- the [account sign up page][tc-save-results] to save your answers
-
-[Finder Frontend]: https://github.com/alphagov/finder-frontend
-[tc-results]: http://finder-frontend.dev.gov.uk/transition-check/results?c[]=living-ie
-[tc-save-results]: http://finder-frontend.dev.gov.uk/transition-check/save-your-results?c%5B%5D=living-ie
-[tc-start]: http://finder-frontend.dev.gov.uk/transition-check/questions
+[frontend]: https://github.com/alphagov/frontend
+[account dashboard]: http://frontend.dev.gov.uk/account/home
 
 
 ## Technical documentation

--- a/app/controllers/internal/user_controller.rb
+++ b/app/controllers/internal/user_controller.rb
@@ -1,7 +1,7 @@
 class Internal::UserController < InternalController
   include AuthenticatedApiConcern
 
-  HOMEPAGE_ATTRIBUTES = %w[email email_verified transition_checker_state].freeze
+  HOMEPAGE_ATTRIBUTES = %w[email email_verified].freeze
 
   def show
     render_api_response(
@@ -10,18 +10,12 @@ class Internal::UserController < InternalController
         mfa: @govuk_account_session.mfa?,
         email: attributes.dig("email", :value),
         email_verified: attributes.dig("email_verified", :value),
-        services: {
-          transition_checker: attribute_service("transition_checker_state"),
-        }.compact,
+        services: {},
       },
     )
   end
 
 private
-
-  def attribute_service(attribute_name)
-    attributes[attribute_name][:state]
-  end
 
   def attributes
     @attributes ||=

--- a/config/user_attributes.yml
+++ b/config/user_attributes.yml
@@ -13,7 +13,8 @@ shared:
   feedback_consent:
     type: local
 
-  transition_checker_state:
+test:
+  test_mfa_attribute:
     type: local
     get_requires_mfa: true
     set_requires_mfa: true

--- a/docs/api.md
+++ b/docs/api.md
@@ -253,9 +253,7 @@ Response:
     "mfa": false,
     "email": "email@example.com",
     "email_verified": false,
-    "services": {
-        "transition_checker": "yes_but_must_reauthenticate",
-    }
+    "services": {}
 }
 ```
 
@@ -453,7 +451,7 @@ Request (with gds-api-adapters):
 
 ```ruby
 GdsApi.account_api.get_email_subscription(
-    name: "transition-checker",
+    name: "some-subscription",
     govuk_account_session: "session-identifier",
 )
 ```
@@ -462,8 +460,8 @@ GdsApi.account_api.get_email_subscription(
 {
     "govuk_account_session": "YWNjZXNzLXRva2Vu.cmVmcmVzaC10b2tlbg==",
     "email_subscription": {
-      "name": "transition-checker",
-      "topic_slug": "brexit-results-12345",
+      "name": "some-subscription",
+      "topic_slug": "subscriber-list-slug",
       "email_alert_api_subscription_id": "cd5f6972-faf3-4f1c-bb76-3774b0a389f0"
     },
 }
@@ -507,8 +505,8 @@ Request (with gds-api-adapters):
 
 ```ruby
 GdsApi.account_api.put_email_subscription(
-    name: "transition-checker",
-    topic_slug: "brexit-results-12345",
+    name: "some-subscription",
+    topic_slug: "subscriber-list-slug",
     govuk_account_session: "session-identifier",
 )
 ```
@@ -517,8 +515,8 @@ GdsApi.account_api.put_email_subscription(
 {
     "govuk_account_session": "YWNjZXNzLXRva2Vu.cmVmcmVzaC10b2tlbg==",
     "email_subscription": {
-      "name": "transition-checker",
-      "topic_slug": "brexit-results-12345",
+      "name": "some-subscription",
+      "topic_slug": "subscriber-list-slug",
       "email_alert_api_subscription_id": "96ae61d6-c2a1-48cb-8e67-da9d105ae381"
     },
 }
@@ -550,7 +548,7 @@ Request (with gds-api-adapters):
 
 ```ruby
 GdsApi.account_api.delete_email_subscription(
-    name: "transition-checker",
+    name: "some-subscription",
     govuk_account_session: "session-identifier",
 )
 ```

--- a/lib/tasks/support.rake
+++ b/lib/tasks/support.rake
@@ -7,15 +7,4 @@ namespace :support do
       puts "User '#{args[:email]}' does not exist"
     end
   end
-
-  desc "Get a user's Transition Checker results"
-  task :tc_results, [:email] => :environment do |_, args|
-    user = OidcUser.find_by("lower(email) = ?", args[:email].downcase)
-    abort "User does not exist" unless user
-
-    criteria_keys = user.transition_checker_state&.dig("criteria_keys")
-    abort "User has no saved transition checker answers" unless criteria_keys
-
-    puts "https://www.gov.uk/transition-check/results?#{Rack::Utils.build_nested_query(c: criteria_keys)}"
-  end
 end

--- a/spec/lib/account_session_spec.rb
+++ b/spec/lib/account_session_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe AccountSession do
 
     let(:cached_attribute_name) { "email" }
     let(:cached_attribute_value) { nil }
-    let(:local_attribute_name) { "transition_checker_state" }
+    let(:local_attribute_name) { "feedback_consent" }
     let(:local_attribute_value) { nil }
 
     describe "get_attributes" do
@@ -116,7 +116,7 @@ RSpec.describe AccountSession do
     end
 
     describe "set_attributes" do
-      let(:local_attribute_value) { [1, 2, 3, { "four" => "five" }] }
+      let(:local_attribute_value) { true }
 
       it "saves attributes to the database" do
         account_session.set_attributes(local_attribute_name => local_attribute_value)

--- a/spec/requests/attributes_spec.rb
+++ b/spec/requests/attributes_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe "Attributes" do
   let(:cached_attribute_name) { "email" }
   let(:cached_attribute_value) { "email@example.com" }
 
-  let(:local_attribute_name) { "transition_checker_state" }
-  let(:local_attribute_value) { [1, 2, { "buckle" => %w[my shoe] }] }
+  let(:local_attribute_name) { "feedback_consent" }
+  let(:local_attribute_value) { true }
 
-  let(:protected_attribute_name) { "transition_checker_state" }
+  let(:protected_attribute_name) { "test_mfa_attribute" }
 
   let(:unwritable_attribute_name) { cached_attribute_name }
 
@@ -127,7 +127,7 @@ RSpec.describe "Attributes" do
     end
 
     it "correctly round-trips local attributes" do
-      old_value = "hello world"
+      old_value = false
 
       account_session.user.update!(local_attribute_name => old_value)
 

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -41,33 +41,6 @@ RSpec.describe "User information endpoint" do
     expect(response_body["email_verified"]).to eq(attributes[:email_verified])
   end
 
-  describe "services.transition_checker" do
-    let(:service_state) { response_body.dig("services", "transition_checker") }
-
-    it "returns 'no'" do
-      get "/api/user", headers: headers
-      expect(service_state).to eq("no")
-    end
-
-    context "when the user has used the checker" do
-      before { session_identifier.user.update!(transition_checker_state: "state") }
-
-      it "returns 'yes_but_must_reauthenticate'" do
-        get "/api/user", headers: headers
-        expect(service_state).to eq("yes_but_must_reauthenticate")
-      end
-
-      context "when the user is logged in with MFA" do
-        let(:mfa) { true }
-
-        it "returns 'yes'" do
-          get "/api/user", headers: headers
-          expect(service_state).to eq("yes")
-        end
-      end
-    end
-  end
-
   context "when the user is not logged in" do
     let(:session_identifier) { nil }
 

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -140,14 +140,6 @@ Pact.provider_states_for "GDS API Adapters" do
     end
   end
 
-  # TODO: remove this state when https://github.com/alphagov/gds-api-adapters/pull/1134 is merged
-  provider_state "there is a valid user session, with an attribute called 'transition_checker_state'" do
-    set_up do
-      stub_cached_attributes
-      oidc_user.update!(transition_checker_state: { array: [1, 2, 3], some: { nested: "json" } })
-    end
-  end
-
   provider_state "there is a valid user session, with an attribute called 'feedback_consent'" do
     set_up do
       stub_cached_attributes


### PR DESCRIPTION
This commit removes all the code and tests referencing the
transition_checker_state attribute, and relevant examples from the
docs.

In a follow-up commit deployed after this one, we should add a
database migration to drop these from the database:

- `oidc_users.has_received_transition_checker_onboarding_email`
- `oidc_users.transition_checker_state`
- `unmigrated_oidc_users`

One downside of this change is that we no longer have an attribute
which stores arbitrary JSON, so the "correctly round-trips local
attributes" test is now much weaker: it's only testing that we handle
booleans properly.  I considered adding a test attribute, but that
felt like a step too far.

---

[Trello card](https://trello.com/c/cWrCi7H3/1231-remove-left-over-code-references-to-the-transition-checker)
