### PR TITLE
Allow multiple Tombstone records for the same sub

### DIFF
--- a/db/migrate/20220525152551_remove_unique_sub_index_from_tombstones.rb
+++ b/db/migrate/20220525152551_remove_unique_sub_index_from_tombstones.rb
@@ -1,0 +1,6 @@
+class RemoveUniqueSubIndexFromTombstones < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :tombstones, column: :sub
+    add_index :tombstones, :sub, if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_20_081234) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_25_152551) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -61,7 +61,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_20_081234) do
     t.string "sub", null: false
     t.datetime "created_at", default: -> { "now()" }, null: false
     t.datetime "updated_at", default: -> { "now()" }, null: false
-    t.index ["sub"], name: "index_tombstones_on_sub", unique: true
+    t.index ["sub"], name: "index_tombstones_on_sub"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/models/oidc_user_spec.rb
+++ b/spec/models/oidc_user_spec.rb
@@ -9,6 +9,15 @@ RSpec.describe OidcUser do
       expect { described_class.create!(sub: sub).destroy! }.to change(Tombstone, :count).by(1)
       expect(Tombstone.find_by(sub: sub)).not_to be_nil
     end
+
+    it "creates two tombstone records when two accounts with the same sub are deleted" do
+      sub = "subject-identifier"
+      Tombstone.destroy_all
+      2.times do
+        described_class.create!(sub: sub).destroy!
+      end
+      expect(Tombstone.count).to eq(2)
+    end
   end
 
   describe "#find_or_create_by_sub!" do


### PR DESCRIPTION
When this app was originally created it was *the* canonical place to
store account data. The Tombstone records were to allow us to count
deleted accounts and enforce uniqueness.

Now however, that's not the case. The source for account data is Auth's
OICD provider and Tombstones are less helpful to us now this app is
only part of a relying party's account storage.

Accounts on GOV.UK are only used for email notifications, so we plan to
use email alert API's logic to delete accounts that have no subscriptions.

This means it will be possible for someone to create an account, sign up
for notifications, delete that subscription and then have that account
deleted automatically. We need to make sure that if that person comes
back to GOV.UK and signs in, we can create a new `OidcUser` for them
that behaves exactly as expected.

In order for that to happen, we have to be able to create multiple
Tombstones for the same sub.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
