### PR TITLE
Stop redirecting rails logger to sidekiq logger inside sidekiq.

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,4 +1,0 @@
-Sidekiq.configure_server do
-  # Calls to Rails.logger in a sidekiq process will use Sidekiq's logger
-  Rails.logger = Sidekiq::Logging.logger
-end


### PR DESCRIPTION
This is no longer necessary as of Sidekiq 6.3.0, and indeed breaks sidekiq in updated versions.

Ref: https://github.com/mperham/sidekiq/commit/90535ab104b6540104af548d15baacd1291ffb5f (6.3.0 sidekiq gem)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
