### PR TITLE
Enforce logout

### DIFF
--- a/app/controllers/concerns/authenticated_api_concern.rb
+++ b/app/controllers/concerns/authenticated_api_concern.rb
@@ -10,14 +10,17 @@ module AuthenticatedApiConcern
         session_secret: Rails.application.credentials.session_secret,
       )
 
-      head :unauthorized unless @govuk_account_session
+      if @govuk_account_session
+        head :unauthorized if LogoutNotice.find(@govuk_account_session.user_id)
+      else
+        head :unauthorized
+      end
     end
 
     rescue_from AccountSession::ReauthenticateUserError do
       head :unauthorized
     end
   end
-
   def render_api_response(options = {})
     render json: options.merge(govuk_account_session: @govuk_account_session.serialise)
   end

--- a/app/controllers/personalisation_controller.rb
+++ b/app/controllers/personalisation_controller.rb
@@ -8,7 +8,11 @@ class PersonalisationController < ApplicationController
       session_secret: Rails.application.credentials.session_secret,
     )
 
-    end_session! unless @govuk_account_session
+    if @govuk_account_session
+      end_session! if LogoutNotice.find(@govuk_account_session.user_id)
+    else
+      end_session!
+    end
   end
 
   before_action :set_caching_headers

--- a/spec/requests/check_email_subscription_spec.rb
+++ b/spec/requests/check_email_subscription_spec.rb
@@ -66,6 +66,18 @@ RSpec.describe "Personalisation - Check Email Subscription" do
         end
       end
 
+      context "when a logout notice exists for that sub" do
+        before do
+          Redis.current.flushdb
+          Redis.current.set("logout-notice/#{sub}", Time.zone.now)
+        end
+
+        it "logs the user out" do
+          get(personalisation_check_email_subscription_path, params:, headers:)
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+
       context "when a base_path is passed" do
         let(:base_path) { "/foo" }
         let(:subscription_slug) { "foo" }

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -20,6 +20,18 @@ RSpec.describe "User information endpoint" do
 
   let(:response_body) { JSON.parse(response.body) }
 
+  context "when a logout notice exists for that sub" do
+    before do
+      Redis.current.flushdb
+      Redis.current.set("logout-notice/#{session_identifier.user_id}", Time.zone.now)
+    end
+
+    it "logs the user out" do
+      get("/api/user", headers:)
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
   it "returns 200 OK" do
     get("/api/user", headers:)
     expect(response).to be_successful


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Ticket: https://trello.com/c/DJ3IB8kj/161-enforce-back-channel-logout-in-account-api, [Jira issue PNP-5465](https://gov-uk.atlassian.net/browse/PNP-5465)

Enforces Logging users out where a LogoutNotice exists. As currently if a user signs out of One login and then visits the email subscriptions page and refreshes they are still logged in and can view their subscriptions. This PR enforces that logout when a LogoutNotice exists for that user.