### PR TITLE
Update i18n to 1.9.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,7 +204,7 @@ GEM
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     httpclient (2.8.3)
-    i18n (1.9.0)
+    i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     json (2.6.1)
     json-jwt (1.13.0)


### PR DESCRIPTION
1.9.0 was yanked

CHANGELOG: https://github.com/ruby-i18n/i18n/releases
