### PR TITLE
Fix `ExpiredTombstoneWorker` sidekiq schedule

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -15,5 +15,5 @@
     class: ExpiredSensitiveExceptionWorker
 
   expired_tombstone_worker:
-    every: '1hr'
+    every: '1h'
     class: ExpiredTombstoneWorker


### PR DESCRIPTION
`1hr` isn't a format Sidekiq recognises, so the worker processes were
crashing when started.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
