### PR TITLE
Capture OAuth failures

### DIFF
--- a/spec/lib/oidc_client_spec.rb
+++ b/spec/lib/oidc_client_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe OidcClient do
       allow(@client_stub).to receive(:access_token!).and_raise(Rack::OAuth2::Client::Error.new(401, { error: "error", error_description: "description" }))
       # rubocop:enable RSpec/InstanceVariable
 
+      expect(GovukError).to receive(:notify)
       expect { client.tokens! }.to raise_error(OidcClient::OAuthFailure)
     end
 


### PR DESCRIPTION
This is a temporary measure to help diagnose an ongoing incident.

Capture errors when calling the `tokens` and `userinfo` endpoints to a
`SensitiveException` and cause a Sentry alert. Continue to raise an
`OAuthFailure` in these cases so the existing behaviour doesn't change.

---
[Trello](https://trello.com/c/GY5uRKms/1298-log-failed-requests-to-auth-oidc-tokens-and-userinfo-endpoints)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
