### PR TITLE
Remove old transition checker state

### DIFF
--- a/db/migrate/20220125163309_remove_old_transition_checker_state.rb
+++ b/db/migrate/20220125163309_remove_old_transition_checker_state.rb
@@ -1,0 +1,14 @@
+class RemoveOldTransitionCheckerState < ActiveRecord::Migration[6.1]
+  def up
+    change_table :oidc_users, bulk: true do |t|
+      t.remove :has_received_transition_checker_onboarding_email
+      t.remove :transition_checker_state
+    end
+
+    drop_table :unmigrated_oidc_users
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_07_090018) do
+ActiveRecord::Schema.define(version: 2022_01_25_163309) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,11 +38,9 @@ ActiveRecord::Schema.define(version: 2021_12_07_090018) do
     t.string "sub", null: false
     t.datetime "created_at", precision: 6, default: -> { "now()" }, null: false
     t.datetime "updated_at", precision: 6, default: -> { "now()" }, null: false
-    t.boolean "has_received_transition_checker_onboarding_email", default: false, null: false
     t.string "email"
     t.boolean "email_verified"
     t.boolean "oidc_users"
-    t.jsonb "transition_checker_state"
     t.string "legacy_sub"
     t.boolean "cookie_consent"
     t.boolean "feedback_consent"
@@ -63,16 +61,6 @@ ActiveRecord::Schema.define(version: 2021_12_07_090018) do
     t.datetime "created_at", precision: 6, default: -> { "now()" }, null: false
     t.datetime "updated_at", precision: 6, default: -> { "now()" }, null: false
     t.index ["sub"], name: "index_tombstones_on_sub", unique: true
-  end
-
-  create_table "unmigrated_oidc_users", force: :cascade do |t|
-    t.string "sub", null: false
-    t.string "email"
-    t.boolean "email_verified"
-    t.boolean "has_unconfirmed_email"
-    t.jsonb "transition_checker_state"
-    t.datetime "created_at", precision: 6, default: -> { "now()" }, null: false
-    t.datetime "updated_at", precision: 6, default: -> { "now()" }, null: false
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
This commit removes the transition checker state from the `oidc_users`
table, and drops the `unmigrated_oidc_users` table entirely.  This
migration is not reversible.

It's worth noting that we've not had any tickets which needed us to
check whether a user existed but wasn't migrated since the original
flurry of migration tickets.  So dropping the entire
`unmigrated_oidc_users` table, rather than just the column for saved
transition checker results, seems sensible.  If we do need this
information, we can always consult the backup we took of the
account-manager database before shutting that app down.

---

[Trello card](https://trello.com/c/cWrCi7H3/1231-remove-left-over-code-references-to-the-transition-checker)
