### PR TITLE
Revert "build(deps): bump bootsnap from 1.24.0 to 1.24.3"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     base64 (0.3.0)
     bigdecimal (4.1.2)
     bindata (2.5.1)
-    bootsnap (1.24.3)
+    bootsnap (1.24.0)
       msgpack (~> 1.2)
     brakeman (8.0.4)
       racc


### PR DESCRIPTION
Reverts alphagov/account-api#1400

(Sadly still hasn't fixed the problem that causes migrations to crash on deploy).