### PR TITLE
Update Sign into Service page text

### DIFF
--- a/app/views/help_pages/sign_in.html.erb
+++ b/app/views/help_pages/sign_in.html.erb
@@ -16,7 +16,7 @@
     links = [{
       text: "HMRC services",
       path: "/log-in-register-hmrc-online-services",
-      description: "Sign in using Government Gateway for tax services including self-assessment.",
+      description: "Sign in to use tax services including self-assessment.",
     },{
       text: "Universal Credit",
       path: "/sign-in-universal-credit",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Update text on Sign into Service page.

## Why
Remove mention of Government Gateway, as part of move to GOV.UK One Login.



