### PR TITLE
Rename parameter variable

### DIFF
--- a/app/controllers/oidc_events_controller.rb
+++ b/app/controllers/oidc_events_controller.rb
@@ -1,6 +1,6 @@
 class OidcEventsController < ApplicationController
   def backchannel_logout
-    logout_token = oidc_client.logout_token(logout_token)
+    logout_token = oidc_client.logout_token(logout_token_jwt)
     if logout_token
       user_id = logout_token[:logout_token].sub
       LogoutNotice.new(user_id).persist
@@ -13,7 +13,7 @@ class OidcEventsController < ApplicationController
 
 private
 
-  def logout_token
+  def logout_token_jwt
     params.require(:logout_token)
   end
 


### PR DESCRIPTION
 - in tests, this worked fine. But in practise, there was some odd variable shadowing going on that led to the client logout_token method being called with a nil.
 
Some details of thse issue:
-  https://gds.slack.com/archives/CADGP8PB4/p1720453623685349 / 
- https://stackoverflow.com/questions/15789540/methods-local-variable-with-same-name-as-another-method

(Basic problem: ruby instantiates local variables instantly and they override class methods, so by declaring a variable logout_token, even on the left hand side, we instantly create that token as nil. Then when it's passed to the variable on the right hand side it has that nil value rather than the one from the method).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
