### PR TITLE
Add extra_info to sensitve exception

### DIFF
--- a/db/migrate/20220310145815_add_extra_information_to_sensitive_exception.rb
+++ b/db/migrate/20220310145815_add_extra_information_to_sensitive_exception.rb
@@ -1,0 +1,5 @@
+class AddExtraInformationToSensitiveException < ActiveRecord::Migration[7.0]
+  def change
+    add_column :sensitive_exceptions, :extra_info, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_01_25_163309) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_10_145815) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -53,6 +53,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_01_25_163309) do
     t.string "full_message"
     t.datetime "created_at", default: -> { "now()" }, null: false
     t.datetime "updated_at", default: -> { "now()" }, null: false
+    t.string "extra_info"
   end
 
   create_table "tombstones", force: :cascade do |t|


### PR DESCRIPTION
Whilst trying to debug we need more information about a subset of
errors. Here we add a next text string (intended for string encoded
JSON), and then supply it with a response code, response body and access
token info for a certain category of error.

We will want to remove this once we're done.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
