### PR TITLE
[PNP-9961] Pin SHAs for third-party actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           path: vendor/publishing-api
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
           bundler-cache: true
 

--- a/.github/workflows/pact-verify.yml
+++ b/.github/workflows/pact-verify.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           repository: alphagov/account-api
           ref: ${{ inputs.ref }}
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
           bundler-cache: true
       - run: bundle exec rails db:setup


### PR DESCRIPTION
Pin non-alphagov/non-github actions

-As per policy: https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-with-github-actions.html#pin-untrusted-github-actions-to-a-commit-sha

JIRA Card: https://gov-uk.atlassian.net/browse/PNP-9961
