### PR TITLE
Remove reference to GOVUK Verify

### DIFF
--- a/app/views/help_pages/sign_in.html.erb
+++ b/app/views/help_pages/sign_in.html.erb
@@ -20,7 +20,7 @@
     },{
       text: "HMRC services",
       path: "/log-in-register-hmrc-online-services",
-      description: "Sign in to HMRC services using Government Gateway or GOV.UK Verify.",
+      description: "Sign in to HMRC services using Government Gateway.",
     },{
       text: "Report a COVID-19 rapid lateral flow test result",
       path: "/report-covid19-result",


### PR DESCRIPTION
Remove reference to Verify from the content for the [sign in page](https://www.gov.uk/sign-in).

This is to go live tomorrow 1st April 2022. 

HMRC are withdrawing Verify from this date.

-----

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
