### PR TITLE
Add Release workflow to version deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,18 +19,16 @@ on:
         - staging
         - production
         default: 'integration'
-  workflow_run:
-    workflows: [CI]
-    types: [completed]
-    branches: [main]
+  release:
+    types: [released]
 
 jobs:
   build-and-publish-image:
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref_name, 'v') 
     name: Build and publish image
     uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@main
     with:
-      gitRef: ${{ inputs.gitRef || github.ref }}
+      gitRef: ${{ inputs.gitRef || github.ref_name }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,16 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+
+jobs:
+  release:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    name: Release
+    uses: alphagov/govuk-infrastructure/.github/workflows/release.yml@main
+    secrets:
+      GH_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}


### PR DESCRIPTION
This adds a release workflow that creates a new GitHub Release (and git
tag) with an incremental version number. This version tag is then used
to tag images and referenced in the rest of the deployment system. This
makes it easier to compare references (vs commit SHAs). The version tag
is calculated as the last version incremented by the number of merge
commits until the reference commit.
