### PR TITLE
Revert "build(deps): bump bootsnap from 1.24.0 to 1.24.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     base64 (0.3.0)
     bigdecimal (4.1.2)
     bindata (2.5.1)
-    bootsnap (1.24.1)
+    bootsnap (1.24.0)
       msgpack (~> 1.2)
     brakeman (8.0.4)
       racc


### PR DESCRIPTION
Reverts alphagov/account-api#1391

It's not clear whether the 1.24.0 or the 1.24.1 version of bootsnap is problematic, so try reverting to 1.24.0 first.