### PR TITLE
Revert "Revert "Bump openid_connect from 1.4.0 to 2.2.0""

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,7 @@ GEM
     ast (2.4.2)
     attr_required (1.0.1)
     awesome_print (1.9.2)
-    bindata (2.4.13)
+    bindata (2.4.14)
     bootsnap (1.14.0)
       msgpack (~> 1.2)
     brakeman (5.3.1)
@@ -188,7 +188,6 @@ GEM
     httparty (0.18.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    httpclient (2.8.3)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     json (2.6.2)
@@ -263,17 +262,19 @@ GEM
     omniauth-oauth2 (1.8.0)
       oauth2 (>= 1.4, < 3)
       omniauth (~> 2.0)
-    openid_connect (1.4.2)
+    openid_connect (2.2.0)
       activemodel
       attr_required (>= 1.0.0)
-      json-jwt (>= 1.15.0)
+      faraday (~> 2.0)
+      faraday-follow_redirects
+      json-jwt (>= 1.16)
       net-smtp
-      rack-oauth2 (~> 1.21)
-      swd (~> 1.3)
+      rack-oauth2 (~> 2.2)
+      swd (~> 2.0)
       tzinfo
       validate_email
       validate_url
-      webfinger (~> 1.2)
+      webfinger (~> 2.0)
     pact (1.63.0)
       pact-mock_service (~> 3.0, >= 3.3.1)
       pact-support (~> 1.16, >= 1.16.9)
@@ -326,10 +327,11 @@ GEM
     raabro (1.4.0)
     racc (1.6.0)
     rack (2.2.4)
-    rack-oauth2 (1.21.3)
+    rack-oauth2 (2.2.0)
       activesupport
       attr_required
-      httpclient
+      faraday (~> 2.0)
+      faraday-follow_redirects
       json-jwt (>= 1.11.0)
       rack (>= 2.1.0)
     rack-protection (3.0.2)
@@ -477,10 +479,11 @@ GEM
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     statsd-ruby (1.5.0)
-    swd (1.3.0)
+    swd (2.0.2)
       activesupport (>= 3)
       attr_required (>= 0.0.5)
-      httpclient (>= 2.4)
+      faraday (~> 2.0)
+      faraday-follow_redirects
     sync (0.5.0)
     table_print (1.5.7)
     term-ansicolor (1.7.1)
@@ -511,9 +514,10 @@ GEM
       rack (>= 2.0.9)
     warden-oauth2 (0.0.1)
       warden
-    webfinger (1.2.0)
+    webfinger (2.1.2)
       activesupport
-      httpclient (>= 2.4)
+      faraday (~> 2.0)
+      faraday-follow_redirects
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)

--- a/app/lib/oidc_client.rb
+++ b/app/lib/oidc_client.rb
@@ -101,8 +101,8 @@ class OidcClient
       )
     end
 
-    JSON.parse(response.body)
-  rescue JSON::ParserError => e
+    response.body
+  rescue Faraday::ParsingError => e
     capture_sensitive_exception(e, response_error_presenter(response, access_token))
     raise OAuthFailure
   end

--- a/app/lib/oidc_client.rb
+++ b/app/lib/oidc_client.rb
@@ -146,7 +146,7 @@ private
       raise Retry if RETRY_STATUSES.include? response.status
 
       response
-    rescue Retry, Errno::ECONNRESET, OpenSSL::SSL::SSLError
+    rescue Retry, Faraday::ConnectionFailed, Faraday::SSLError
       raise OAuthFailure unless retries < MAX_OAUTH_RETRIES
 
       retries += 1

--- a/spec/lib/oidc_client_spec.rb
+++ b/spec/lib/oidc_client_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe OidcClient do
     it "calls userinfo to fetch the legacy sub and creates the user model" do
       stub = stub_request(:get, "http://openid-provider/userinfo-endpoint")
         .with(headers: { Authorization: "Bearer access-token" })
-        .to_return(status: 200, body: { "legacy_subject_id" => "legacy-sub" }.to_json)
+        .to_return(status: 200, headers: { "Content-Type": "application/json" }, body: { "legacy_subject_id" => "legacy-sub" }.to_json)
 
       expect { client.callback(AuthRequest.generate!, "code") }.to change(OidcUser, :count).by(1)
 
@@ -51,7 +51,7 @@ RSpec.describe OidcClient do
       it "calls userinfo to fetch the legacy sub and updates the user model" do
         stub = stub_request(:get, "http://openid-provider/userinfo-endpoint")
           .with(headers: { Authorization: "Bearer access-token" })
-          .to_return(status: 200, body: { "legacy_subject_id" => "legacy-sub" }.to_json)
+          .to_return(status: 200, headers: { "Content-Type": "application/json" }, body: { "legacy_subject_id" => "legacy-sub" }.to_json)
 
         expect { client.callback(AuthRequest.generate!, "code") }.not_to change(OidcUser, :count)
 
@@ -67,7 +67,7 @@ RSpec.describe OidcClient do
       it "does not call userinfo" do
         stub = stub_request(:get, "http://openid-provider/userinfo-endpoint")
           .with(headers: { Authorization: "Bearer access-token" })
-          .to_return(status: 200, body: { "legacy_subject_id" => "legacy-sub" }.to_json)
+          .to_return(status: 200, headers: { "Content-Type": "application/json" }, body: { "legacy_subject_id" => "legacy-sub" }.to_json)
 
         expect { client.callback(AuthRequest.generate!, "code") }.not_to change(OidcUser, :count)
 
@@ -141,7 +141,7 @@ RSpec.describe OidcClient do
       it "retries" do
         stub_request(:get, "http://openid-provider/userinfo-endpoint")
           .with(headers: { Authorization: "Bearer access-token" })
-          .to_return(status: 200, body: { id: "foo" }.to_json)
+          .to_return(status: 200, headers: { "Content-Type": "application/json" }, body: { id: "foo" }.to_json)
 
         expect(client.userinfo(access_token: "access-token"))
           .to eq({ "id" => "foo" })

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "Authentication" do
     def stub_userinfo(attributes = {})
       stub_request(:get, "http://openid-provider/userinfo-endpoint")
         .with(headers: { Authorization: "Bearer access-token" })
-        .to_return(status: 200, body: attributes.to_json)
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: attributes.to_json)
     end
   end
 

--- a/spec/support/helpers/oidc_client_helper.rb
+++ b/spec/support/helpers/oidc_client_helper.rb
@@ -34,7 +34,7 @@ module OidcClientHelper
 
   def stub_userinfo(attributes = {})
     stub_request(:get, "http://openid-provider/userinfo-endpoint")
-      .to_return(status: 200, body: attributes.to_json)
+      .to_return(status: 200, headers: { "Content-Type": "application/json" }, body: attributes.to_json)
   end
 
   def stub_jwk_discovery


### PR DESCRIPTION
We need to update how we're getting back results - seems like faraday is returning pre-parsed bodies, so we're getting errors like this:

https://sentry.io/organizations/govuk/issues/3727423113/?referrer=slack

Openid connect changes that might be relevant:

https://github.com/nov/openid_connect/compare/v1.4.0...v2.2.0#diff-1e4b17b797d3704d8ba5d6eeed053f777bc25e5fac07e4a453e32aa4e8a72aacR29

Probable changes - check where bodies are being parsed that don't need to be, update test mocks to return pre-parsed data.


Reverts alphagov/account-api#532

https://trello.com/c/8eLTjlLQ/1644-dependahour-update-openidconnect-to-v2-in-account-api