### PR TITLE
GUA-22 - Backchannel logout endpoint

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,10 @@ class ApplicationController < ActionController::API
 
 private
 
+  def invalidate_logout_notice(sub)
+    LogoutNotice.new(sub).remove
+  end
+
   def capture_sensitive_exceptions(user)
     yield
   rescue StandardError => e

--- a/app/controllers/internal/authentication_controller.rb
+++ b/app/controllers/internal/authentication_controller.rb
@@ -31,6 +31,8 @@ class Internal::AuthenticationController < InternalController
       fetch_cacheable_attributes!(govuk_account_session, details)
     end
 
+    invalidate_logout_notice(govuk_account_session.user.sub)
+
     render json: {
       govuk_account_session: govuk_account_session.serialise,
       redirect_path: redirect_path,

--- a/app/controllers/internal/oidc_users_controller.rb
+++ b/app/controllers/internal/oidc_users_controller.rb
@@ -29,6 +29,7 @@ class Internal::OidcUsersController < InternalController
     )
 
     end_email_alert_api_subscriptions(user)
+    invalidate_logout_notice(params.fetch(:subject_identifier))
 
     user.destroy!
 

--- a/app/controllers/oidc_events_controller.rb
+++ b/app/controllers/oidc_events_controller.rb
@@ -1,0 +1,27 @@
+class OidcEventsController < ApplicationController
+  def backchannel_logout
+    logout_token = oidc_client.logout_token(logout_token)
+    if logout_token
+      user_id = logout_token[:logout_token].sub
+      LogoutNotice.new(user_id).persist
+      head :ok
+    end
+  rescue OidcClient::BackchannelLogoutFailure
+    head :bad_request
+  end
+
+private
+
+  def logout_token
+    params.require(:logout_token)
+  end
+
+  def oidc_client
+    @oidc_client ||=
+      if Rails.env.development?
+        OidcClient::Fake.new
+      else
+        OidcClient.new
+      end
+  end
+end

--- a/app/models/logout_notice.rb
+++ b/app/models/logout_notice.rb
@@ -1,0 +1,21 @@
+class LogoutNotice
+  def self.find(sub)
+    Redis.current.get("logout-notice/#{sub}")
+  end
+
+  def initialize(sub)
+    @sub = sub
+  end
+
+  def persist
+    Redis.current.set("logout-notice/#{sub}", Time.zone.now)
+  end
+
+  def remove
+    Redis.current.del("logout-notice/#{sub}")
+  end
+
+private
+
+  attr_reader :sub
+end

--- a/app/models/oidc_user.rb
+++ b/app/models/oidc_user.rb
@@ -19,6 +19,7 @@ class OidcUser < ApplicationRecord
     transaction do
       find_by_sub!(sub, legacy_sub: legacy_sub)
     rescue ActiveRecord::RecordNotFound
+      LogoutNotice.new(sub).remove
       create!(sub: sub, legacy_sub: legacy_sub)
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,5 +28,9 @@ Rails.application.routes.draw do
     namespace :personalisation do
       get "check-email-subscription", to: "check_email_subscription#show", as: :check_email_subscription
     end
+
+    scope :oidc_events do
+      post "backchannel_logout", to: "oidc_events#backchannel_logout", as: :backchannel_logout
+    end
   end
 end

--- a/docs/api.md
+++ b/docs/api.md
@@ -574,7 +574,7 @@ This endpoint requires the `update_protected_attributes` scope.
 #### Request parameters
 
 - `subject_identifier`
-  - the subject identifier of the user to delete
+  - the subject identifier of the user to update
 
 #### JSON request parameters
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,7 +13,7 @@ management. This API is not for other government services.
   - [`POST /api/oauth2/callback`](#post-apioauth2callback)
   - [`GET /api/oauth2/end-session`](#get-apioauth2end-session)
   - [`GET /api/user`](#get-apiuser)
-  - [`GET /user/match-by-email`](#get-apiusermatch-by-email)
+  - [`GET /user/match-by-email`](#get-usermatch-by-email)
   - [`GET /api/attributes`](#get-apiattributes)
   - [`PATCH /api/attributes`](#patch-apiattributes)
   - [`GET /api/email-subscriptions/:subscription_name`](#get-apiemail-subscriptionssubscription_name)
@@ -725,7 +725,7 @@ A public API endpoint that Implements OpenID Connect Back-Channel Logout 1.0 - d
 
 #### Note
 
-This endpoint is intended for calls to be made exclusively from the Digital Identity OP to the GOV.UK relaying party. As such it will not appear in GDS API Adaptors as it is not intended to be called from another Ruby compatible
+This endpoint will only ever receive calls from the Oidc OP (Digital Identity), as an OIDC event. Because of that, there is not an GDS API Adaptor for this endpoint, as it will not be called from another Ruby application.
 
 ## API errors
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -22,6 +22,7 @@ management. This API is not for other government services.
   - [`PUT /api/oidc-users/:subject_identifier`](#put-apioidc-userssubject_identifier)
   - [`DELETE /api/oidc-users/:subject_identifier`](#delete-apioidc-userssubject_identifier)
   - [`GET /api/personalisation/check-email-subscription`](#get-apipersonalisationcheck-email-subscription)
+  - [`POST /api/oidc_events/backchannel_logout`](#post-apioidc_eventsbackchannel_logout)
 - [API errors](#api-errors)
   - [MFA required](#mfa-required)
   - [Unknown attribute names](#unknown-attribute-names)
@@ -708,6 +709,23 @@ curl -H "GOVUK-Account-Session={{account_session_header}}" \
     "button_html": "<form>...</form>"
 }
 ```
+
+### `POST /api/oidc_events/backchannel_logout`
+
+A public API endpoint that Implements OpenID Connect Back-Channel Logout 1.0 - draft 07.
+
+#### Query parameters
+- `logout_token`
+  - A signed JWT
+
+#### Response codes
+
+- 400 if the Logout Token JWT is invalid or signature cannot be verified
+- 200 otherwise
+
+#### Note
+
+This endpoint is intended for calls to be made exclusively from the Digital Identity OP to the GOV.UK relaying party. As such it will not appear in GDS API Adaptors as it is not intended to be called from another Ruby compatible
 
 ## API errors
 

--- a/spec/lib/oidc_client_spec.rb
+++ b/spec/lib/oidc_client_spec.rb
@@ -206,16 +206,4 @@ RSpec.describe OidcClient do
 
     oidc_client
   end
-
-  def stub_jwk_discovery
-    # rubocop:disable RSpec/AnyInstance
-    allow_any_instance_of(OpenIDConnect::Discovery::Provider::Config::Response).to receive(:jwks).and_return(jwt_signing_key)
-    # rubocop:enable RSpec/AnyInstance
-  end
-
-  def stub_issuer
-    # rubocop:disable RSpec/AnyInstance
-    allow_any_instance_of(OpenIDConnect::Discovery::Provider::Config::Response).to receive(:issuer).and_return(iss)
-    # rubocop:enable RSpec/AnyInstance
-  end
 end

--- a/spec/models/logout_notice_spec.rb
+++ b/spec/models/logout_notice_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe LogoutNotice do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:sub) { "sub" }
+  let(:instance) { described_class.new(sub) }
+  let(:redis_formatted_time) { Time.zone.now.strftime("%F %T %z") }
+
+  before do
+    freeze_time
+    Redis.current.flushdb
+  end
+
+  describe ".find" do
+    it "returns nil if a Notice has not been persisted" do
+      expect(described_class.find(sub)).to be_nil
+    end
+
+    it "returns the created at timestamp if a Notice has been persisted" do
+      Redis.current.set("logout-notice/#{sub}", Time.zone.now)
+      expect(described_class.find(sub)).to eq(redis_formatted_time)
+    end
+  end
+
+  describe "#persist" do
+    it "returns OK if persist went well" do
+      expect(instance.persist).to eq("OK")
+    end
+
+    it "persists a sub with in a logout notice timespace with a timestamp" do
+      instance.persist
+      expect(Redis.current.get("logout-notice/#{sub}")).to eq(redis_formatted_time)
+    end
+  end
+
+  describe "#remove" do
+    it "returns 1 if the record was removed" do
+      Redis.current.set("logout-notice/#{sub}", Time.zone.now)
+      expect(instance.remove).to eq(1)
+    end
+
+    it "returns 0 if the records was not found" do
+      expect(instance.remove).to eq(0)
+    end
+  end
+end

--- a/spec/models/oidc_user_spec.rb
+++ b/spec/models/oidc_user_spec.rb
@@ -19,6 +19,16 @@ RSpec.describe OidcUser do
       expect { described_class.find_or_create_by_sub!(sub) }.to change(described_class, :count).by(1)
     end
 
+    it "clears a LogoutNotice if one exists" do
+      time = Time.zone.now
+      Redis.current.set("logout-notice/#{sub}", time)
+      expect {
+        described_class.find_or_create_by_sub!(sub)
+      }.to change {
+        LogoutNotice.find(sub)
+      }.from(time.strftime("%F %T %z")).to(nil)
+    end
+
     it "saves the sub and legacy_sub" do
       user = described_class.find_or_create_by_sub!(sub, legacy_sub: legacy_sub)
       expect(user.sub).to eq(sub)

--- a/spec/requests/back_channel_logout_spec.rb
+++ b/spec/requests/back_channel_logout_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe "OIDC Backchannel Logout" do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:logout_token_jwt) { "pretend_this_is_a_jwt" }
+  let(:sub) { "user_id " }
+
+  let(:params) do
+    { logout_token: logout_token_jwt }
+  end
+
+  let(:oidc_client_logout_token) do
+    {
+      logout_token_jwt: logout_token_jwt,
+      logout_token: logout_token,
+      request_time: Time.zone.now,
+    }
+  end
+
+  let(:oidc_client) { instance_double(OidcClient) }
+  let(:logout_token) { instance_double(LogoutToken) }
+  let(:redis_formatted_time) { Time.zone.now.strftime("%F %T %z") }
+
+  before do
+    allow(OidcClient).to receive(:new).and_return(oidc_client)
+    allow(oidc_client).to receive(:logout_token).and_return(oidc_client_logout_token)
+    allow(logout_token).to receive(:sub).and_return(sub)
+    freeze_time
+    Redis.current.flushdb
+  end
+
+  describe "POST" do
+    context "with an token that is unverifiable" do
+      before do
+        allow(oidc_client).to receive(:logout_token).and_raise(OidcClient::BackchannelLogoutFailure)
+      end
+
+      it "returns 400" do
+        post backchannel_logout_path, params: params
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+
+    context "with a valid logout token" do
+      it "records a session expiry notice" do
+        post backchannel_logout_path, params: params
+        expect(Redis.current.get("logout-notice/#{sub}")).to eq(redis_formatted_time)
+      end
+
+      it "returns 200" do
+        post backchannel_logout_path, params: params
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end

--- a/spec/requests/logout_notice_invalidation_spec.rb
+++ b/spec/requests/logout_notice_invalidation_spec.rb
@@ -1,0 +1,31 @@
+require "gds_api/test_helpers/email_alert_api"
+
+RSpec.describe "Logout Notice Invalidation" do
+  include ActiveSupport::Testing::TimeHelpers
+  let(:sub) { "user-id" }
+  let(:redis_state) { Redis.current.get("logout-notice/#{sub}") }
+  let(:redis_formatted_time) { Time.zone.now.strftime("%F %T %z") }
+
+  before do
+    freeze_time
+    Redis.current.flushdb
+  end
+
+  context "when a logout notice exists for sub" do
+    before { Redis.current.set("logout-notice/#{sub}", Time.zone.now) }
+
+    it "invalidates the notice on a sucessful callback_path request" do
+      stub_userinfo
+      stub_oidc_discovery
+      stub_token_response
+      auth_request = AuthRequest.create!(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "/some-path")
+      expect {
+        post callback_path,
+             headers: { "Content-Type" => "application/json" },
+             params: { state: auth_request.to_oauth_state, code: "12345" }.to_json
+      }.to change {
+        Redis.current.get("logout-notice/#{sub}")
+      }.from(redis_formatted_time).to(nil)
+    end
+  end
+end

--- a/spec/requests/logout_notice_invalidation_spec.rb
+++ b/spec/requests/logout_notice_invalidation_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Logout Notice Invalidation" do
   let(:sub) { "user-id" }
   let(:redis_state) { Redis.current.get("logout-notice/#{sub}") }
   let(:redis_formatted_time) { Time.zone.now.strftime("%F %T %z") }
+  let(:headers) { { "Content-Type" => "application/json" } }
 
   before do
     freeze_time
@@ -21,8 +22,18 @@ RSpec.describe "Logout Notice Invalidation" do
       auth_request = AuthRequest.create!(oauth_state: "foo", oidc_nonce: "bar", redirect_path: "/some-path")
       expect {
         post callback_path,
-             headers: { "Content-Type" => "application/json" },
+             headers: headers,
              params: { state: auth_request.to_oauth_state, code: "12345" }.to_json
+      }.to change {
+        Redis.current.get("logout-notice/#{sub}")
+      }.from(redis_formatted_time).to(nil)
+    end
+
+    it "invalidates the notice a successful call to destroy a user" do
+      user = FactoryBot.create(:oidc_user, sub: sub, legacy_sub: nil)
+      stub_request(:get, "#{GdsApi::TestHelpers::EmailAlertApi::EMAIL_ALERT_API_ENDPOINT}/subscribers/govuk-account/#{user.id}").to_return(status: 404)
+      expect {
+        delete oidc_user_path(subject_identifier: sub)
       }.to change {
         Redis.current.get("logout-notice/#{sub}")
       }.from(redis_formatted_time).to(nil)

--- a/spec/support/helpers/oidc_client_helper.rb
+++ b/spec/support/helpers/oidc_client_helper.rb
@@ -36,6 +36,18 @@ module OidcClientHelper
     stub_request(:get, "http://openid-provider/userinfo-endpoint")
       .to_return(status: 200, body: attributes.to_json)
   end
+
+  def stub_jwk_discovery
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(OpenIDConnect::Discovery::Provider::Config::Response).to receive(:jwks).and_return(jwt_signing_key)
+    # rubocop:enable RSpec/AnyInstance
+  end
+
+  def stub_issuer
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(OpenIDConnect::Discovery::Provider::Config::Response).to receive(:issuer).and_return(iss)
+    # rubocop:enable RSpec/AnyInstance
+  end
 end
 
 RSpec.configuration.send :include, OidcClientHelper


### PR DESCRIPTION
[Jira - GUA-22](https://govukverify.atlassian.net/browse/GUA-22)

Add a Backchannel logout endpoint which:
- Recieves a request with a logout_token as an signed JWT.
  - Responds with 400 if the JWT is invalid, or the signature cannot be validated
  - Responds 200 and creates a LogoutNotice if the JWT is valid.

A logout Notice is a Redis persisted `sub`, it is intended to sit there and await a visit from a user attempting to authorise with that sub. Upon success it will trigger a logout and redirect.

This PR only impliments the backchannel logout endpoint and expiry notice creation. Two follow up PRs will shortly be needed:

1. To check authorised internal requests and queries to the personalisation endpoint with a valid session cookie log out a user and redirect. This will need to _not_ apply to any login / create endpoints.
2. To invalidate / clear Redis upon a sucessful login or create attempt. We may also want to consider changes to the session duration on GOV.UK and if Redis based logout notices should be set to expire at a similar time.

Both of these will require a bit of 🧠 to consider a multi-device scenario, so I'm leaving these to a follow up.