### PR TITLE
Delete old Tombstone records

### DIFF
--- a/app/models/tombstone.rb
+++ b/app/models/tombstone.rb
@@ -1,3 +1,6 @@
 class Tombstone < ApplicationRecord
   validates :sub, presence: true
+
+  EXPIRATION_AGE = 30.days
+  scope :expired, -> { where("created_at < ?", EXPIRATION_AGE.ago) }
 end

--- a/app/workers/expired_tombstone_worker.rb
+++ b/app/workers/expired_tombstone_worker.rb
@@ -1,0 +1,5 @@
+class ExpiredTombstoneWorker < ApplicationWorker
+  def perform
+    Tombstone.expired.delete_all
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -13,3 +13,7 @@
   expired_sensitive_exception_worker:
     every: '1h'
     class: ExpiredSensitiveExceptionWorker
+
+  expired_tombstone_worker:
+    every: '1hr'
+    class: ExpiredTombstoneWorker

--- a/spec/workers/expired_tombstone_worker_spec.rb
+++ b/spec/workers/expired_tombstone_worker_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe ExpiredTombstoneWorker do
+  include ActiveSupport::Testing::TimeHelpers
+
+  before { freeze_time }
+
+  it "deletes old tombstones" do
+    Tombstone.create!(sub: "sub", created_at: (Tombstone::EXPIRATION_AGE + 1.day).ago)
+    expect { described_class.new.perform }.to change(Tombstone, :count).to(0)
+  end
+
+  it "doesn't delete recent tombstones" do
+    Tombstone.create!(sub: "sub", created_at: Tombstone::EXPIRATION_AGE.ago)
+    expect { described_class.new.perform }.not_to change(Tombstone, :count)
+  end
+end


### PR DESCRIPTION
In [[1]] we allowed there to be multiple Tombstones with the same sub
as this app is no longer the canonical place for account creation and
deletion data.

Since we're no longer checking for duplicates, we can also start
deleting old records as they're now only really useful for debugging.

We went with 30 days as that matches the time needed for an account to
be marked 'inactive' by email alert API.

We do lose the ability to count the number of accounts that has ever
existed by adding this worker but, as mentioned before, this app isn't
the right place to count this anyway so it's not a real loss.

[1]: https://github.com/alphagov/account-api/pull/421

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
