### PR TITLE
Add support Rake tasks for deleting, and finding deleted, users

### DIFF
--- a/lib/tasks/support.rake
+++ b/lib/tasks/support.rake
@@ -32,4 +32,14 @@ namespace :support do
       end
     end
   end
+
+  desc "Check if a user previously existed for a given OICD sub"
+  task :find_deleted_user_by_oicd_sub, [:sub] => :environment do |_, args|
+    tombstone = Tombstone.find_by(sub: args[:sub])
+    if tombstone
+      puts "User was deleted at #{tombstone.created_at.to_formatted_s(:db)}"
+    else
+      puts "No deleted user for sub '#{args[:sub]}' found"
+    end
+  end
 end

--- a/lib/tasks/support.rake
+++ b/lib/tasks/support.rake
@@ -7,4 +7,29 @@ namespace :support do
       puts "User '#{args[:email]}' does not exist"
     end
   end
+
+  namespace :delete_user do
+    desc "Dry Run to delete user for the given email address"
+    task :dry_run, [:email] => :environment do |_, args|
+      user = OidcUser.find_by("lower(email) = ?", args[:email].downcase)
+      if user
+        puts "Dry Run: User '#{user.email}' would have been deleted"
+        puts "Dry Run: User sub: #{user.sub}"
+      else
+        puts "User '#{args[:email]}' does not exist"
+      end
+    end
+
+    desc "Delete user for the given email address"
+    task :real, [:email] => :environment do |_, args|
+      user = OidcUser.find_by("lower(email) = ?", args[:email].downcase)
+      if user
+        user.destroy!
+        puts "User '#{user.email}' deleted"
+        puts "User sub: #{user.sub}"
+      else
+        puts "User '#{args[:email]}' does not exist"
+      end
+    end
+  end
 end

--- a/spec/lib/oidc_client_spec.rb
+++ b/spec/lib/oidc_client_spec.rb
@@ -1,5 +1,4 @@
 RSpec.describe OidcClient do
-  include ActiveSupport::Testing::TimeHelpers
   subject(:client) { described_class.new }
 
   let(:jwt_signing_key) { "secret" }

--- a/spec/lib/support_spec.rb
+++ b/spec/lib/support_spec.rb
@@ -22,4 +22,44 @@ RSpec.describe "Support tasks" do
       end
     end
   end
+
+  describe ":delete_user" do
+    before do
+      FactoryBot.create(:oidc_user, email: "foo@example.gov.uk", sub: "123")
+    end
+
+    context "when a dry run" do
+      subject(:task) { Rake.application["support:delete_user:dry_run"] }
+
+      context "when a user with email exists" do
+        it "reports that the user would have been deleted" do
+          expect { task.execute({ email: "foo@example.gov.uk" }) }.to output("Dry Run: User 'foo@example.gov.uk' would have been deleted\nDry Run: User sub: 123\n").to_stdout
+        end
+
+        it "outputs other users don't exist" do
+          expect { task.execute({ email: "bar@example.com" }) }.to output("User 'bar@example.com' does not exist\n").to_stdout
+        end
+      end
+    end
+
+    context "when a real run" do
+      subject(:task) { Rake.application["support:delete_user:real"] }
+
+      context "when a user with email exists" do
+        it "reports that the user has been deleted" do
+          expect { task.execute({ email: "foo@example.gov.uk" }) }.to output("User 'foo@example.gov.uk' deleted\nUser sub: 123\n").to_stdout
+        end
+
+        it "deletes the user" do
+          count = OidcUser.count
+          task.execute({ email: "foo@example.gov.uk" })
+          expect(OidcUser.count).to eq count - 1
+        end
+
+        it "outputs other users don't exist" do
+          expect { task.execute({ email: "bar@example.com" }) }.to output("User 'bar@example.com' does not exist\n").to_stdout
+        end
+      end
+    end
+  end
 end

--- a/spec/lib/support_spec.rb
+++ b/spec/lib/support_spec.rb
@@ -62,4 +62,24 @@ RSpec.describe "Support tasks" do
       end
     end
   end
+
+  describe ":find_deleted_user_by_oicd_sub" do
+    subject(:task) { Rake.application["support:find_deleted_user_by_oicd_sub"] }
+
+    context "when a user with sub 'user-id-123' previously existed" do
+      before do
+        user = FactoryBot.create(:oidc_user, email: "foo@example.gov.uk", sub: "user-id-123")
+        freeze_time
+        user.destroy!
+      end
+
+      it "can find that user's tombstone by sub" do
+        expect { task.execute({ sub: "user-id-123" }) }.to output("User was deleted at #{Time.zone.now.to_formatted_s(:db)}\n").to_stdout
+      end
+
+      it "outputs other users did not exist" do
+        expect { task.execute({ sub: "user-id-456" }) }.to output("No deleted user for sub 'user-id-456' found\n").to_stdout
+      end
+    end
+  end
 end

--- a/spec/models/logout_notice_spec.rb
+++ b/spec/models/logout_notice_spec.rb
@@ -1,6 +1,4 @@
 RSpec.describe LogoutNotice do
-  include ActiveSupport::Testing::TimeHelpers
-
   let(:sub) { "sub" }
   let(:instance) { described_class.new(sub) }
   let(:redis_formatted_time) { Time.zone.now.strftime("%F %T %z") }

--- a/spec/requests/back_channel_logout_spec.rb
+++ b/spec/requests/back_channel_logout_spec.rb
@@ -1,6 +1,4 @@
 RSpec.describe "OIDC Backchannel Logout" do
-  include ActiveSupport::Testing::TimeHelpers
-
   let(:logout_token_jwt) { "pretend_this_is_a_jwt" }
   let(:sub) { "user_id " }
 

--- a/spec/requests/logout_notice_invalidation_spec.rb
+++ b/spec/requests/logout_notice_invalidation_spec.rb
@@ -1,7 +1,6 @@
 require "gds_api/test_helpers/email_alert_api"
 
 RSpec.describe "Logout Notice Invalidation" do
-  include ActiveSupport::Testing::TimeHelpers
   let(:sub) { "user-id" }
   let(:redis_state) { Redis.new.get("logout-notice/#{sub}") }
   let(:redis_formatted_time) { Time.zone.now.strftime("%F %T %z") }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,7 @@ RSpec.configure do |config|
     Sidekiq::Worker.clear_all
   end
 
+  config.include ActiveSupport::Testing::TimeHelpers
   config.expose_dsl_globally = false
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!

--- a/spec/workers/expired_auth_request_worker_spec.rb
+++ b/spec/workers/expired_auth_request_worker_spec.rb
@@ -1,6 +1,4 @@
 RSpec.describe ExpiredAuthRequestWorker do
-  include ActiveSupport::Testing::TimeHelpers
-
   before { freeze_time }
 
   it "deletes old state" do

--- a/spec/workers/expired_sensitive_exception_worker_spec.rb
+++ b/spec/workers/expired_sensitive_exception_worker_spec.rb
@@ -1,6 +1,4 @@
 RSpec.describe ExpiredSensitiveExceptionWorker do
-  include ActiveSupport::Testing::TimeHelpers
-
   before { freeze_time }
 
   it "deletes old exceptions" do

--- a/spec/workers/expired_tombstone_worker_spec.rb
+++ b/spec/workers/expired_tombstone_worker_spec.rb
@@ -1,6 +1,4 @@
 RSpec.describe ExpiredTombstoneWorker do
-  include ActiveSupport::Testing::TimeHelpers
-
   before { freeze_time }
 
   it "deletes old tombstones" do


### PR DESCRIPTION
This PR adds 3 new support rake tasks.

`support:delete_user:dry_run['test@example.com']` will simulate deleting a user for the given email address, returning the user's OICD sub for further confirmation.

`support:delete_user:real['test@example.com']` will delete the user.

`support:find_deleted_user_by_oicd_sub['user-id-123`]` will return the time that the user for the given OICD sub was deleted.

[trello](https://trello.com/c/ObbXmXJC/1757-add-rake-task-to-delete-accounts-more-efficiently)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
