### PR TITLE
Remove button html from API response

### DIFF
--- a/app/controllers/personalisation/check_email_subscription_controller.rb
+++ b/app/controllers/personalisation/check_email_subscription_controller.rb
@@ -4,7 +4,6 @@ class Personalisation::CheckEmailSubscriptionController < PersonalisationControl
   before_action do
     @base_path = params[:base_path]
     @topic_slug = params[:topic_slug]
-    @button_location = params[:button_location]
 
     head :unprocessable_entity if @base_path && @topic_slug
     head :unprocessable_entity unless @base_path || @topic_slug
@@ -32,16 +31,7 @@ private
     {
       base_path: @base_path,
       topic_slug: @topic_slug,
-      button_location: @button_location,
       active:,
-      button_html: render_button_component(active),
     }.compact
-  end
-
-  def render_button_component(active)
-    ActionController::Base.render(
-      partial: "govuk_publishing_components/components/single_page_notification_button",
-      locals: { base_path: @base_path, button_location: @button_location, already_subscribed: active },
-    ).presence
   end
 end

--- a/docs/api.md
+++ b/docs/api.md
@@ -662,8 +662,6 @@ See [Progressive enhancement ADR for more details](adr/002-progressive-enhanceme
   - the base path of the page (to match against the "url" of an email-alert-api subscriber list)
 - `topic_slug` *(optional)*
   - the email-alert-api topic slug
-- `button_location` *(optional)*
-  - the location of the button on the page (`top` or `bottom`). This is passed to the button component to add tracking parameters for Google Analytics
 
 Exactly one of `base_path` and `topic_slug` must be specified.
 
@@ -675,10 +673,6 @@ Exactly one of `base_path` and `topic_slug` must be specified.
   - the topic_slug parameter, if there is one (a string)
 - `active`
   - whether the subscription is active (a boolean)
-- `button_html`
-  - the rendered single-page notification button component HTML, if a `base_path` was given (a string)
-- `button_location`
-  - the button_location parameter, if there is one (a string)
 
 #### Response codes
 

--- a/spec/requests/check_email_subscription_spec.rb
+++ b/spec/requests/check_email_subscription_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe "Personalisation - Check Email Subscription" do
   describe "GET /api/personalisation/check-email-subscription" do
     let(:base_path) { nil }
     let(:topic_slug) { nil }
-    let(:button_location) { nil }
-    let(:params) { { base_path:, topic_slug:, button_location: }.compact }
+    let(:params) { { base_path:, topic_slug: }.compact }
 
     let(:active) { false }
 
@@ -91,11 +90,6 @@ RSpec.describe "Personalisation - Check Email Subscription" do
               expect(JSON.parse(response.body)).to include(subscription_details)
             end
 
-            it "includes the inactive-state button HTML" do
-              get personalisation_check_email_subscription_path, params: params, headers: headers
-              expect(JSON.parse(response.body)["button_html"]).to include("Get emails about this page")
-            end
-
             context "when an active subscription has a matching url" do
               let(:list_url) { base_path }
               let(:active) { true }
@@ -103,11 +97,6 @@ RSpec.describe "Personalisation - Check Email Subscription" do
               it "returns subscription status details as active" do
                 get personalisation_check_email_subscription_path, params: params, headers: headers
                 expect(JSON.parse(response.body)).to include(subscription_details)
-              end
-
-              it "includes the active-state button HTML" do
-                get personalisation_check_email_subscription_path, params: params, headers: headers
-                expect(JSON.parse(response.body)["button_html"]).to include("Stop getting emails about this page")
               end
             end
           end
@@ -119,20 +108,6 @@ RSpec.describe "Personalisation - Check Email Subscription" do
               get personalisation_check_email_subscription_path, params: params, headers: headers
               expect(JSON.parse(response.body)).to include(subscription_details)
             end
-
-            it "includes the inactive-state button HTML" do
-              get personalisation_check_email_subscription_path, params: params, headers: headers
-              expect(JSON.parse(response.body)["button_html"]).to include("Get emails about this page")
-            end
-
-            context "when a button location is passed" do
-              let(:button_location) { "top-of-page" }
-
-              it "returns the location in the response" do
-                get personalisation_check_email_subscription_path, params: params, headers: headers
-                expect(JSON.parse(response.body)["button_location"]).to eq(button_location)
-              end
-            end
           end
         end
 
@@ -142,11 +117,6 @@ RSpec.describe "Personalisation - Check Email Subscription" do
           it "returns subscription status details as not active" do
             get personalisation_check_email_subscription_path, params: params, headers: headers
             expect(JSON.parse(response.body)).to include(subscription_details)
-          end
-
-          it "includes the inactive-state button HTML" do
-            get personalisation_check_email_subscription_path, params: params, headers: headers
-            expect(JSON.parse(response.body)["button_html"]).to include("Get emails about this page")
           end
         end
       end
@@ -164,11 +134,6 @@ RSpec.describe "Personalisation - Check Email Subscription" do
             expect(JSON.parse(response.body)).to include(subscription_details)
           end
 
-          it "does not include button HTML" do
-            get personalisation_check_email_subscription_path, params: params, headers: headers
-            expect(response.body).not_to include("button_html")
-          end
-
           context "when an active subscription has a matching slug" do
             let(:list_slug) { topic_slug }
             let(:active) { true }
@@ -176,11 +141,6 @@ RSpec.describe "Personalisation - Check Email Subscription" do
             it "returns subscription status details as active" do
               get personalisation_check_email_subscription_path, params: params, headers: headers
               expect(JSON.parse(response.body)).to include(subscription_details)
-            end
-
-            it "does not include button HTML" do
-              get personalisation_check_email_subscription_path, params: params, headers: headers
-              expect(response.body).not_to include("button_html")
             end
           end
         end
@@ -191,11 +151,6 @@ RSpec.describe "Personalisation - Check Email Subscription" do
           it "returns subscription status details as not active" do
             get personalisation_check_email_subscription_path, params: params, headers: headers
             expect(JSON.parse(response.body)).to include(subscription_details)
-          end
-
-          it "does not include button HTML" do
-            get personalisation_check_email_subscription_path, params: params, headers: headers
-            expect(response.body).not_to include("button_html")
           end
         end
       end


### PR DESCRIPTION
## What 

Remove button html from API response

## Why

So that it's possible to update the text of the single page notification button component without making changes to this API. 


This API endpoint is only used by the single page notification button component in the gem, see [here](https://github.com/search?q=org%3Aalphagov+check-email-subscription&type=code). The gem has been updated to expect a different response, see [here](https://github.com/alphagov/govuk_publishing_components/pull/3071).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

https://trello.com/c/gpch42Uc/1456-support-custom-button-text-on-the-single-page-notification-button-l, [Jira issue NAV-5475](https://gov-uk.atlassian.net/browse/NAV-5475)