### PR TITLE
GUA-838: Add new link to /sign-in page

### DIFF
--- a/app/views/help_pages/sign_in.html.erb
+++ b/app/views/help_pages/sign_in.html.erb
@@ -22,6 +22,10 @@
       path: "/sign-in-universal-credit",
       description: "See and update your Universal credit claim.",
     },{
+      text: "How to sign in to continue your visa application",
+      path: "/sign-in-visa",
+      description: "Find out how to sign in to complete a visa application you’ve started",
+    },{
       text: "View and prove your immigration status",
       path: "/view-prove-immigration-status",
       description: "View your immigration status online or prove your status to others.",


### PR DESCRIPTION
Following the One Login accounts team review of the `/sign-in` page, we have decided to add another visa related link on the page and review it after a month to see if that has any impact on the search term.

In the past quarter the top 4 and 5 page searches were for 'visa' or 'visa application' and users were going to the visa application guidance page. We have added a link to the guidance page on 'How to sign in to continue your visa application', as some supporting data suggests that people are struggling to sign in to complete an unfinished visa application.

https://govukverify.atlassian.net/browse/GUA-838


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
