### PR TITLE
Revert "Bump openid_connect from 1.4.0 to 2.2.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,7 @@ GEM
     ast (2.4.2)
     attr_required (1.0.1)
     awesome_print (1.9.2)
-    bindata (2.4.14)
+    bindata (2.4.13)
     bootsnap (1.13.0)
       msgpack (~> 1.2)
     brakeman (5.3.1)
@@ -188,6 +188,7 @@ GEM
     httparty (0.18.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
+    httpclient (2.8.3)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     json (2.6.2)
@@ -262,19 +263,16 @@ GEM
     omniauth-oauth2 (1.8.0)
       oauth2 (>= 1.4, < 3)
       omniauth (~> 2.0)
-    openid_connect (2.2.0)
+    openid_connect (1.4.0)
       activemodel
       attr_required (>= 1.0.0)
-      faraday (~> 2.0)
-      faraday-follow_redirects
-      json-jwt (>= 1.16)
-      net-smtp
-      rack-oauth2 (~> 2.2)
-      swd (~> 2.0)
+      json-jwt (>= 1.15.0)
+      rack-oauth2 (>= 1.6.1)
+      swd (>= 1.0.0)
       tzinfo
       validate_email
       validate_url
-      webfinger (~> 2.0)
+      webfinger (>= 1.0.1)
     pact (1.63.0)
       pact-mock_service (~> 3.0, >= 3.3.1)
       pact-support (~> 1.16, >= 1.16.9)
@@ -327,11 +325,10 @@ GEM
     raabro (1.4.0)
     racc (1.6.0)
     rack (2.2.4)
-    rack-oauth2 (2.2.0)
+    rack-oauth2 (1.21.3)
       activesupport
       attr_required
-      faraday (~> 2.0)
-      faraday-follow_redirects
+      httpclient
       json-jwt (>= 1.11.0)
       rack (>= 2.1.0)
     rack-protection (3.0.2)
@@ -479,11 +476,10 @@ GEM
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     statsd-ruby (1.5.0)
-    swd (2.0.2)
+    swd (1.3.0)
       activesupport (>= 3)
       attr_required (>= 0.0.5)
-      faraday (~> 2.0)
-      faraday-follow_redirects
+      httpclient (>= 2.4)
     sync (0.5.0)
     table_print (1.5.7)
     term-ansicolor (1.7.1)
@@ -514,10 +510,9 @@ GEM
       rack (>= 2.0.9)
     warden-oauth2 (0.0.1)
       warden
-    webfinger (2.1.2)
+    webfinger (1.2.0)
       activesupport
-      faraday (~> 2.0)
-      faraday-follow_redirects
+      httpclient (>= 2.4)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)

--- a/app/lib/oidc_client.rb
+++ b/app/lib/oidc_client.rb
@@ -146,7 +146,7 @@ private
       raise Retry if RETRY_STATUSES.include? response.status
 
       response
-    rescue Retry, Faraday::ConnectionFailed, Faraday::SSLError
+    rescue Retry, Errno::ECONNRESET, OpenSSL::SSL::SSLError
       raise OAuthFailure unless retries < MAX_OAUTH_RETRIES
 
       retries += 1


### PR DESCRIPTION
Reverts alphagov/account-api#513

Likely cause of these errors: https://sentry.io/organizations/govuk/issues/3727423113/?project=5671868