### PR TITLE
Add a worker to delete old `SensitiveExceptions`

### DIFF
--- a/app/models/sensitive_exception.rb
+++ b/app/models/sensitive_exception.rb
@@ -1,2 +1,4 @@
 class SensitiveException < ApplicationRecord
+  EXPIRATION_AGE = 14.days
+  scope :expired, -> { where("created_at < ?", EXPIRATION_AGE.ago) }
 end

--- a/app/workers/expired_sensitive_exception_worker.rb
+++ b/app/workers/expired_sensitive_exception_worker.rb
@@ -1,0 +1,5 @@
+class ExpiredSensitiveExceptionWorker < ApplicationWorker
+  def perform
+    SensitiveException.expired.delete_all
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -9,3 +9,7 @@
   expired_auth_request_worker:
     every: '1h'
     class: ExpiredAuthRequestWorker
+
+  expired_sensitive_exception_worker:
+    every: '1h'
+    class: ExpiredSensitiveExceptionWorker

--- a/spec/workers/expired_sensitive_exception_worker_spec.rb
+++ b/spec/workers/expired_sensitive_exception_worker_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe ExpiredSensitiveExceptionWorker do
+  include ActiveSupport::Testing::TimeHelpers
+
+  before { freeze_time }
+
+  it "deletes old exceptions" do
+    SensitiveException.create!(message: "foo", full_message: "bar", created_at: (SensitiveException::EXPIRATION_AGE + 1.day).ago)
+    expect { described_class.new.perform }.to change(SensitiveException, :count).to(0)
+  end
+
+  it "doesn't delete recent exceptions" do
+    SensitiveException.create!(message: "foo", full_message: "bar", created_at: SensitiveException::EXPIRATION_AGE.ago)
+    expect { described_class.new.perform }.not_to change(SensitiveException, :count)
+  end
+end


### PR DESCRIPTION
We use `SensitiveExceptions` to store error messages which may contain
personal data so we can report the error in Sentry or Kibana but only
store the data and error message in our database.

We're also planning to use this mechanism to capture error responses
from the Auth team's OIDC API. These may contain authorisation codes
and access tokens which would allow access to a user's account.

We need a mechanism which automatically deletes these database records
once they're no longer useful to us. We should be getting a Sentry alert
and investigation quickly once an exception is raised, so we don't
need to keep them around for very long.

`AuthRequest`s have a very similar mechanism for cleaning up old entries
so reusing that makes sense.

We chose 14 days as the retention period as this matches how long GOV.UK
stores application logs in Kibana. There's no point in keeping this data
longer than the application logs as it's not very useful on its own.

---

[Trello](https://trello.com/c/15WqAeVo/1310-add-a-worker-to-account-api-that-deletes-old-sensitiveexceptions)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
