### PR TITLE
Remove cookies and feedback consent attributes

### DIFF
--- a/app/controllers/internal/authentication_controller.rb
+++ b/app/controllers/internal/authentication_controller.rb
@@ -34,8 +34,6 @@ class Internal::AuthenticationController < InternalController
     render json: {
       govuk_account_session: govuk_account_session.serialise,
       redirect_path: redirect_path,
-      cookie_consent: govuk_account_session.user.cookie_consent,
-      feedback_consent: govuk_account_session.user.feedback_consent,
     }
   rescue OidcClient::OAuthFailure
     head :unauthorized

--- a/config/user_attributes.yml
+++ b/config/user_attributes.yml
@@ -7,13 +7,14 @@ shared:
     type: cached
     writable: false
 
-  cookie_consent:
+  local_attribute:
     type: local
-
-  feedback_consent:
-    type: local
+    writable: true
 
 test:
+  test_local_attribute:
+    type: local
+
   test_mfa_attribute:
     type: local
     get_requires_mfa: true

--- a/db/migrate/20220512145426_remove_cookie_and_feedback_consent_from_oidc_users.rb
+++ b/db/migrate/20220512145426_remove_cookie_and_feedback_consent_from_oidc_users.rb
@@ -1,0 +1,8 @@
+class RemoveCookieAndFeedbackConsentFromOidcUsers < ActiveRecord::Migration[7.0]
+  def change
+    change_table :oidc_users, bulk: true do |t|
+      t.remove :cookie_consent, type: :boolean
+      t.remove :feedback_consent, type: :boolean
+    end
+  end
+end

--- a/db/migrate/20220519105404_add_local_attribute_to_oicd_users.rb
+++ b/db/migrate/20220519105404_add_local_attribute_to_oicd_users.rb
@@ -1,0 +1,5 @@
+class AddLocalAttributeToOicdUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :oidc_users, :local_attribute, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_10_145815) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_19_105404) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -41,8 +41,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_10_145815) do
     t.boolean "email_verified"
     t.boolean "oidc_users"
     t.string "legacy_sub"
-    t.boolean "cookie_consent"
-    t.boolean "feedback_consent"
+    t.string "local_attribute"
     t.index ["email"], name: "index_oidc_users_on_email", unique: true
     t.index ["legacy_sub"], name: "index_oidc_users_on_legacy_sub", unique: true
     t.index ["sub"], name: "index_oidc_users_on_sub", unique: true

--- a/docs/adr/003-cookie-consent.md
+++ b/docs/adr/003-cookie-consent.md
@@ -64,8 +64,8 @@ overhead is worth it.
 
 ### Store the consent in the account
 
-This is what we currently do.  It works for logged-in users, but
+This is what we used to do.  It worked for logged-in users, but
 logged-out users would still see two cookie banners.
 
-So, regardless of whether we persist the consent in the account (which
-we are likely to do), for logged-out users this is not a solution.
+So, regardless of whether we persist the consent in the account, 
+for logged-out users this is not a solution.

--- a/docs/api.md
+++ b/docs/api.md
@@ -139,10 +139,6 @@ identity provider redirects the user after signing in to
   - a session identifier
 - `redirect_path` *(optional)*
   - the `redirect_path` which was previously passed to `GET /api/oauth2/sign-in`, if given
-- `cookie_consent`
-  - whether the user has accepted or rejected usage cookies (a boolean, or `null` if the user hasn't saved a preference)
-- `feedback_consent`
-  - whether the user has accepted or rejected being contacted for feedback (a boolean, or `null` if the user hasn't saved a preference)
 
 #### Response codes
 
@@ -166,7 +162,6 @@ Response:
 {
     "govuk_account_session": "YWNjZXNzLXRva2Vu.cmVmcmVzaC10b2tlbg==",
     "redirect_path": "/guidance/keeping-a-pet-pig-or-micropig",
-    "cookie_consent": false,
 }
 ```
 

--- a/spec/lib/account_session_spec.rb
+++ b/spec/lib/account_session_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe AccountSession do
 
     let(:cached_attribute_name) { "email" }
     let(:cached_attribute_value) { nil }
-    let(:local_attribute_name) { "feedback_consent" }
+    let(:local_attribute_name) { "local_attribute" }
     let(:local_attribute_value) { nil }
 
     describe "get_attributes" do
@@ -116,7 +116,7 @@ RSpec.describe AccountSession do
     end
 
     describe "set_attributes" do
-      let(:local_attribute_value) { true }
+      let(:local_attribute_value) { "true" }
 
       it "saves attributes to the database" do
         account_session.set_attributes(local_attribute_name => local_attribute_value)

--- a/spec/requests/attributes_spec.rb
+++ b/spec/requests/attributes_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe "Attributes" do
   let(:cached_attribute_name) { "email" }
   let(:cached_attribute_value) { "email@example.com" }
 
-  let(:local_attribute_name) { "feedback_consent" }
-  let(:local_attribute_value) { true }
+  let(:local_attribute_name) { "local_attribute" }
+  let(:local_attribute_value) { "foo" }
 
   let(:protected_attribute_name) { "test_mfa_attribute" }
 
@@ -127,7 +127,7 @@ RSpec.describe "Attributes" do
     end
 
     it "correctly round-trips local attributes" do
-      old_value = false
+      old_value = "bar"
 
       account_session.user.update!(local_attribute_name => old_value)
 

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Authentication" do
       stub_userinfo
       post callback_path, headers: headers, params: { state: auth_request.to_oauth_state, code: "12345" }.to_json
       expect(response).to be_successful
-      expect(JSON.parse(response.body)).to include("govuk_account_session", "redirect_path" => auth_request.redirect_path, "cookie_consent" => nil, "feedback_consent" => nil)
+      expect(JSON.parse(response.body)).to include("govuk_account_session", "redirect_path" => auth_request.redirect_path)
     end
 
     context "when cacheable attributes are missing" do
@@ -72,16 +72,12 @@ RSpec.describe "Authentication" do
       end
     end
 
-    context "when the user exists and has cookie & feedback consents saved" do
-      before { FactoryBot.create(:oidc_user, sub: "user-id", cookie_consent: cookie_consent, feedback_consent: feedback_consent) }
+    context "when the user exists" do
+      before { FactoryBot.create(:oidc_user, sub: "user-id") }
 
-      let(:cookie_consent) { true }
-      let(:feedback_consent) { false }
-
-      it "returns the consents" do
+      it "returns the user" do
         post callback_path, headers: headers, params: { state: auth_request.to_oauth_state, code: "12345" }.to_json
         expect(response).to be_successful
-        expect(JSON.parse(response.body)).to include("cookie_consent" => cookie_consent, "feedback_consent" => feedback_consent)
       end
     end
 

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -113,15 +113,6 @@ Pact.provider_states_for "GDS API Adapters" do
     end
   end
 
-  provider_state "there is a valid OAuth response, with cookie consent 'true'" do
-    set_up do
-      auth_request = AuthRequest.generate!(redirect_path: "/some-arbitrary-path")
-      allow(AuthRequest).to receive(:from_oauth_state).and_return(auth_request)
-      stub_cached_attributes
-      oidc_user.update!(cookie_consent: true)
-    end
-  end
-
   provider_state "there is a valid user session" do
     set_up do
       stub_cached_attributes
@@ -137,13 +128,6 @@ Pact.provider_states_for "GDS API Adapters" do
       stub_cached_attributes
       stub_will_create_email_subscription "wizard-news-topic-slug"
       FactoryBot.create(:email_subscription, name: "wizard-news", oidc_user_id: oidc_user.id)
-    end
-  end
-
-  provider_state "there is a valid user session, with an attribute called 'feedback_consent'" do
-    set_up do
-      stub_cached_attributes
-      oidc_user.update!(feedback_consent: true)
     end
   end
 


### PR DESCRIPTION
We've removed the first time sign in page which asked users to consent
to cookies and sending them emails for feedback [[1]] and the form to
see and manage these attributes in the account home area [[2]].

Now we can remove them from the API and drop the database columns so
we're not hoarding personal data.

These two attributes are the only two `local` attributes, and are used
throughout for testing the logic for local vs. cached attributes.
Instead of removing all that logic as well, this commit sets up a new
dummy attribute `local_attribute` that can be used for testing while
keeping the logic in place. A later PR will clean up the different types
of attributes.

[1]: https://github.com/alphagov/frontend/pull/3234
[2]: https://github.com/alphagov/frontend/pull/3225

---

*DO NOT MERGE* until https://github.com/alphagov/frontend/pull/3225 and
the corresponding account management app PR have been merged. 

---
[Trello]()

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
