### PR TITLE
Logout token

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ruby File.read(".ruby-version").strip
 
 gem "rails", "7.0.2.4"
 
+gem "attr_required"
 gem "bootsnap"
 gem "dalli"
 gem "gds-api-adapters"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -549,6 +549,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  attr_required
   awesome_print
   bootsnap
   bullet

--- a/app/lib/logout_token.rb
+++ b/app/lib/logout_token.rb
@@ -121,4 +121,10 @@ private
     Redis.current.set("logout-token/#{jti}", "OK")
     Redis.current.expire("logout-token/#{jti}", 2.minutes)
   end
+
+  class << self
+    def decode(jwt_string, key)
+      new JSON::JWT.decode jwt_string, key
+    end
+  end
 end

--- a/app/lib/logout_token.rb
+++ b/app/lib/logout_token.rb
@@ -1,0 +1,124 @@
+require "attr_required"
+require "attr_optional"
+
+class LogoutToken
+  include AttrOptional
+  include AttrRequired
+  class InvalidToken < RuntimeError; end
+  class ExpiredToken < InvalidToken; end
+  class InvalidIssuer < InvalidToken; end
+  class InvalidAudience < InvalidToken; end
+  class InvalidIssuedAt < InvalidToken; end
+  class InvalidEvent < InvalidToken; end
+  class InvalidBackchanelLogoutEvent < InvalidToken; end
+  class InvalidIdentifiers < InvalidToken; end
+  class TokenRecentlyUsed < InvalidToken; end
+  class ProhibitedNonse < InvalidToken; end
+
+  BACK_CHANNEL_EVENT_NAME = "http://schemas.openid.net/event/backchannel-logout".freeze
+
+  attr_required :iss, :aud, :iat, :jti, :events
+  attr_optional :sub, :sid, :auth_time
+  attr_accessor :access_token, :code, :state
+  alias_method :subject, :sub
+  alias_method :subject=, :sub=
+
+  NON_STRING_ATTRIBUTES = %i[aud exp iat auth_time sub_jwk events].freeze
+
+  def initialize(attributes = {})
+    attributes_to_methods(attributes)
+    apply_attribute_values_types(all_attributes)
+    validate_prohibited_attribtues(attributes)
+  end
+
+  def verify!(expected = {})
+    validates_issuer(expected)
+    validates_audience(expected)
+    validates_issued_at_time
+    validates_session_and_or_user_id_presence
+    validates_events(expected)
+    validate_jti_not_recently_used
+
+    true
+  end
+
+private
+
+  def attributes_to_methods(attributes)
+    all_attributes.each do |attr|
+      send :"#{attr}=", attributes[attr]
+    end
+    attr_missing!
+  end
+
+  def all_attributes
+    self.class.required_attributes + self.class.optional_attributes
+  end
+
+  def apply_attribute_values_types(all_attributes)
+    (all_attributes - NON_STRING_ATTRIBUTES).each do |key|
+      send "#{key}=", send(key).try(:to_s)
+    end
+    self.iat = Time.zone.at(iat.to_i) unless iat.nil?
+    self.auth_time = auth_time.to_i unless auth_time.nil?
+    self.events = JSON.parse(events) unless events.nil?
+  end
+
+  def validate_prohibited_attribtues(attributes)
+    raise ProhibitedNonse if attributes.keys.include?(:nonse)
+  end
+
+  # Validate iss(uer_ matches Auth's .well-known/openid-configuration
+  def validates_issuer(expected = {})
+    raise InvalidIssuer, "Invalid Logout token: Issuer does not match" unless iss == expected[:issuer]
+  end
+
+  # Validate aud(ience), which can be a string or an array of strings, matches client_id from registration
+  def validates_audience(expected = {})
+    unless Array(aud).include?(expected[:client_id]) || aud == expected[:client_id]
+      raise InvalidAudience, "Invalid Logout token: Audience does not match"
+    end
+  end
+
+  # Validate iat(issued at time) is in the past
+  def validates_issued_at_time
+    raise InvalidIssuedAt, "Invalid Logout token: Issued at does not match" unless iat.past?
+  end
+
+  # Verifiy the logout token contains SID, SUB or both.
+  def validates_session_and_or_user_id_presence
+    unless sub || sid
+      raise InvalidIdentifiers, "Invalid Logout token: Must contain either SID, SUB or both"
+    end
+  end
+
+  # Validates the logout token has a correctly formatted events claim
+  def validates_events(_expected = {})
+    raise InvalidBackchanelLogoutEvent, "Invalid Logout token: Events is not a hash" unless events.is_a? Hash
+    unless events.keys.include?(BACK_CHANNEL_EVENT_NAME)
+      raise InvalidBackchanelLogoutEvent, "Invalid Logout token: Events hash does not have the back channel logout event"
+    end
+
+    unless events[BACK_CHANNEL_EVENT_NAME] == {}
+      raise InvalidBackchanelLogoutEvent, "Invalid Logout token: Event should be the empty JSON object {}"
+    end
+  end
+
+  # Verify that we've not recently recieved another request with a jti
+  def validate_jti_not_recently_used
+    raise TokenRecentlyUsed if is_recent_jti?(jti)
+
+    record_jti_as_recently_verified(jti)
+  end
+
+  def is_recent_jti?(jti)
+    return true if Redis.current.get("logout-token/#{jti}") == "OK"
+
+    false
+  end
+
+  def record_jti_as_recently_verified(jti)
+    Redis.current.set("logout-token/#{jti}", "OK")
+    Redis.current.expire("logout-token/#{jti}", 2.minutes)
+  end
+end

--- a/spec/lib/logout_token_spec.rb
+++ b/spec/lib/logout_token_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe LogoutToken do
   let(:sid)         { SecureRandom.uuid }
   let(:client_id)   { "client_id" }
   let(:logout_event_name) { "http://schemas.openid.net/event/backchannel-logout" }
+  let(:jwt_signing_key) { "secret" }
+  let(:signed_jwt) { JSON::JWT.new(required_attributes).sign(jwt_signing_key).to_s }
   let(:required_attributes) do
     {
       iss: "https://server.example.com",
@@ -201,6 +203,18 @@ RSpec.describe LogoutToken do
           )
         }.to raise_error LogoutToken::TokenRecentlyUsed
       end
+    end
+  end
+
+  describe "LogoutToken.decode" do
+    it "decodes a signed JWT with a valid signing key" do
+      expect(described_class.decode(signed_jwt, jwt_signing_key)).to be_a described_class
+    end
+
+    it "raises an error if verification fails" do
+      expect {
+        described_class.decode(signed_jwt, "wrong")
+      }.to raise_error JSON::JWS::VerificationFailed
     end
   end
 end

--- a/spec/lib/logout_token_spec.rb
+++ b/spec/lib/logout_token_spec.rb
@@ -1,0 +1,206 @@
+RSpec.describe LogoutToken do
+  let(:klass) { described_class }
+  let(:logout_token) { klass.new attributes }
+  let(:attributes)  { required_attributes }
+  let(:ext)         { 10.minutes.from_now }
+  let(:iat)         { Time.zone.now.advance(minutes: -5) }
+  let(:jti)         { "bWJq" }
+  let(:sid)         { SecureRandom.uuid }
+  let(:client_id)   { "client_id" }
+  let(:logout_event_name) { "http://schemas.openid.net/event/backchannel-logout" }
+  let(:required_attributes) do
+    {
+      iss: "https://server.example.com",
+      sub: "user_id",
+      aud: client_id,
+      iat: iat,
+      sid: sid,
+      events: {
+        logout_event_name => {},
+      }.to_json,
+      jti: jti,
+    }
+  end
+
+  let(:required_attribute_keys) { %i[iss aud iat jti events] }
+  let(:optional_attribute_keys) { %i[sub sid auth_time] }
+
+  before { Redis.current.flushdb }
+
+  describe "attributes" do
+    it "validates required attributes" do
+      expect(logout_token.required_attributes).to eq(required_attribute_keys)
+    end
+
+    it "stores optional attributes" do
+      expect(logout_token.optional_attributes).to eq(optional_attribute_keys)
+    end
+
+    describe "auth_time" do
+      context "when Time object given" do
+        let(:attributes) do
+          required_attributes.merge(auth_time: Time.zone.now)
+        end
+
+        it "is numeric" do
+          expect(logout_token.auth_time).to be_a Numeric
+        end
+      end
+    end
+
+    describe "issued at time" do
+      context "when an issued at time (iat) object given" do
+        let(:attributes) do
+          required_attributes.merge(iat: "1471566154")
+        end
+
+        it "is a Time with Zone" do
+          expect(logout_token.iat).to be_a ActiveSupport::TimeWithZone
+        end
+      end
+    end
+  end
+
+  describe "#verify!" do
+    context "when passed a valid token" do
+      it "returns true" do
+        expect(logout_token.verify!(
+                 issuer: attributes[:iss],
+                 client_id: attributes[:aud],
+               )).to be true
+      end
+
+      context "when aud(ience) is an array of identifiers" do
+        let(:client_id) { "client_id" }
+        let(:attributes) { required_attributes.merge(aud: ["some_other_identifier", client_id]) }
+
+        it "returns true" do
+          expect(logout_token.verify!(
+                   issuer: attributes[:iss],
+                   client_id: attributes[:aud].last,
+                 )).to be true
+        end
+      end
+    end
+
+    context "when issuer is invalid" do
+      it "raises an error" do
+        expect {
+          logout_token.verify!(
+            issuer: "invalid_issuer",
+            client_id: attributes[:aud],
+          )
+        }.to raise_error LogoutToken::InvalidToken
+      end
+    end
+
+    context "when issuer is missing" do
+      it "raises an error" do
+        expect {
+          logout_token.verify!(
+            client_id: attributes[:aud],
+          )
+        }.to raise_error LogoutToken::InvalidToken
+      end
+    end
+
+    context "when client_id is invalid" do
+      it "raises an error" do
+        expect {
+          logout_token.verify!(
+            issuer: attributes[:iss],
+            client_id: "invalid_client",
+          )
+        }.to raise_error LogoutToken::InvalidToken
+      end
+    end
+
+    context "when client_id is missing" do
+      it "raises an error" do
+        expect {
+          logout_token.verify!(
+            issuer: attributes[:iss],
+          )
+        }.to raise_error LogoutToken::InvalidToken
+      end
+    end
+
+    context "when issued at time is in the future" do
+      let(:attributes) { required_attributes.merge(iat: Time.zone.now.advance(minutes: 5).strftime("%s")) }
+
+      it "raises an error" do
+        expect {
+          logout_token.verify!(
+            issuer: attributes[:iss],
+            client_id: attributes[:aud],
+          )
+        }.to raise_error LogoutToken::InvalidToken
+      end
+    end
+
+    context "when sub and sid are missing" do
+      let(:attributes) { required_attributes.reject { |k, _v| %i[sub sid].include?(k) } }
+
+      it "raises an error" do
+        expect {
+          logout_token.verify!(
+            issuer: attributes[:iss],
+            client_id: attributes[:aud],
+          )
+        }.to raise_error LogoutToken::InvalidToken
+      end
+    end
+
+    context "when events claim does not include backchannel logout event" do
+      let(:attributes) { required_attributes.merge(events: {}.to_json) }
+
+      it "raises an error" do
+        expect {
+          logout_token.verify!(
+            issuer: attributes[:iss],
+            client_id: attributes[:aud],
+          )
+        }.to raise_error LogoutToken::InvalidToken
+      end
+    end
+
+    context "when events claim back channel logout event is not an empty hash" do
+      let(:attributes) { required_attributes.merge(events: { logout_event_name => { "empty" => false } }.to_json) }
+
+      it "raises an error" do
+        expect {
+          logout_token.verify!(
+            issuer: attributes[:iss],
+            client_id: attributes[:aud],
+          )
+        }.to raise_error LogoutToken::InvalidToken
+      end
+    end
+
+    context "when nonse is given" do
+      let(:attributes)  { required_attributes.merge(nonse: "nonse") }
+
+      it "raises an error" do
+        expect {
+          logout_token.verify!(
+            issuer: attributes[:iss],
+            client_id: attributes[:aud],
+          )
+        }.to raise_error LogoutToken::ProhibitedNonse
+      end
+    end
+
+    context "when a JTI is already in the cache" do
+      it "raises an error" do
+        Redis.current.set("logout-token/#{jti}", "OK")
+        Redis.current.expire("logout-token/#{jti}", 2.minutes)
+        expect {
+          logout_token.verify!(
+            issuer: attributes[:iss],
+            client_id: attributes[:aud],
+          )
+        }.to raise_error LogoutToken::TokenRecentlyUsed
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Trello](https://trello.com/c/p3328fd0/1346-create-a-new-endpoint-to-support-auth)

We're implimenting OIDC backchannel logout, to recieve messages from digital identity
indicating the uses wishes to have their session removed everywhere.

The initial stage of this is to:

- give `account-api` the awarenss of a LogoutToken
- Validate and verify contents [following the specification](https://openid.net/specs/openid-connect-backchannel-1_0.html#Validation)
- Ensure the JWT can be decoded correctly and the signature verified

This PR adds a Plain old ruby class to do just that.