### PR TITLE
Log tokens response for failed userinfo calls

### DIFF
--- a/spec/lib/oidc_client_spec.rb
+++ b/spec/lib/oidc_client_spec.rb
@@ -1,4 +1,5 @@
 RSpec.describe OidcClient do
+  include ActiveSupport::Testing::TimeHelpers
   subject(:client) { described_class.new }
 
   before { stub_oidc_discovery }
@@ -69,10 +70,12 @@ RSpec.describe OidcClient do
       # rubocop:disable RSpec/InstanceVariable
       allow(@client_stub).to receive(:access_token!).and_return(access_token)
       # rubocop:enable RSpec/InstanceVariable
+
+      freeze_time
     end
 
     it "doesn't fetch an ID token by default" do
-      expect(client.tokens!).to eq({ access_token: "access-token" })
+      expect(client.tokens!).to eq({ access_token: "access-token", request_time: Time.zone.now.to_s })
     end
 
     it "fetches an ID token if a nonce is provided" do


### PR DESCRIPTION
This is a temporary measure to help debugging and has no effect on
successful logins.

Store the processed response from the tokens endpoint in an instance
variable. Then, if the following call to userinfo fails, include the
tokens response in the `SensitiveException` information. This will
allow us to ensure that the tokens match what we send to the OIDC
provider and also check the time between calls (as the access token has
a low TTL).

---

[Trello](https://trello.com/c/LmNPwBAb/1299-investigate-incident-p3-some-users-may-be-unable-to-sign-in-or-create-an-account)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
