### PR TITLE
GUA-22 enforce logout notice

### DIFF
--- a/app/controllers/concerns/authenticated_api_concern.rb
+++ b/app/controllers/concerns/authenticated_api_concern.rb
@@ -10,7 +10,11 @@ module AuthenticatedApiConcern
         session_secret: Rails.application.secrets.session_secret,
       )
 
-      head :unauthorized unless @govuk_account_session
+      if @govuk_account_session
+        head :unauthorized if LogoutNotice.find(@govuk_account_session.user_id)
+      else
+        head :unauthorized
+      end
     end
 
     rescue_from AccountSession::ReauthenticateUserError do

--- a/app/controllers/personalisation_controller.rb
+++ b/app/controllers/personalisation_controller.rb
@@ -8,7 +8,11 @@ class PersonalisationController < ApplicationController
       session_secret: Rails.application.secrets.session_secret,
     )
 
-    end_session! unless @govuk_account_session
+    if @govuk_account_session
+      end_session! if LogoutNotice.find(@govuk_account_session.user_id)
+    else
+      end_session!
+    end
   end
 
   before_action :set_caching_headers

--- a/spec/requests/check_email_subscription_spec.rb
+++ b/spec/requests/check_email_subscription_spec.rb
@@ -67,6 +67,18 @@ RSpec.describe "Personalisation - Check Email Subscription" do
         end
       end
 
+      context "when a logout notice exists for that sub" do
+        before do
+          Redis.current.flushdb
+          Redis.current.set("logout-notice/#{sub}", Time.zone.now)
+        end
+
+        it "logs the user out" do
+          get personalisation_check_email_subscription_path, params: params, headers: headers
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+
       context "when a base_path is passed" do
         let(:base_path) { "/foo" }
         let(:subscription_slug) { "foo" }


### PR DESCRIPTION
Dependent on:
https://github.com/alphagov/account-api/pull/412

Enforces Logging users out where a LogoutNotice exists.
Applies to all Personalisation Routes (enforced at parent personalisation controller level)
Also applies to Internal Routes that use the AuthenticatedApiConcern

Must not apply to any routes that indicate an action that would supercede or invalidate a logout notice (for instance any logging in or creation action).