### PR TITLE
Update content for Sign in to a service page

### DIFF
--- a/app/views/help_pages/sign_in.html.erb
+++ b/app/views/help_pages/sign_in.html.erb
@@ -26,10 +26,6 @@
       path: "/report-covid19-result",
       description: "Report your result to the NHS after using a rapid lateral flow test kit.",
     },{
-      text: "Passenger locator form",
-      path: "/provide-journey-contact-details-before-travel-uk",
-      description: "Edit and submit an unfinished passenger locator form for travelling to the UK.",
-    },{
       text: "Check your State Pension forecast",
       path: "/check-state-pension",
       description: "Find out how much State Pension you could get and when.",


### PR DESCRIPTION
Remove passenger locator form from the list of services on "Sign in to a
service".
This is because travel rules are changing from Friday 18th March and
this step in travel will no longer be necessary.

Do not release this change until Friday March 18th

-----

https://trello.com/c/JozVHrIL

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
