### PR TITLE
Add a `local_attribute` attribute for testing

### DIFF
--- a/config/user_attributes.yml
+++ b/config/user_attributes.yml
@@ -13,6 +13,9 @@ shared:
   feedback_consent:
     type: local
 
+  local_attribute:
+    type: local
+
 test:
   test_mfa_attribute:
     type: local

--- a/db/migrate/20220520081234_add_local_attribute_to_oidc_user.rb
+++ b/db/migrate/20220520081234_add_local_attribute_to_oidc_user.rb
@@ -1,0 +1,5 @@
+class AddLocalAttributeToOidcUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :oidc_users, :local_attribute, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_10_145815) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_20_081234) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -41,8 +41,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_10_145815) do
     t.boolean "email_verified"
     t.boolean "oidc_users"
     t.string "legacy_sub"
-    t.boolean "cookie_consent"
     t.boolean "feedback_consent"
+    t.boolean "cookie_consent"
+    t.boolean "local_attribute"
     t.index ["email"], name: "index_oidc_users_on_email", unique: true
     t.index ["legacy_sub"], name: "index_oidc_users_on_legacy_sub", unique: true
     t.index ["sub"], name: "index_oidc_users_on_sub", unique: true

--- a/spec/lib/account_session_spec.rb
+++ b/spec/lib/account_session_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe AccountSession do
 
     let(:cached_attribute_name) { "email" }
     let(:cached_attribute_value) { nil }
-    let(:local_attribute_name) { "feedback_consent" }
+    let(:local_attribute_name) { "local_attribute" }
     let(:local_attribute_value) { nil }
 
     describe "get_attributes" do

--- a/spec/requests/attributes_spec.rb
+++ b/spec/requests/attributes_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Attributes" do
   let(:cached_attribute_name) { "email" }
   let(:cached_attribute_value) { "email@example.com" }
 
-  let(:local_attribute_name) { "feedback_consent" }
+  let(:local_attribute_name) { "local_attribute" }
   let(:local_attribute_value) { true }
 
   let(:protected_attribute_name) { "test_mfa_attribute" }

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -147,6 +147,13 @@ Pact.provider_states_for "GDS API Adapters" do
     end
   end
 
+  provider_state "there is a valid user session, with an attribute called 'local_attribute'" do
+    set_up do
+      stub_cached_attributes
+      oidc_user.update!(local_attribute: true)
+    end
+  end
+
   provider_state "there is a user with subject identifier 'the-subject-identifier'" do
     set_up do
       user = FactoryBot.create(:oidc_user, sub: "the-subject-identifier")


### PR DESCRIPTION
We are planning to remove the cookie and feedback consent attributes
as these are no longer going to be stored in the account API. However,
these are the last two local attributes and are used throughout the test
suites to test the logic for local attributes vs. cached attributes.

Removing them would therefore cause all the unit tests to fail. Rather
than deleting all the logic differentiating between attribute types at
this stage (which will take a while), we are adding a new local
attribute which is only used for testing.

We will then update the pact tests to use this new attribute, then
remove the cookie and feedback consent attributes and drop the data.

We'll then be in a place where we can clean up the tech debt introduced
by this commit and remove all the logic for local attributes.

---
[Trello](https://trello.com/c/XGmG7Jav/1371-tidy-up-database-after-cookies-and-feedback)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
