### PR TITLE
Use Redis.new rather than Redis.current

### DIFF
--- a/app/lib/logout_token.rb
+++ b/app/lib/logout_token.rb
@@ -112,14 +112,14 @@ private
   end
 
   def is_recent_jti?(jti)
-    return true if Redis.current.get("logout-token/#{jti}") == "OK"
+    return true if Redis.new.get("logout-token/#{jti}") == "OK"
 
     false
   end
 
   def record_jti_as_recently_verified(jti)
-    Redis.current.set("logout-token/#{jti}", "OK")
-    Redis.current.expire("logout-token/#{jti}", 2.minutes)
+    Redis.new.set("logout-token/#{jti}", "OK")
+    Redis.new.expire("logout-token/#{jti}", 2.minutes)
   end
 
   class << self

--- a/app/models/logout_notice.rb
+++ b/app/models/logout_notice.rb
@@ -1,6 +1,6 @@
 class LogoutNotice
   def self.find(sub)
-    Redis.current.get("logout-notice/#{sub}")
+    Redis.new.get("logout-notice/#{sub}")
   end
 
   def initialize(sub)
@@ -8,11 +8,11 @@ class LogoutNotice
   end
 
   def persist
-    Redis.current.set("logout-notice/#{sub}", Time.zone.now)
+    Redis.new.set("logout-notice/#{sub}", Time.zone.now)
   end
 
   def remove
-    Redis.current.del("logout-notice/#{sub}")
+    Redis.new.del("logout-notice/#{sub}")
   end
 
 private

--- a/spec/lib/logout_token_spec.rb
+++ b/spec/lib/logout_token_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe LogoutToken do
   let(:required_attribute_keys) { %i[iss aud iat jti events] }
   let(:optional_attribute_keys) { %i[sub sid auth_time] }
 
-  before { Redis.current.flushdb }
+  before { Redis.new.flushdb }
 
   describe "attributes" do
     it "validates required attributes" do
@@ -194,8 +194,8 @@ RSpec.describe LogoutToken do
 
     context "when a JTI is already in the cache" do
       it "raises an error" do
-        Redis.current.set("logout-token/#{jti}", "OK")
-        Redis.current.expire("logout-token/#{jti}", 2.minutes)
+        Redis.new.set("logout-token/#{jti}", "OK")
+        Redis.new.expire("logout-token/#{jti}", 2.minutes)
         expect {
           logout_token.verify!(
             issuer: attributes[:iss],

--- a/spec/models/logout_notice_spec.rb
+++ b/spec/models/logout_notice_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe LogoutNotice do
 
   before do
     freeze_time
-    Redis.current.flushdb
+    Redis.new.flushdb
   end
 
   describe ".find" do
@@ -16,7 +16,7 @@ RSpec.describe LogoutNotice do
     end
 
     it "returns the created at timestamp if a Notice has been persisted" do
-      Redis.current.set("logout-notice/#{sub}", Time.zone.now)
+      Redis.new.set("logout-notice/#{sub}", Time.zone.now)
       expect(described_class.find(sub)).to eq(redis_formatted_time)
     end
   end
@@ -28,13 +28,13 @@ RSpec.describe LogoutNotice do
 
     it "persists a sub with in a logout notice timespace with a timestamp" do
       instance.persist
-      expect(Redis.current.get("logout-notice/#{sub}")).to eq(redis_formatted_time)
+      expect(Redis.new.get("logout-notice/#{sub}")).to eq(redis_formatted_time)
     end
   end
 
   describe "#remove" do
     it "returns 1 if the record was removed" do
-      Redis.current.set("logout-notice/#{sub}", Time.zone.now)
+      Redis.new.set("logout-notice/#{sub}", Time.zone.now)
       expect(instance.remove).to eq(1)
     end
 

--- a/spec/models/oidc_user_spec.rb
+++ b/spec/models/oidc_user_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe OidcUser do
 
     it "clears a LogoutNotice if one exists" do
       time = Time.zone.now
-      Redis.current.set("logout-notice/#{sub}", time)
+      Redis.new.set("logout-notice/#{sub}", time)
       expect {
         described_class.find_or_create_by_sub!(sub)
       }.to change {

--- a/spec/requests/back_channel_logout_spec.rb
+++ b/spec/requests/back_channel_logout_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "OIDC Backchannel Logout" do
     allow(oidc_client).to receive(:logout_token).and_return(oidc_client_logout_token)
     allow(logout_token).to receive(:sub).and_return(sub)
     freeze_time
-    Redis.current.flushdb
+    Redis.new.flushdb
   end
 
   describe "POST" do
@@ -43,7 +43,7 @@ RSpec.describe "OIDC Backchannel Logout" do
     context "with a valid logout token" do
       it "records a session expiry notice" do
         post backchannel_logout_path, params: params
-        expect(Redis.current.get("logout-notice/#{sub}")).to eq(redis_formatted_time)
+        expect(Redis.new.get("logout-notice/#{sub}")).to eq(redis_formatted_time)
       end
 
       it "returns 200" do

--- a/spec/requests/logout_notice_invalidation_spec.rb
+++ b/spec/requests/logout_notice_invalidation_spec.rb
@@ -3,17 +3,17 @@ require "gds_api/test_helpers/email_alert_api"
 RSpec.describe "Logout Notice Invalidation" do
   include ActiveSupport::Testing::TimeHelpers
   let(:sub) { "user-id" }
-  let(:redis_state) { Redis.current.get("logout-notice/#{sub}") }
+  let(:redis_state) { Redis.new.get("logout-notice/#{sub}") }
   let(:redis_formatted_time) { Time.zone.now.strftime("%F %T %z") }
   let(:headers) { { "Content-Type" => "application/json" } }
 
   before do
     freeze_time
-    Redis.current.flushdb
+    Redis.new.flushdb
   end
 
   context "when a logout notice exists for sub" do
-    before { Redis.current.set("logout-notice/#{sub}", Time.zone.now) }
+    before { Redis.new.set("logout-notice/#{sub}", Time.zone.now) }
 
     it "invalidates the notice on a sucessful callback_path request" do
       stub_userinfo
@@ -25,7 +25,7 @@ RSpec.describe "Logout Notice Invalidation" do
              headers: headers,
              params: { state: auth_request.to_oauth_state, code: "12345" }.to_json
       }.to change {
-        Redis.current.get("logout-notice/#{sub}")
+        Redis.new.get("logout-notice/#{sub}")
       }.from(redis_formatted_time).to(nil)
     end
 
@@ -35,7 +35,7 @@ RSpec.describe "Logout Notice Invalidation" do
       expect {
         delete oidc_user_path(subject_identifier: sub)
       }.to change {
-        Redis.current.get("logout-notice/#{sub}")
+        Redis.new.get("logout-notice/#{sub}")
       }.from(redis_formatted_time).to(nil)
     end
   end


### PR DESCRIPTION
Redis.current will be deprecated in Redis 5.0.

As Redis.current ultimately calls Redis.new we can migrate this method now to pave the way for future upgrades.

From Redis changelog from [5.0][1]:

‘Removed Redis.current. You shouldn't assume there is a single global Redis connection, use a connection pool instead, and libaries using Redis should accept a Redis instance (or connection pool) as a config. E.g. MyLibrary.redis = Redis.new(…).’

[Redis.current][2] just calls Redis.new so should just be able to swap methods.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
