### PR TITLE
Upgrade ruby to 3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG ruby_version=3.2
+ARG ruby_version=3.3
 ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
 ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
 


### PR DESCRIPTION
The #govuk-platform-security-reliability-team expects teams to review, test and deploy this following the steps in the [docs](https://docs.publishing.service.gov.uk/manual/ruby.html#updating-individual-applications)