### PR TITLE
Delete subscriptions on manually deleting account

### DIFF
--- a/docs/support/rake_tasks.md
+++ b/docs/support/rake_tasks.md
@@ -49,8 +49,8 @@ support:delete_user:dry_run[email_address]
 ```
 
 ### Deleting a user
-This will delete the user, and confirm the user's
-OICD sub
+This will delete the user, and confirm the user's OICD sub. Deleting a user
+will also remove any email subscriptions they may have in Email Alert API.
 ```ruby
 support:delete_user:real[email_address]
 ```


### PR DESCRIPTION
Email subscriptions get ended when an account is deleted via the API [1], however the manual rake task doesn't include this step. If the subscriber doesn't exist then we'll just return `nil` and continue with the account deletion.

[1]: https://github.com/alphagov/account-api/blob/39af89177ed2ed6380d30f3469e6ab7c86348de2/app/controllers/internal/oidc_users_controller.rb#L31

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
