### PR TITLE
Remove failing Snyk SCA tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,14 @@ jobs:
   snyk-security:
     name: SNYK security analysis
     uses: alphagov/govuk-infrastructure/.github/workflows/snyk-security.yml@main
+    with:
+      skip_sca: true
     secrets: inherit
     permissions:
       contents: read
       security-events: write
       actions: read
-  
+
   codeql-sast:
     name: CodeQL SAST scan
     uses: alphagov/govuk-infrastructure/.github/workflows/codeql-analysis.yml@main
@@ -29,7 +31,7 @@ jobs:
   dependency-review:
     name: Dependency Review scan
     uses: alphagov/govuk-infrastructure/.github/workflows/dependency-review.yml@main
-  
+
   security-analysis:
     name: Security Analysis
     uses: alphagov/govuk-infrastructure/.github/workflows/brakeman.yml@main


### PR DESCRIPTION
Snyk's SCA is failing for no known reason, and it's skipped in some other repos, so remove it for the time being.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
