### PR TITLE
Change pact tests to use `main` branch

### DIFF
--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -58,7 +58,7 @@ Pact.service_provider "Account API" do
     else
       base_url = "https://pact-broker.cloudapps.digital"
       path = "pacts/provider/#{url_encode(name)}/consumer/#{url_encode(consumer_name)}"
-      version_modifier = "versions/#{url_encode(ENV.fetch('PACT_CONSUMER_VERSION', 'branch-master'))}"
+      version_modifier = "versions/#{url_encode(ENV.fetch('PACT_CONSUMER_VERSION', 'branch-main'))}"
 
       pact_uri("#{base_url}/#{path}/#{version_modifier}")
     end


### PR DESCRIPTION
The default branch of https://github.com/alphagov/gds-api-adapters has
changeed to `main`. This repo includes the consumer part of the pact
tests for this API, so update the test config to look at the correct
branch.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
