### PR TITLE
Remove attribute types and local attribute logic

### DIFF
--- a/app/lib/account_session.rb
+++ b/app/lib/account_session.rb
@@ -7,8 +7,6 @@ class AccountSession
 
   class SessionVersionInvalid < ReauthenticateUserError; end
 
-  class MissingCachedAttribute < ReauthenticateUserError; end
-
   class UserDestroyed < ReauthenticateUserError; end
 
   CURRENT_VERSION = 1
@@ -65,9 +63,6 @@ class AccountSession
   end
 
   def get_attributes(attribute_names)
-    values_to_cache = attribute_names.select { |name| user_attributes.type(name) == "cached" }.select { |name| user[name].nil? }
-    raise MissingCachedAttribute unless values_to_cache.empty?
-
     user.get_attributes_by_name(attribute_names).compact
   end
 

--- a/app/lib/user_attributes.rb
+++ b/app/lib/user_attributes.rb
@@ -5,8 +5,8 @@ class UserAttributes
 
   def initialize(attributes = nil)
     @attributes = (attributes || Rails.configuration.x.user_attributes).transform_values do |config|
+      config ||= {}
       AttributeDefinition.new(
-        type: config[:type],
         writable: config.fetch(:writable, true),
         check_requires_mfa: config.fetch(:check_requires_mfa, false),
         get_requires_mfa: config.fetch(:get_requires_mfa, false),
@@ -17,10 +17,6 @@ class UserAttributes
 
   def defined?(name)
     attributes.key? name.to_sym
-  end
-
-  def type(name)
-    fetch(name)[:type]
   end
 
   def is_writable?(name)

--- a/app/models/attribute_definition.rb
+++ b/app/models/attribute_definition.rb
@@ -1,14 +1,11 @@
 class AttributeDefinition < OpenStruct
   include ActiveModel::Validations
 
-  validates :type, presence: true
-  validates :type, inclusion: %w[local cached]
   validates :check_requires_mfa, :get_requires_mfa, :set_requires_mfa, :writable, exclusion: [nil]
   validate :check_mfa_implies_get_mfa
   validate :get_mfa_implies_set_mfa_if_writable
-  validate :writable_implies_type_is_local
 
-  def initialize(type:, writable: true, check_requires_mfa: false, get_requires_mfa: false, set_requires_mfa: false)
+  def initialize(writable: true, check_requires_mfa: false, get_requires_mfa: false, set_requires_mfa: false)
     super
   end
 
@@ -20,11 +17,5 @@ class AttributeDefinition < OpenStruct
     return unless writable
 
     errors.add(:get_requires_mfa, "implies :set_requires_mfa") if get_requires_mfa && !set_requires_mfa
-  end
-
-  def writable_implies_type_is_local
-    return if type == "local"
-
-    errors.add(:writable, "implies :type is local") if writable
   end
 end

--- a/config/user_attributes.yml
+++ b/config/user_attributes.yml
@@ -5,8 +5,6 @@ shared:
   email_verified:
     writable: false
 
-  local_attribute:
-
 test:
   test_mfa_attribute:
     get_requires_mfa: true

--- a/config/user_attributes.yml
+++ b/config/user_attributes.yml
@@ -1,17 +1,13 @@
 shared:
   email:
-    type: cached
     writable: false
 
   email_verified:
-    type: cached
     writable: false
 
   local_attribute:
-    type: local
 
 test:
   test_mfa_attribute:
-    type: local
     get_requires_mfa: true
     set_requires_mfa: true

--- a/db/migrate/20220608082309_remove_local_attribute_from_oidc_users.rb
+++ b/db/migrate/20220608082309_remove_local_attribute_from_oidc_users.rb
@@ -1,0 +1,5 @@
+class RemoveLocalAttributeFromOidcUsers < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :oidc_users, :local_attribute, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_30_122329) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_08_082309) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -41,7 +41,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_30_122329) do
     t.boolean "email_verified"
     t.boolean "oidc_users"
     t.string "legacy_sub"
-    t.boolean "local_attribute"
     t.index ["email"], name: "index_oidc_users_on_email", unique: true
     t.index ["legacy_sub"], name: "index_oidc_users_on_legacy_sub", unique: true
     t.index ["sub"], name: "index_oidc_users_on_sub", unique: true

--- a/spec/lib/account_session_spec.rb
+++ b/spec/lib/account_session_spec.rb
@@ -87,40 +87,25 @@ RSpec.describe AccountSession do
   describe "attributes" do
     before do
       account_session.set_attributes(
-        cached_attribute_name => cached_attribute_value,
-        local_attribute_name => local_attribute_value,
+        attribute_name => attribute_value,
       )
     end
 
-    let(:cached_attribute_name) { "email" }
-    let(:cached_attribute_value) { nil }
-    let(:local_attribute_name) { "local_attribute" }
-    let(:local_attribute_value) { nil }
+    let(:attribute_name) { "email" }
+    let(:attribute_value) { nil }
 
     describe "get_attributes" do
-      it "throws an exception for a missing cached attribute" do
-        expect { account_session.get_attributes([cached_attribute_name]) }.to raise_error(AccountSession::MissingCachedAttribute)
-      end
-
-      it "returns nil for a missing local attribute" do
-        expect(account_session.get_attributes([local_attribute_name])).to eq({})
-      end
-
-      context "when the attribute value is cached" do
-        let(:cached_attribute_value) { "email@example.com" }
-
-        it "returns it" do
-          expect(account_session.get_attributes([cached_attribute_name])).to eq({ cached_attribute_name => cached_attribute_value })
-        end
+      it "returns nil for a missing attribute" do
+        expect(account_session.get_attributes([attribute_name])).to eq({})
       end
     end
 
     describe "set_attributes" do
-      let(:local_attribute_value) { true }
+      let(:attribute_value) { "email@example.com" }
 
       it "saves attributes to the database" do
-        account_session.set_attributes(local_attribute_name => local_attribute_value)
-        expect(account_session.user[local_attribute_name]).to eq(local_attribute_value)
+        account_session.set_attributes(attribute_name => attribute_value)
+        expect(account_session.user[attribute_name]).to eq(attribute_value)
       end
     end
   end

--- a/spec/models/attribute_definition_spec.rb
+++ b/spec/models/attribute_definition_spec.rb
@@ -1,35 +1,26 @@
 RSpec.describe AttributeDefinition do
-  subject(:attribute) { described_class.new(type: :local) }
+  subject(:attribute) { described_class.new }
 
-  it { is_expected.to validate_presence_of(:type) }
-
-  it { is_expected.to validate_inclusion_of(:type).in_array(%w[local cached]) }
   it { is_expected.to validate_exclusion_of(:check_requires_mfa).in_array([nil]) }
   it { is_expected.to validate_exclusion_of(:get_requires_mfa).in_array([nil]) }
   it { is_expected.to validate_exclusion_of(:set_requires_mfa).in_array([nil]) }
   it { is_expected.to validate_exclusion_of(:writable).in_array([nil]) }
 
   it "validates that :check_requires_mfa implies :get_requires_mfa" do
-    attribute = described_class.new(type: :local, check_requires_mfa: true, get_requires_mfa: false, set_requires_mfa: false)
+    attribute = described_class.new(check_requires_mfa: true, get_requires_mfa: false, set_requires_mfa: false)
     attribute.valid?
     expect(attribute.errors[:check_requires_mfa]).not_to be_empty
   end
 
   it "validates that :get_requires_mfa implies :set_requires_mfa" do
-    attribute = described_class.new(type: :local, check_requires_mfa: false, get_requires_mfa: true, set_requires_mfa: false)
+    attribute = described_class.new(check_requires_mfa: false, get_requires_mfa: true, set_requires_mfa: false)
     attribute.valid?
     expect(attribute.errors[:get_requires_mfa]).not_to be_empty
   end
 
-  it "validates that :writable implies :type is local" do
-    attribute = described_class.new(type: :cached, writable: true)
-    attribute.valid?
-    expect(attribute.errors[:writable]).not_to be_empty
-  end
-
   context "when the attribute is not writable" do
     it "does not validate that :get_requires_mfa implies :set_requires_mfa" do
-      attribute = described_class.new(type: :local, check_requires_mfa: false, get_requires_mfa: true, set_requires_mfa: false, writable: false)
+      attribute = described_class.new(check_requires_mfa: false, get_requires_mfa: true, set_requires_mfa: false, writable: false)
       attribute.valid?
       expect(attribute.errors[:get_requires_mfa]).to be_empty
     end

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -59,19 +59,6 @@ RSpec.describe "Authentication" do
       expect(JSON.parse(response.body)).to include("govuk_account_session", "redirect_path" => auth_request.redirect_path)
     end
 
-    context "when cacheable attributes are missing" do
-      let!(:user) { FactoryBot.create(:oidc_user, sub: "user-id", email: nil, email_verified: nil) }
-
-      it "fetches them from userinfo" do
-        stub = stub_userinfo(email: "email@example.com", email_verified: true)
-        post callback_path, headers: headers, params: { state: auth_request.to_oauth_state, code: "12345" }.to_json
-        expect(response).to be_successful
-        expect(stub).to have_been_made
-        expect(user.reload.email).to eq("email@example.com")
-        expect(user.reload.email_verified).to be(true)
-      end
-    end
-
     it "returns a 401 if there is no matching AuthRequest" do
       post callback_path, headers: headers, params: { state: "something-else" }.to_json
       expect(response).to have_http_status(:unauthorized)

--- a/spec/requests/email_subscriptions_spec.rb
+++ b/spec/requests/email_subscriptions_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Email subscriptions" do
     let(:email_verified) { false }
 
     it "creates a new subscription record if one doesn't already exist" do
-      stub_local_attributes
+      stub_attributes
 
       expect { put email_subscription_path(subscription_name: "name"), params: params.to_json, headers: headers }.to change(EmailSubscription, :count).by(1)
 
@@ -59,20 +59,12 @@ RSpec.describe "Email subscriptions" do
       expect(JSON.parse(response.body)["email_subscription"]).to eq(EmailSubscription.last.to_hash)
     end
 
-    context "when the email and email verified attributes are not cached locally" do
-      it "returns a 401" do
-        expect { put email_subscription_path(subscription_name: "name"), params: params.to_json, headers: headers }.not_to change(EmailSubscription, :count)
-
-        expect(response).to have_http_status(:unauthorized)
-      end
-    end
-
     context "when the user has verified their email address" do
       let(:email_verified) { true }
 
       it "calls email-alert-api to create the subscription" do
         expect_activate_email_subscription do
-          stub_local_attributes
+          stub_attributes
 
           expect { put email_subscription_path(subscription_name: "name"), params: params.to_json, headers: headers }.to change(EmailSubscription, :count).by(1)
 
@@ -87,7 +79,7 @@ RSpec.describe "Email subscriptions" do
         FactoryBot.create(:email_subscription, oidc_user: session_identifier.user, email_alert_api_subscription_id: "prior-subscription-id")
       end
 
-      before { stub_local_attributes }
+      before { stub_attributes }
 
       it "calls email-alert-api to deactivate the old subscription" do
         stub_cancel_old = stub_email_alert_api_unsubscribes_a_subscription(email_subscription.email_alert_api_subscription_id)
@@ -115,7 +107,7 @@ RSpec.describe "Email subscriptions" do
       end
     end
 
-    def stub_local_attributes
+    def stub_attributes
       session_identifier.user.update!(
         email: email,
         email_verified: email_verified,

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -9,7 +9,7 @@ Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
 module PactStubHelpers
   EMAIL_ADDRESS = "user@example.com".freeze
 
-  def stub_cached_attributes(email_verified: true)
+  def stub_attributes(email_verified: true)
     oidc_user.update!(
       email: EMAIL_ADDRESS,
       email_verified: email_verified,
@@ -101,7 +101,7 @@ Pact.provider_states_for "GDS API Adapters" do
     set_up do
       auth_request = AuthRequest.generate!
       allow(AuthRequest).to receive(:from_oauth_state).and_return(auth_request)
-      stub_cached_attributes
+      stub_attributes
     end
   end
 
@@ -109,7 +109,7 @@ Pact.provider_states_for "GDS API Adapters" do
     set_up do
       auth_request = AuthRequest.generate!(redirect_path: "/some-arbitrary-path")
       allow(AuthRequest).to receive(:from_oauth_state).and_return(auth_request)
-      stub_cached_attributes
+      stub_attributes
     end
   end
 
@@ -117,14 +117,14 @@ Pact.provider_states_for "GDS API Adapters" do
     set_up do
       auth_request = AuthRequest.generate!(redirect_path: "/some-arbitrary-path")
       allow(AuthRequest).to receive(:from_oauth_state).and_return(auth_request)
-      stub_cached_attributes
+      stub_attributes
       oidc_user.update!(cookie_consent: true)
     end
   end
 
   provider_state "there is a valid user session" do
     set_up do
-      stub_cached_attributes
+      stub_attributes
       stub_will_create_email_subscription "wizard-news-topic-slug"
       # rubocop:disable RSpec/AnyInstance
       allow_any_instance_of(AccountSession).to receive(:set_remote_attributes)
@@ -134,16 +134,16 @@ Pact.provider_states_for "GDS API Adapters" do
 
   provider_state "there is a valid user session, with a 'wizard-news' email subscription" do
     set_up do
-      stub_cached_attributes
+      stub_attributes
       stub_will_create_email_subscription "wizard-news-topic-slug"
       FactoryBot.create(:email_subscription, name: "wizard-news", oidc_user_id: oidc_user.id)
     end
   end
 
-  provider_state "there is a valid user session, with an attribute called 'local_attribute'" do
+  provider_state "there is a valid user session, with an attribute called 'email'" do
     set_up do
-      stub_cached_attributes
-      oidc_user.update!(local_attribute: true)
+      stub_attributes
+      oidc_user.update!(email: "email@example.com")
     end
   end
 


### PR DESCRIPTION
In #418 we removed the last two local attributes, cookie and feedback
consent. In that PR we replaced them with a dummy local attribute that
allowed all the logic to stay in place temporarily.

This PR cleans up after that one by removing attribute types and the
logic associated with what used to be `local` attributes. We only have
what used to be `cached` attributes left, which are those provided by
the IDP and aren't allowed to be updated by internal GOV.UK apps.

We might want to add other attributes in the future and we don't want
to break existing behaviour when trying to update these attributes
(which will return a 403), so this PR removes the logic for
updating attributes and the associated tests but leaves the `update`
controller method in place. This means the change to gds-api-adaptors
doesn't need to be a breaking change where we remove a method and have
to audit all other apps to check if it's used.

It's quite a lot all in one commit (sorry) but the logic is pushed down to 
the models and services so there's not a good way of separating the 
changes out into multiple commits.

---
[JIRA](https://govukverify.atlassian.net/jira/software/c/projects/GUA/boards/195?modal=detail&selectedIssue=GUA-122)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
